### PR TITLE
fix(appimage): prefer host WebKitGTK over the bundled copy when available

### DIFF
--- a/.github/workflows/linux-bundle-test.yml
+++ b/.github/workflows/linux-bundle-test.yml
@@ -72,6 +72,10 @@ jobs:
           VITE_LASTFM_API_SECRET: ${{ secrets.VITE_LASTFM_API_SECRET }}
           APPIMAGE_EXTRACT_AND_RUN: 1
         run: npm run tauri:build -- --bundles ${{ inputs.bundles }} --verbose
+      # Same patch the release channel applies, so a dispatch run exercises it
+      # and the artifact is what users would actually download.
+      - name: patch AppImage to prefer host WebKitGTK
+        run: scripts/appimage-prefer-host-webkit.sh src-tauri/target/release/bundle/appimage
       - name: verify bundle output
         run: |
           set -euo pipefail

--- a/.github/workflows/reusable-channel-publish.yml
+++ b/.github/workflows/reusable-channel-publish.yml
@@ -401,6 +401,16 @@ jobs:
           VITE_LASTFM_API_SECRET: ${{ secrets.VITE_LASTFM_API_SECRET }}
           APPIMAGE_EXTRACT_AND_RUN: 1
         run: npm run tauri:build -- --bundles deb,rpm,appimage
+      - name: patch AppImage to prefer host WebKitGTK
+        env:
+          APPIMAGE_EXTRACT_AND_RUN: 1
+        run: |
+          curl -fsSL -o /tmp/appimagetool \
+            https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x /tmp/appimagetool
+          for f in src-tauri/target/release/bundle/appimage/*.AppImage; do
+            APPIMAGETOOL=/tmp/appimagetool scripts/appimage-prefer-host-webkit.sh "$f"
+          done
       - name: upload Linux artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-channel-publish.yml
+++ b/.github/workflows/reusable-channel-publish.yml
@@ -401,6 +401,8 @@ jobs:
           VITE_LASTFM_API_SECRET: ${{ secrets.VITE_LASTFM_API_SECRET }}
           APPIMAGE_EXTRACT_AND_RUN: 1
         run: npm run tauri:build -- --bundles deb,rpm,appimage
+      - name: patch AppImage to prefer host WebKitGTK
+        run: scripts/appimage-prefer-host-webkit.sh src-tauri/target/release/bundle/appimage
       - name: upload Linux artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+### The AppImage starts on Fedora and the atomic distros again
+
+**By [@netherguy4](https://github.com/netherguy4), PR [#1348](https://github.com/Psysonic/psysonic/pull/1348)**
+
+* On Fedora 42+ and the atomic distros built on it (Silverblue, Kinoite, Bluefin) the AppImage opened an empty window and nothing ever appeared in it. The WebKitGTK copy shipped inside the AppImage cannot start on those systems' newer graphics stack, and it crashed on every launch.
+* The AppImage now launches against your system WebKitGTK whenever one is installed, which is the copy that works there. Systems without one keep using the bundled copy exactly as before, and `PSYSONIC_FORCE_BUNDLED_WEBKIT=1` forces the bundled copy back if you ever need it.
+
 ### Shared Top Albums pictures show their covers again
 
 **By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1478](https://github.com/Psysonic/psysonic/pull/1478)**

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ curl -fsSL https://raw.githubusercontent.com/Psysonic/psysonic/main/scripts/inst
 Linux builds are also available through GitHub Releases, AUR and Cachix/Nix.
 
 > **AppImage runs under X11/XWayland** — it pins `GDK_BACKEND=x11` for a stable WebKitGTK stack. For a native-Wayland launch, use the `.deb`, `.rpm`, AUR, or Nix packages, which follow your session's display server.
+>
+> **AppImage uses your system WebKitGTK when you have one** — if `libwebkit2gtk-4.1` is installed, the AppImage launches against it instead of the copy it ships, which is what makes it work on Fedora and the atomic distros (Silverblue, Kinoite, Bluefin), where the bundled build cannot start. Without it the bundled copy is used, unchanged. Should the system one ever misbehave, `PSYSONIC_FORCE_BUNDLED_WEBKIT=1 ./Psysonic_*.AppImage` goes back to the bundled stack.
 
 ## Windows
 

--- a/scripts/appimage-prefer-host-webkit.sh
+++ b/scripts/appimage-prefer-host-webkit.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Post-process a Tauri-built AppImage so its AppRun prefers the host WebKitGTK
+# stack when one is available.
+#
+# Rationale: the AppImage bundles the Ubuntu build of WebKitGTK. On hosts with
+# a newer graphics stack (Mesa/libglvnd on Fedora 42+, atomic distros like
+# Bluefin/Silverblue) that build fails to create an EGL display
+# (EGL_BAD_PARAMETER) and WebKitWebProcess aborts, leaving a blank window.
+# The host WebKitGTK, when installed, is always a better fit; the bundled copy
+# remains as a fallback for hosts without webkit2gtk-4.1.
+#
+# Usage: appimage-prefer-host-webkit.sh <path-to.AppImage>
+# Requires: appimagetool (path via $APPIMAGETOOL, default: from $PATH).
+set -euo pipefail
+
+appimage="$(readlink -f "$1")"
+appimagetool="${APPIMAGETOOL:-appimagetool}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+cd "$workdir"
+
+"$appimage" --appimage-extract >/dev/null
+
+apprun=squashfs-root/AppRun
+# Sanity check: only patch the linuxdeploy-generated AppRun we know the shape of.
+grep -q 'apprun-hooks' "$apprun" || {
+    echo "error: unexpected AppRun format in $appimage, refusing to patch" >&2
+    exit 1
+}
+grep -q 'PSYSONIC_FORCE_BUNDLED_WEBKIT' "$apprun" && {
+    echo "AppRun already patched, nothing to do"
+    exit 0
+}
+
+binary="$(ls squashfs-root/usr/bin)"
+[ "$(echo "$binary" | wc -l)" -eq 1 ] || {
+    echo "error: expected exactly one binary in usr/bin" >&2
+    exit 1
+}
+
+block="$(cat <<'EOF'
+
+# Prefer the host WebKitGTK stack when available. The bundled (Ubuntu) build of
+# WebKitGTK is incompatible with newer host graphics stacks (Mesa/libglvnd on
+# e.g. Fedora 42+): EGL display creation fails with EGL_BAD_PARAMETER and
+# WebKitWebProcess aborts, leaving a blank window. LD_LIBRARY_PATH outranks the
+# binary's RUNPATH ($ORIGIN/../lib), so pointing it at the host libdir makes
+# every library resolve from the host instead of the bundled copies.
+# Set PSYSONIC_FORCE_BUNDLED_WEBKIT=1 to skip this and use the bundled stack.
+if [ -z "${PSYSONIC_FORCE_BUNDLED_WEBKIT:-}" ]; then
+    host_webkit="$(ldconfig -p 2>/dev/null | awk '/libwebkit2gtk-4\.1\.so\.0 .*x86-64/{print $NF; exit}')"
+    if [ -n "$host_webkit" ] && [ -e "$host_webkit" ]; then
+        host_libdir="$(dirname "$host_webkit")"
+        export LD_LIBRARY_PATH="$host_libdir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        exec "$this_dir"/usr/bin/@BINARY@ "$@"
+    fi
+fi
+EOF
+)"
+block="${block//@BINARY@/$binary}"
+
+# ENVIRON (unlike awk -v) does not mangle backslash escapes in the block text.
+BLOCK="$block" awk '{print} /^this_dir=/{print ENVIRON["BLOCK"]}' "$apprun" > "$apprun.new"
+mv "$apprun.new" "$apprun"
+chmod +x "$apprun"
+
+ARCH=x86_64 "$appimagetool" squashfs-root "$appimage.patched" >/dev/null
+mv "$appimage.patched" "$appimage"
+echo "patched: $appimage"

--- a/scripts/appimage-prefer-host-webkit.sh
+++ b/scripts/appimage-prefer-host-webkit.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Post-process a Tauri-built AppImage so its AppRun prefers the host WebKitGTK
+# stack when one is available.
+#
+# Rationale: the AppImage bundles the Ubuntu build of WebKitGTK. On hosts with
+# a newer graphics stack (Mesa/libglvnd on Fedora 42+, atomic distros like
+# Bluefin/Silverblue) that build fails to create an EGL display
+# (EGL_BAD_PARAMETER) and WebKitWebProcess aborts, leaving a blank window.
+# The host WebKitGTK, when installed, is always a better fit; the bundled copy
+# remains as a fallback for hosts without webkit2gtk-4.1.
+#
+# Usage: appimage-prefer-host-webkit.sh <AppImage-or-directory>...
+# Directories are scanned for *.AppImage; producing none is not an error, so a
+# build that skipped the AppImage bundle still passes.
+#
+# appimagetool comes from $APPIMAGETOOL, else $PATH, else a pinned release
+# downloaded and checksummed here.
+set -euo pipefail
+
+APPIMAGETOOL_VERSION=1.9.1
+
+arch="$(uname -m)"
+case "$arch" in
+    # ldconfig_arch is how `ldconfig -p` spells the architecture, which differs
+    # from uname; the filter keeps a multiarch host from matching its i386 copy.
+    x86_64)  appimagetool_sha256=ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0; ldconfig_arch='x86-64' ;;
+    aarch64) appimagetool_sha256=f0837e7448a0c1e4e650a93bb3e85802546e60654ef287576f46c71c126a9158; ldconfig_arch='AArch64' ;;
+    *) echo "error: unsupported architecture: $arch" >&2; exit 1 ;;
+esac
+
+tmproot="$(mktemp -d)"
+trap 'rm -rf "$tmproot"' EXIT
+
+resolve_appimagetool() {
+    if [ -n "${APPIMAGETOOL:-}" ]; then
+        echo "$APPIMAGETOOL"
+        return
+    fi
+    if command -v appimagetool >/dev/null; then
+        command -v appimagetool
+        return
+    fi
+    local tool="$tmproot/appimagetool"
+    curl -fsSL -o "$tool" \
+        "https://github.com/AppImage/appimagetool/releases/download/$APPIMAGETOOL_VERSION/appimagetool-$arch.AppImage" >&2
+    echo "$appimagetool_sha256  $tool" | sha256sum -c - >&2
+    chmod +x "$tool"
+    echo "$tool"
+}
+
+# The block is inserted after linuxdeploy's own apprun-hooks (which pin
+# GDK_BACKEND=x11 among other things) and before the final exec, so everything
+# the hooks set is kept. It has to exec the binary directly rather than fall
+# through to AppRun.wrapped, because AppRun.wrapped rebuilds LD_LIBRARY_PATH as
+# "$APPDIR/usr/lib/:...:$LD_LIBRARY_PATH" and would put the bundled libraries
+# back in front. AppRun.wrapped sets nothing else this app needs that the hooks
+# do not already set (GST_PLUGIN_SYSTEM_PATH_1_0 comes from the gstreamer hook).
+read -r -d '' block <<'EOF' || true
+
+# Prefer the host WebKitGTK stack when available. The bundled (Ubuntu) build of
+# WebKitGTK is incompatible with newer host graphics stacks (Mesa/libglvnd on
+# e.g. Fedora 42+): EGL display creation fails with EGL_BAD_PARAMETER and
+# WebKitWebProcess aborts, leaving a blank window. LD_LIBRARY_PATH outranks the
+# binary's RUNPATH ($ORIGIN/../lib), so putting the host libdir first makes the
+# whole stack resolve from the host instead of the bundled copies. The binary is
+# exec'd directly because AppRun.wrapped would prepend the bundled libdirs again.
+# Set PSYSONIC_FORCE_BUNDLED_WEBKIT=1 to skip this and use the bundled stack.
+if [ -z "${PSYSONIC_FORCE_BUNDLED_WEBKIT:-}" ]; then
+    # ldconfig lives in sbin, which is not on a non-root PATH on Debian.
+    psysonic_host_webkit="$(PATH=/usr/sbin:/sbin:$PATH ldconfig -p 2>/dev/null | awk '/libwebkit2gtk-4\.1\.so\.0 .*@LDARCH@/{print $NF; exit}')"
+    if [ -n "$psysonic_host_webkit" ] && [ -e "$psysonic_host_webkit" ]; then
+        export LD_LIBRARY_PATH="$(dirname "$psysonic_host_webkit")${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        export PATH="$this_dir/usr/bin:$PATH"
+        exec "$this_dir"/usr/bin/@BINARY@ "$@"
+    fi
+fi
+EOF
+block="${block//@LDARCH@/$ldconfig_arch}"
+
+patch_appimage() {
+    local appimage
+    appimage="$(readlink -f "$1")"
+    local workdir="$tmproot/work"
+    rm -rf "$workdir"
+    mkdir -p "$workdir"
+
+    (
+        cd "$workdir"
+        "$appimage" --appimage-extract >/dev/null
+
+        local apprun=squashfs-root/AppRun
+        # Only patch the linuxdeploy-generated AppRun we know the shape of.
+        grep -q 'apprun-hooks' "$apprun" || {
+            echo "error: unexpected AppRun format in $appimage, refusing to patch" >&2
+            exit 1
+        }
+        grep -q '^exec ' "$apprun" || {
+            echo "error: no exec line in AppRun of $appimage, refusing to patch" >&2
+            exit 1
+        }
+        if grep -q 'PSYSONIC_FORCE_BUNDLED_WEBKIT' "$apprun"; then
+            echo "already patched, skipping: $appimage"
+            exit 0
+        fi
+
+        local binary
+        binary="$(ls squashfs-root/usr/bin)"
+        [ "$(echo "$binary" | wc -l)" -eq 1 ] || {
+            echo "error: expected exactly one binary in usr/bin of $appimage" >&2
+            exit 1
+        }
+
+        # ENVIRON (unlike awk -v) does not mangle backslash escapes in the block
+        # text. Insert before the first exec so the hooks above it still run.
+        BLOCK="${block//@BINARY@/$binary}" \
+            awk '/^exec / && !done {print ENVIRON["BLOCK"]; done=1} {print}' \
+            "$apprun" > "$apprun.new"
+        mv "$apprun.new" "$apprun"
+        chmod +x "$apprun"
+
+        # APPIMAGE_EXTRACT_AND_RUN is for appimagetool alone (it is an AppImage
+        # and the runners have no FUSE); exported globally it would also make
+        # the runtime of the AppImage above run the app instead of extracting.
+        # Absolute AppDir path: APPIMAGE_EXTRACT_AND_RUN makes appimagetool's own
+        # runtime chdir into its extraction dir, so a relative one does not resolve.
+        ARCH="$arch" APPIMAGE_EXTRACT_AND_RUN=1 "$appimagetool" "$PWD/squashfs-root" "$appimage.patched" >/dev/null
+        mv "$appimage.patched" "$appimage"
+        echo "patched: $appimage"
+    )
+}
+
+shopt -s nullglob
+targets=()
+for arg in "$@"; do
+    if [ -d "$arg" ]; then
+        targets+=("$arg"/*.AppImage)
+    elif [ -f "$arg" ]; then
+        targets+=("$arg")
+    else
+        # A build that skipped the appimage bundle leaves no directory at all.
+        echo "skipping (not found): $arg" >&2
+    fi
+done
+
+if [ "${#targets[@]}" -eq 0 ]; then
+    echo "no AppImage found in: $*"
+    exit 0
+fi
+
+appimagetool="$(resolve_appimagetool)"
+for target in "${targets[@]}"; do
+    patch_appimage "$target"
+done


### PR DESCRIPTION
Fixes #1347

## Problem

The AppImage bundles the Ubuntu build of WebKitGTK. On hosts with a newer graphics stack (Mesa/libglvnd on Fedora 42+, atomic distros like Bluefin/Silverblue/Kinoite) that build fails to create an EGL display (`EGL_BAD_PARAMETER`) and `WebKitWebProcess` aborts with SIGABRT on every launch, leaving a permanently blank window. Details, stack trace and environment info in #1347.

None of the usual runtime workarounds help (`WEBKIT_DISABLE_DMABUF_RENDERER=1`, `WEBKIT_DISABLE_COMPOSITING_MODE=1`, `LIBGL_ALWAYS_SOFTWARE=1`, `GDK_BACKEND=x11`) — the incompatibility is at the library level.

## Fix

A CI post-processing step (`scripts/appimage-prefer-host-webkit.sh`) patches the linuxdeploy-generated `AppRun` inside each built AppImage:

- If the host has `libwebkit2gtk-4.1` (detected via `ldconfig`), the app is launched with `LD_LIBRARY_PATH` pointing at the host libdir. `LD_LIBRARY_PATH` outranks the binary's `RUNPATH` (`$ORIGIN/../lib`), so the whole stack resolves from the host — same behaviour users currently get by extracting the AppImage and running the inner binary manually.
- Hosts **without** webkit2gtk-4.1 keep using the bundled stack, unchanged.
- `PSYSONIC_FORCE_BUNDLED_WEBKIT=1` forces the old behaviour as an escape hatch.

Post-processing is the only viable seam in this repo: tauri-bundler generates `AppRun` and packs the squashfs inside a single linuxdeploy invocation, and the `bundle.linux.appimage.files` config only reaches the `usr/` subtree before linuxdeploy runs, so the AppRun can't be customized at build time.

## Verified

On Bluefin (Fedora 44, GNOME Wayland, AMD Radeon 680M, webkit2gtk4.1-2.52.5):

- unpatched 1.50.0 AppImage: `EGL_BAD_PARAMETER`, WebKitWebProcess SIGABRT via coredumpctl, blank window;
- 1.50.0 AppImage patched by this script: renders normally on the host WebKit (`/usr/libexec/webkit2gtk-4.1/WebKitWebProcess`), no crashes;
- `PSYSONIC_FORCE_BUNDLED_WEBKIT=1`: behaves exactly like the unpatched original.

Repacking loses no signatures — the current Linux release assets carry no embedded update info or `.sig`.

## Note

This is a workaround for what is ultimately a tauri-bundler/linuxdeploy limitation. If Tauri's generated AppRun ever learns to prefer the host WebKitGTK itself, this step can simply be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)