### PR TITLE
fix: migrate Navidrome canonical IDs safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Home, Albums, Artists, New Releases, Lossless Albums and Search reuse bounded local results instead of repeating large scoped reads while routes mount, paginate or restore their session.
 * Browse pages coordinate cover traffic and background catalogue work more carefully, so the first useful content appears before non-visible enrichment and prefetch work.
 
+### Navidrome canonical IDs — migrate existing libraries safely
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1393](https://github.com/Psychotoxical/psysonic/pull/1393)**
+
+* When a Navidrome server switches artist, album, track and music-folder IDs to its canonical format, Psysonic detects the live server behaviour and pauses sync behind a visible migration screen instead of creating duplicate library rows or broken references.
+* The migration preserves playback queues, offline files, Device Sync sources, music-folder selections and playlist folders, while derived caches rebuild with the new IDs. Interrupted work resumes safely, and errors remain retryable without exposing a half-migrated library.
+
 ## Fixed
 
 ### Cross-server ownership — IDs no longer collide or drift to the active server

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4269,6 +4269,7 @@ dependencies = [
 name = "psysonic-library"
 version = "1.51.0-dev"
 dependencies = [
+ "md5",
  "psysonic-core",
  "psysonic-integration",
  "reqwest",

--- a/src-tauri/crates/psysonic-library/Cargo.toml
+++ b/src-tauri/crates/psysonic-library/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1"
 rusqlite = { version = "0.40", features = ["bundled", "functions"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "gzip", "brotli"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time"] }
+md5 = "0.8"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "test-util"] }

--- a/src-tauri/crates/psysonic-library/migrations/027_navidrome_canonical_ids.sql
+++ b/src-tauri/crates/psysonic-library/migrations/027_navidrome_canonical_ids.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS server_identity_transition (
+  server_id            TEXT PRIMARY KEY,
+  canonical_version    INTEGER NOT NULL DEFAULT 1,
+  state                TEXT NOT NULL,
+  probe_old_id         TEXT,
+  probe_new_id         TEXT,
+  detected_at          INTEGER NOT NULL,
+  native_migrated_at   INTEGER,
+  frontend_acked_at    INTEGER,
+  last_error           TEXT,
+  CHECK (state IN (
+    'legacy',
+    'no_legacy_ids',
+    'awaiting_supplemental_probe',
+    'transition_detected',
+    'retryable',
+    'pending_frontend',
+    'ready',
+    'blocked'
+  ))
+);
+
+CREATE TABLE IF NOT EXISTS entity_id_remap (
+  server_id    TEXT NOT NULL,
+  entity_kind  TEXT NOT NULL,
+  old_id       TEXT NOT NULL,
+  new_id       TEXT NOT NULL,
+  remapped_at  INTEGER NOT NULL,
+  active       INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+  PRIMARY KEY (server_id, entity_kind, old_id),
+  CHECK (entity_kind IN ('artist', 'album', 'track', 'folder'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_id_remap_new
+  ON entity_id_remap(server_id, entity_kind, new_id);

--- a/src-tauri/crates/psysonic-library/migrations/028_identity_probe_cursor.sql
+++ b/src-tauri/crates/psysonic-library/migrations/028_identity_probe_cursor.sql
@@ -1,0 +1,4 @@
+-- JSON-encoded keyset cursor for bounded canonical-ID candidate discovery.
+-- Applied idempotently by store.rs so a crash after this single ALTER but
+-- before schema_migrations is recorded recovers on the next open.
+ALTER TABLE server_identity_transition ADD COLUMN probe_cursor TEXT;

--- a/src-tauri/crates/psysonic-library/migrations/029_identity_alias_cursor.sql
+++ b/src-tauri/crates/psysonic-library/migrations/029_identity_alias_cursor.sql
@@ -1,0 +1,6 @@
+-- Text keyset cursor for bounded inactive-alias baseline scans.
+ALTER TABLE library_data_migration ADD COLUMN cursor_text TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_album_artist_ref
+  ON album(server_id, artist_id)
+  WHERE artist_id IS NOT NULL AND artist_id != '';

--- a/src-tauri/crates/psysonic-library/src/artist_artwork.rs
+++ b/src-tauri/crates/psysonic-library/src/artist_artwork.rs
@@ -59,6 +59,12 @@ pub fn upsert_artist_artwork(
     updated_at: i64,
 ) -> Result<(), String> {
     store.with_conn_mut("artist_artwork.upsert", |conn| {
+        let artist_id = crate::navidrome_identity::resolve_remapped_id_with_conn(
+            conn,
+            server_id,
+            "artist",
+            artist_id,
+        )?;
         conn.execute(
             "INSERT INTO artist_artwork_lookup
                  (server_id, artist_id, surface_kind, mbid, mbid_source, status, provider, updated_at)
@@ -142,5 +148,40 @@ mod tests {
         // Clear-per-server removes it.
         assert_eq!(clear_artist_artwork_for_server(&store, "srv").unwrap(), 1);
         assert!(get_artist_artwork(&store, "srv", "ar-1", sk).unwrap().is_none());
+    }
+
+    #[test]
+    fn late_upsert_resolves_artist_identity_remap() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn("test.seed_remap", |conn| {
+                conn.execute(
+                    "INSERT INTO entity_id_remap(server_id, entity_kind, old_id, new_id, remapped_at) \
+                     VALUES ('srv', 'artist', 'old-artist', 'new-artist', 1)",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        upsert_artist_artwork(
+            &store,
+            "srv",
+            "old-artist",
+            "fanart",
+            None,
+            None,
+            "no_mbid",
+            None,
+            1000,
+        )
+        .unwrap();
+
+        assert!(get_artist_artwork(&store, "srv", "old-artist", "fanart")
+            .unwrap()
+            .is_none());
+        assert!(get_artist_artwork(&store, "srv", "new-artist", "fanart")
+            .unwrap()
+            .is_some());
     }
 }

--- a/src-tauri/crates/psysonic-library/src/browse_support.rs
+++ b/src-tauri/crates/psysonic-library/src/browse_support.rs
@@ -9,12 +9,12 @@ use crate::dto::CatalogYearBoundsDto;
 use crate::dto::GenreAlbumCountDto;
 use crate::dto::LibraryAlbumDto;
 use crate::runtime::LibraryRuntime;
-use crate::store::LibraryStore;
-use crate::sync::mapping::format_iso_ms_z;
 use crate::search::{
     library_scope_in_sql, library_scope_sargable_equals_sql, normalized_library_scopes,
     push_library_scope_binds,
 };
+use crate::store::LibraryStore;
+use crate::sync::mapping::format_iso_ms_z;
 
 #[derive(Debug, Clone, serde::Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
@@ -56,8 +56,7 @@ pub(crate) fn overlay_album_starred_at_rows(
     albums: &mut [LibraryAlbumDto],
 ) {
     for album in albums.iter_mut() {
-        album.starred_at =
-            read_album_starred_at(conn, &album.server_id, &album.id).unwrap_or(None);
+        album.starred_at = read_album_starred_at(conn, &album.server_id, &album.id).unwrap_or(None);
     }
 }
 
@@ -93,7 +92,10 @@ pub(crate) fn overlay_album_artist_links(
     for album in albums.iter_mut() {
         let owner = stmt
             .query_row(params![album.server_id, album.id], |r| {
-                Ok((r.get::<_, Option<String>>(0)?, r.get::<_, Option<String>>(1)?))
+                Ok((
+                    r.get::<_, Option<String>>(0)?,
+                    r.get::<_, Option<String>>(1)?,
+                ))
             })
             .optional()
             .unwrap_or(None);
@@ -104,7 +106,11 @@ pub(crate) fn overlay_album_artist_links(
         // album-artist tag only answers whether this album has an album-artist credit
         // at all. A card crediting the track performer therefore keeps its own id.
         let tagged = album_artist.is_some_and(|value| !value.trim().is_empty());
-        let credit = if tagged { album.artist.as_deref() } else { None };
+        let credit = if tagged {
+            album.artist.as_deref()
+        } else {
+            None
+        };
         album.artist_id =
             pick_album_group_artist_id(album.artist_id.take(), credit, album_artist_id);
     }
@@ -158,13 +164,16 @@ pub(crate) fn apply_album_patch(
     runtime
         .store
         .with_conn("browse.patch_album", |conn| {
+            let album_id = crate::navidrome_identity::resolve_remapped_id_with_conn(
+                conn, server_id, "album", album_id,
+            )?;
             if let Some(v) = starred_at {
                 conn.execute(
                     "UPDATE album SET starred_at = ?3 \
                      WHERE server_id = ?1 AND id = ?2",
                     params![server_id, album_id, v],
                 )?;
-                sync_album_raw_json_starred(conn, server_id, album_id, v)?;
+                sync_album_raw_json_starred(conn, server_id, &album_id, v)?;
             }
             Ok(())
         })
@@ -239,6 +248,15 @@ pub(crate) fn reconcile_album_stars(
             let placeholders = std::iter::repeat_n("?", starred.len())
                 .collect::<Vec<_>>()
                 .join(", ");
+            let starred = starred
+                .iter()
+                .map(|item| {
+                    crate::navidrome_identity::resolve_remapped_id_with_conn(
+                        conn, server_id, "album", &item.id,
+                    )
+                    .map(|id| (id, item.starred_at))
+                })
+                .collect::<rusqlite::Result<Vec<_>>>()?;
             let clear_sql = format!(
                 "UPDATE album SET starred_at = NULL \
                  WHERE server_id = ?1 AND starred_at IS NOT NULL \
@@ -246,18 +264,15 @@ pub(crate) fn reconcile_album_stars(
             );
             let mut clear_params: Vec<rusqlite::types::Value> =
                 vec![rusqlite::types::Value::Text(server_id.to_string())];
-            for item in starred {
-                clear_params.push(rusqlite::types::Value::Text(item.id.clone()));
+            for (id, _) in &starred {
+                clear_params.push(rusqlite::types::Value::Text(id.clone()));
             }
-            conn.execute(
-                &clear_sql,
-                rusqlite::params_from_iter(clear_params.iter()),
-            )?;
-            for item in starred {
+            conn.execute(&clear_sql, rusqlite::params_from_iter(clear_params.iter()))?;
+            for (id, starred_at) in starred {
                 conn.execute(
                     "UPDATE album SET starred_at = ?3 \
-                     WHERE server_id = ?1 AND id = ?2",
-                    params![server_id, item.id, item.starred_at],
+                      WHERE server_id = ?1 AND id = ?2",
+                    params![server_id, id, starred_at],
                 )?;
             }
             Ok(())
@@ -650,6 +665,47 @@ mod tests {
         assert!(old.is_none());
         assert_eq!(keep, Some(99));
         assert!(new.is_none());
+    }
+
+    #[test]
+    fn reconcile_album_stars_resolves_late_legacy_ids() {
+        let store = Arc::new(LibraryStore::open_in_memory());
+        store
+            .with_conn("test.seed_album_remap", |conn| {
+                conn.execute(
+                    "INSERT INTO album(server_id, id, name, synced_at, raw_json) \
+                     VALUES ('s1', 'new-album', 'Album', 1, '{}')",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT INTO entity_id_remap(server_id, entity_kind, old_id, new_id, remapped_at) \
+                     VALUES ('s1', 'album', 'old-album', 'new-album', 1)",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        reconcile_album_stars(
+            &runtime(store.clone()),
+            "s1",
+            &[StarredAlbumReconcileItem {
+                id: "old-album".into(),
+                starred_at: 99,
+            }],
+        )
+        .unwrap();
+
+        let starred_at = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT starred_at FROM album WHERE server_id = 's1' AND id = 'new-album'",
+                    [],
+                    |row| row.get::<_, Option<i64>>(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(starred_at, Some(99));
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -22,15 +22,15 @@ use crate::cross_server;
 use crate::dto::{
     local_tracks_max_updated_ms, ArtifactInputDto, EntityUserRatingDto, EntityUserRatingRefDto,
     FactInputDto, LibraryAdvancedSearchRequest, LibraryAdvancedSearchResponse,
-    LibraryCrossServerSearchResponse, LibraryLiveSearchRequest, LibraryLiveSearchResponse,
-    LibraryMainstageAlbumsRequest, LibraryMainstageAlbumsResponse, LibraryMostPlayedRequest,
-    LibraryMostPlayedResponse, LibraryScopeAlbumDetailRequest, LibraryScopeAlbumDetailResponse,
+    LibraryAlbumOverlayResolutionDto, LibraryCrossServerSearchResponse, LibraryEntitySourceDto,
+    LibraryLiveSearchRequest, LibraryLiveSearchResponse, LibraryMainstageAlbumsRequest,
+    LibraryMainstageAlbumsResponse, LibraryMostPlayedRequest, LibraryMostPlayedResponse,
+    LibraryResolveAlbumOverlayRequest, LibraryResolveEntitySourcesRequest,
+    LibraryScopeAlbumDetailRequest, LibraryScopeAlbumDetailResponse,
     LibraryScopeArtistDetailRequest, LibraryScopeArtistDetailResponse, LibraryScopeBrowseRequest,
     LibraryScopeBrowseResponse, LibraryScopeComposerDetailRequest,
     LibraryScopeComposerDetailResponse, LibraryScopeListRequest, LibraryScopeSearchRequest,
-    LibraryAlbumOverlayResolutionDto, LibraryEntitySourceDto,
-    LibraryResolveAlbumOverlayRequest, LibraryResolveEntitySourcesRequest, LibraryStatisticsDto,
-    LibraryStatisticsRequest, LibraryTrackDto, LibraryTracksEnvelope,
+    LibraryStatisticsDto, LibraryStatisticsRequest, LibraryTrackDto, LibraryTracksEnvelope,
     OfflinePathDto, PlaySessionDayDetailDto, PlaySessionHeatmapDayDto, PlaySessionInputDto,
     PlaySessionRecentDayDto, PlaySessionRecentTrackDto, PlaySessionYearBoundsDto,
     PlaySessionYearSummaryDto, PurgeReportDto, SyncJobDto, SyncStateDto, TrackArtifactDto,
@@ -568,12 +568,14 @@ pub async fn library_get_tracks_by_album(
 /// build `media/library/…` paths before a full sync has ingested the rows.
 // NOT specta-collected: takes a serde_json::Value arg — specta rc.25 can't export it. Stays hand-written on generate_handler!.
 #[tauri::command]
-pub fn library_upsert_songs_from_api(
+pub async fn library_upsert_songs_from_api(
     runtime: State<'_, LibraryRuntime>,
     server_id: String,
     songs: Vec<serde_json::Value>,
 ) -> Result<u32, String> {
-    upsert_songs_from_api(&runtime.store, &server_id, songs)
+    let _identity_guard = runtime.identity_mutation_guard().await;
+    let store = Arc::clone(&runtime.store);
+    library_spawn_blocking(move || upsert_songs_from_api(&store, &server_id, songs)).await
 }
 
 fn upsert_songs_from_api(
@@ -587,12 +589,21 @@ fn upsert_songs_from_api(
     if songs.is_empty() {
         return Ok(0);
     }
+    crate::navidrome_identity::assert_sync_ready(store, server_id)?;
     let synced_at = now_unix_ms();
     let repo = TrackRepository::new(store);
     let mut rows = Vec::with_capacity(songs.len());
-    for raw in songs {
+    let canonicalize = crate::navidrome_identity::transition_status(store, server_id)
+        .map(|status| status.state == "ready")
+        .unwrap_or(false);
+    for mut raw in songs {
+        if canonicalize {
+            crate::navidrome_identity::canonicalize_song_payload(&mut raw);
+        }
         let song: Song = serde_json::from_value(raw.clone()).map_err(|e| e.to_string())?;
-        rows.push(subsonic_song_to_track_row(server_id, &song, &raw, synced_at, None));
+        rows.push(subsonic_song_to_track_row(
+            server_id, &song, &raw, synced_at, None,
+        ));
     }
     repo.upsert_batch(&rows)?;
     Ok(rows.len() as u32)
@@ -1195,6 +1206,87 @@ pub async fn library_sync_bind_session(
     .await
 }
 
+#[tauri::command]
+#[specta::specta]
+pub fn library_identity_transition_status(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+) -> Result<crate::navidrome_identity::IdentityTransitionDto, String> {
+    crate::navidrome_identity::transition_status(&runtime.store, &server_id)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn library_identity_transition_ack(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+) -> Result<(), String> {
+    crate::navidrome_identity::acknowledge_frontend(&runtime.store, &server_id)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn library_identity_transition_probe(
+    runtime: State<'_, LibraryRuntime>,
+    http_registry: State<'_, Arc<ServerHttpRegistry>>,
+    server_id: String,
+    candidates: Vec<crate::navidrome_identity::IdentityProbeCandidateDto>,
+) -> Result<crate::navidrome_identity::IdentityTransitionDto, String> {
+    probe_identity_transition(&runtime, http_registry.as_ref(), &server_id, candidates).await
+}
+
+async fn probe_identity_transition(
+    runtime: &LibraryRuntime,
+    http_registry: &ServerHttpRegistry,
+    server_id: &str,
+    candidates: Vec<crate::navidrome_identity::IdentityProbeCandidateDto>,
+) -> Result<crate::navidrome_identity::IdentityTransitionDto, String> {
+    let session = runtime.get_session(server_id).ok_or_else(|| {
+        format!("no bound session for server `{server_id}` — call library_sync_bind_session first")
+    })?;
+    let subsonic = subsonic_client_with_registry(
+        Some(http_registry),
+        server_id,
+        session.base_url,
+        session.username,
+        session.password,
+    );
+    crate::navidrome_identity::ensure_transition_with_probe_candidates(
+        &runtime.store,
+        &subsonic,
+        server_id,
+        candidates,
+    )
+    .await
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn library_identity_transition_run_native_migration(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+) -> Result<crate::navidrome_identity::IdentityTransitionDto, String> {
+    run_identity_native_migration(&runtime, &server_id).await
+}
+
+async fn run_identity_native_migration(
+    runtime: &LibraryRuntime,
+    server_id: &str,
+) -> Result<crate::navidrome_identity::IdentityTransitionDto, String> {
+    let server_id = server_id.trim().to_string();
+    let _barrier = runtime
+        .cancel_and_drain_sync(None, Some(&server_id))
+        .await?;
+    let _identity_guard = runtime.identity_migration_guard().await;
+    let store = Arc::clone(&runtime.store);
+    let server_id_for_worker = server_id.clone();
+    library_spawn_blocking(move || {
+        crate::navidrome_identity::run_native_migration(&store, &server_id_for_worker)
+    })
+    .await?;
+    crate::navidrome_identity::transition_status(&runtime.store, &server_id)
+}
+
 async fn bind_sync_session_inner(
     runtime: &LibraryRuntime,
     http_registry: &ServerHttpRegistry,
@@ -1256,7 +1348,7 @@ async fn bind_sync_session_inner(
         bearer_token: tok,
     });
     let scope = library_scope.as_deref().unwrap_or_default();
-    probe_and_persist_with_timeout(
+    let probe = probe_and_persist_with_timeout(
         &runtime.store,
         &subsonic,
         navidrome_creds.as_ref(),
@@ -1267,6 +1359,11 @@ async fn bind_sync_session_inner(
     )
     .await
     .map_err(|e| format!("bind probe failed: {e}"))?;
+    if matches!(probe.server_info.server_type.as_deref(), Some("navidrome")) {
+        crate::navidrome_identity::ensure_transition(&runtime.store, &subsonic, &server_id)
+            .await
+            .map_err(|error| format!("canonical-ID readiness failed: {error}"))?;
+    }
     runtime.set_session(session)?;
     Ok(())
 }
@@ -1281,9 +1378,7 @@ pub async fn library_sync_clear_session(
 }
 
 async fn clear_sync_session(runtime: &LibraryRuntime, server_id: &str) -> Result<(), String> {
-    let _barrier = runtime
-        .cancel_and_drain_sync(None, Some(server_id))
-        .await?;
+    let _barrier = runtime.cancel_and_drain_sync(None, Some(server_id)).await?;
     runtime.clear_session(server_id);
     Ok(())
 }
@@ -1354,6 +1449,7 @@ async fn library_sync_start_inner(
     let session = runtime.get_session(&server_id).ok_or_else(|| {
         format!("no bound session for server `{server_id}` — call library_sync_bind_session first")
     })?;
+    crate::navidrome_identity::assert_sync_ready(&runtime.store, &server_id)?;
     let scope = library_scope
         .clone()
         .or(session.library_scope.clone())
@@ -1527,15 +1623,13 @@ async fn library_sync_start_inner(
         }
         // Wait for the runner to finish + emit sync-idle.
         let mut outcome = match runner_handle.await {
-            Ok(Ok(())) => {
-                LibrarySyncIdlePayload::ok(
-                    &server_id_for_emit,
-                    &scope_for_emit,
-                    &kind_for_emit,
-                    "foreground",
-                )
-                .with_job_id(&job_id_for_emit)
-            }
+            Ok(Ok(())) => LibrarySyncIdlePayload::ok(
+                &server_id_for_emit,
+                &scope_for_emit,
+                &kind_for_emit,
+                "foreground",
+            )
+            .with_job_id(&job_id_for_emit),
             Ok(Err(msg)) => LibrarySyncIdlePayload::err(
                 &server_id_for_emit,
                 &scope_for_emit,
@@ -1544,15 +1638,13 @@ async fn library_sync_start_inner(
                 &msg,
             )
             .with_job_id(&job_id_for_emit),
-            Err(join_err) if join_err.is_cancelled() => {
-                LibrarySyncIdlePayload::ok(
-                    &server_id_for_emit,
-                    &scope_for_emit,
-                    &kind_for_emit,
-                    "foreground",
-                )
-                .with_job_id(&job_id_for_emit)
-            }
+            Err(join_err) if join_err.is_cancelled() => LibrarySyncIdlePayload::ok(
+                &server_id_for_emit,
+                &scope_for_emit,
+                &kind_for_emit,
+                "foreground",
+            )
+            .with_job_id(&job_id_for_emit),
             Err(join_err) => LibrarySyncIdlePayload::err(
                 &server_id_for_emit,
                 &scope_for_emit,
@@ -1675,6 +1767,9 @@ pub fn patch_content_hash(
     runtime
         .store
         .with_conn("cmd.patch_content_hash", |conn| {
+            let track_id = crate::navidrome_identity::resolve_remapped_id_with_conn(
+                conn, server_id, "track", track_id,
+            )?;
             conn.execute(
                 "UPDATE track SET content_hash = ?3 \
                  WHERE server_id = ?1 AND id = ?2",
@@ -1723,6 +1818,9 @@ pub(crate) fn apply_track_patch(
     runtime
         .store
         .with_conn("cmd.patch_track", |conn| {
+            let track_id = crate::navidrome_identity::resolve_remapped_id_with_conn(
+                conn, server_id, "track", track_id,
+            )?;
             // One UPDATE per field present — keeps SQL simple and
             // matches the spec's per-field patch semantics.
             if let Some(v) = starred_at {
@@ -1997,6 +2095,14 @@ fn purge_server_data(
                 "DELETE FROM identity_invalidation WHERE server_id = ?1",
                 params![server_id],
             )?;
+            tx.execute(
+                "DELETE FROM entity_id_remap WHERE server_id = ?1",
+                params![server_id],
+            )?;
+            tx.execute(
+                "DELETE FROM server_identity_transition WHERE server_id = ?1",
+                params![server_id],
+            )?;
             tx.execute("DELETE FROM track WHERE server_id = ?1", params![server_id])?;
             tx.execute("DELETE FROM album WHERE server_id = ?1", params![server_id])?;
             tx.execute(
@@ -2173,6 +2279,12 @@ fn put_entity_user_ratings(
             if !valid_entity_user_rating_key(server_id, entity_kind, entity_id) {
                 continue;
             }
+            let entity_id = crate::navidrome_identity::resolve_remapped_id_with_conn(
+                &transaction,
+                server_id,
+                entity_kind,
+                entity_id,
+            )?;
             statement.execute(params![
                 server_id,
                 entity_kind,
@@ -2279,8 +2391,12 @@ mod tests {
                        VALUES ('{server_id}', '{artist_id}', 'fanart', 'hit', 1);
                       INSERT INTO library_tag_state(server_id, folders_hash, completed_at)
                         VALUES ('{server_id}', 'hash', 1);
-                      INSERT INTO library_tag_cursor(server_id, folders_hash, next_folder_id, updated_at)
-                        VALUES ('{server_id}', 'hash', 'folder-1', 1);
+                       INSERT INTO library_tag_cursor(server_id, folders_hash, next_folder_id, updated_at)
+                         VALUES ('{server_id}', 'hash', 'folder-1', 1);
+                       INSERT INTO server_identity_transition(server_id, canonical_version, state, detected_at)
+                         VALUES ('{server_id}', 1, 'legacy', 1);
+                       INSERT INTO entity_id_remap(server_id, entity_kind, old_id, new_id, remapped_at)
+                         VALUES ('{server_id}', 'track', 'old-{track_id}', '{track_id}', 1);
                      INSERT INTO entity_user_rating(server_id, entity_kind, entity_id, rating, fetched_at)
                        VALUES ('{server_id}', 'track', '{track_id}', 5, 1);
                      INSERT INTO album_browse_projection(
@@ -2356,6 +2472,39 @@ mod tests {
     }
 
     #[test]
+    fn api_song_upsert_is_blocked_while_identity_migration_is_pending() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn("test.seed_transition", |conn| {
+                conn.execute(
+                    "INSERT INTO server_identity_transition(server_id, canonical_version, state, detected_at) \
+                     VALUES ('s1', 1, 'transition_detected', 1)",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        let error = upsert_songs_from_api(
+            &store,
+            "s1",
+            vec![serde_json::json!({
+                "id": "e3b7fc2ae9447bbec37a13bf916e3cf6",
+                "title": "Track",
+                "album": "Album",
+                "duration": 120
+            })],
+        )
+        .unwrap_err();
+
+        assert!(error.contains("migration is ready to run"));
+        let count = store
+            .with_read_conn(|conn| conn.query_row("SELECT COUNT(*) FROM track", [], |row| row.get::<_, i64>(0)))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
     fn patch_content_hash_sets_value_and_noops_on_absent_or_empty() {
         let store = Arc::new(LibraryStore::open_in_memory());
         TrackRepository::new(&store)
@@ -2383,6 +2532,56 @@ mod tests {
 
         patch_content_hash(&rt, "s1", "tr_1", "md5-playback").unwrap();
         assert_eq!(read(&store).as_deref(), Some("md5-playback"));
+    }
+
+    #[test]
+    fn patch_content_hash_ignores_inactive_alias_until_native_migration_commits() {
+        let store = Arc::new(LibraryStore::open_in_memory());
+        TrackRepository::new(&store)
+            .upsert_batch(&[make_row("s1", "old-track", "al_1", 1)])
+            .unwrap();
+        store
+            .with_conn("test.seed_alias", |conn| {
+                conn.execute(
+                    "INSERT INTO entity_id_remap(server_id, entity_kind, old_id, new_id, remapped_at, active) \
+                     VALUES ('s1', 'track', 'old-track', 'new-track', 1, 0)",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        let rt = runtime(store.clone());
+
+        patch_content_hash(&rt, "s1", "old-track", "before-migration").unwrap();
+        let legacy_hash = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT content_hash FROM track WHERE server_id = 's1' AND id = 'old-track'",
+                    [],
+                    |row| row.get::<_, Option<String>>(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(legacy_hash.as_deref(), Some("before-migration"));
+
+        store
+            .with_conn("test.activate_alias", |conn| {
+                conn.execute("UPDATE track SET id = 'new-track' WHERE server_id = 's1'", [])?;
+                conn.execute("UPDATE entity_id_remap SET active = 1 WHERE server_id = 's1'", [])?;
+                Ok(())
+            })
+            .unwrap();
+        patch_content_hash(&rt, "s1", "old-track", "after-migration").unwrap();
+        let canonical_hash = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT content_hash FROM track WHERE server_id = 's1' AND id = 'new-track'",
+                    [],
+                    |row| row.get::<_, Option<String>>(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(canonical_hash.as_deref(), Some("after-migration"));
     }
 
     #[test]
@@ -2572,6 +2771,44 @@ mod tests {
     }
 
     #[test]
+    fn entity_user_rating_late_write_resolves_canonical_id() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn("test.seed_remap", |conn| {
+                conn.execute(
+                    "INSERT INTO entity_id_remap(server_id, entity_kind, old_id, new_id, remapped_at) \
+                     VALUES ('s1', 'album', 'old-album', 'new-album', 1)",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        put_entity_user_ratings(
+            &store,
+            &[EntityUserRatingDto {
+                server_id: "s1".into(),
+                entity_kind: "album".into(),
+                entity_id: "old-album".into(),
+                rating: 5,
+                fetched_at: 10,
+            }],
+            20,
+        )
+        .unwrap();
+
+        let entity_id = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT entity_id FROM entity_user_rating WHERE server_id = 's1'",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(entity_id, "new-album");
+    }
+
+    #[test]
     fn entity_user_rating_batch_limit_matches_spec_cap() {
         assert_eq!(ENTITY_USER_RATINGS_BATCH_LIMIT, 300);
     }
@@ -2688,6 +2925,104 @@ mod tests {
         assert_eq!(runtime.get_session("s1"), Some(previous));
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn supplemental_identity_probe_does_not_require_navidrome_token() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "subsonic-response": {
+                    "status": "failed",
+                    "error": { "code": 70, "message": "Song not found" }
+                }
+            })))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let store = Arc::new(LibraryStore::open_in_memory());
+        store
+            .with_conn("test.seed_legacy_track", |conn| {
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                     VALUES ('s1','e3b7fc2ae9447bbec37a13bf916e3cf6','Track','Album',1,'{}')",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        let runtime = LibraryRuntime::new(store);
+        runtime
+            .set_session(SyncSession {
+                server_id: "s1".into(),
+                base_url: server.uri(),
+                username: "user".into(),
+                password: "password".into(),
+                navidrome_token: None,
+                library_scope: None,
+            })
+            .unwrap();
+
+        let status =
+            probe_identity_transition(&runtime, &ServerHttpRegistry::new(), "s1", Vec::new())
+                .await
+                .unwrap();
+
+        assert_eq!(status.state, "retryable");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn explicit_native_migration_cancels_and_drains_foreground_sync() {
+        let store = Arc::new(LibraryStore::open_in_memory());
+        let old_track = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        store
+            .with_conn("test.seed_transition", |conn| {
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Track','Album',1,'{}')",
+                    params![old_track],
+                )?;
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, probe_old_id, probe_new_id, detected_at) \
+                     VALUES ('s1', 1, 'transition_detected', ?1, ?2, 1)",
+                    params![old_track, crate::navidrome_identity::canonical_id(old_track)],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        let runtime = Arc::new(LibraryRuntime::new(store));
+        let cancel = Arc::new(AtomicBool::new(false));
+        let done = Arc::new(tokio::sync::Notify::new());
+        let job_id = "identity-drain".to_string();
+        runtime
+            .install_current_job(CurrentJob {
+                job_id: job_id.clone(),
+                server_id: "s1".into(),
+                kind: "delta_sync".into(),
+                cancel: Arc::clone(&cancel),
+                abort_handle: None,
+                done: Arc::clone(&done),
+            })
+            .unwrap();
+        let runtime_for_job = Arc::clone(&runtime);
+        let job = tokio::spawn(async move {
+            while !cancel.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+            runtime_for_job.complete_current_job(&job_id, &done);
+        });
+
+        let status = run_identity_native_migration(&runtime, "s1").await.unwrap();
+
+        assert_eq!(status.state, "pending_frontend");
+        assert!(runtime.current_job().is_none());
+        job.await.unwrap();
+    }
+
     #[test]
     fn sync_outcome_treats_cancellation_as_silent_success() {
         // Cancellation (user cancel, or a newer sync_start superseding this
@@ -2767,6 +3102,8 @@ mod tests {
             ("artist_artwork_lookup", "server_id"),
             ("library_tag_state", "server_id"),
             ("library_tag_cursor", "server_id"),
+            ("server_identity_transition", "server_id"),
+            ("entity_id_remap", "server_id"),
             ("entity_user_rating", "server_id"),
             ("album_browse_projection", "server_id"),
             ("canonical_enrichment_link", "owner_server_id"),
@@ -2797,11 +3134,10 @@ mod tests {
                     |row| row.get(0),
                 )?;
                 assert_eq!(preserved_offline, 1);
-                let foreign_key_errors: i64 = conn.query_row(
-                    "SELECT COUNT(*) FROM pragma_foreign_key_check",
-                    [],
-                    |row| row.get(0),
-                )?;
+                let foreign_key_errors: i64 =
+                    conn.query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |row| {
+                        row.get(0)
+                    })?;
                 assert_eq!(foreign_key_errors, 0);
                 Ok(())
             })

--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -1217,10 +1217,12 @@ pub fn library_identity_transition_status(
 
 #[tauri::command]
 #[specta::specta]
-pub fn library_identity_transition_ack(
+pub async fn library_identity_transition_ack(
     runtime: State<'_, LibraryRuntime>,
     server_id: String,
 ) -> Result<(), String> {
+    let lock = crate::navidrome_identity::transition_probe_lock(&server_id);
+    let _transition_guard = lock.lock().await;
     crate::navidrome_identity::acknowledge_frontend(&runtime.store, &server_id)
 }
 
@@ -1277,6 +1279,8 @@ async fn run_identity_native_migration(
     let _barrier = runtime
         .cancel_and_drain_sync(None, Some(&server_id))
         .await?;
+    let lock = crate::navidrome_identity::transition_probe_lock(&server_id);
+    let _transition_guard = lock.lock().await;
     let _identity_guard = runtime.identity_migration_guard().await;
     let store = Arc::clone(&runtime.store);
     let server_id_for_worker = server_id.clone();
@@ -1449,7 +1453,6 @@ async fn library_sync_start_inner(
     let session = runtime.get_session(&server_id).ok_or_else(|| {
         format!("no bound session for server `{server_id}` — call library_sync_bind_session first")
     })?;
-    crate::navidrome_identity::assert_sync_ready(&runtime.store, &server_id)?;
     let scope = library_scope
         .clone()
         .or(session.library_scope.clone())
@@ -1983,6 +1986,8 @@ pub async fn library_purge_server(
     let _barrier = runtime
         .cancel_and_drain_sync(None, Some(&server_id))
         .await?;
+    let transition_lock = crate::navidrome_identity::transition_probe_lock(&server_id);
+    let _transition_guard = transition_lock.lock().await;
     runtime.clear_session(&server_id);
     purge_server_data(&runtime, &server_id, include_offline)
 }
@@ -2103,6 +2108,7 @@ fn purge_server_data(
                 "DELETE FROM server_identity_transition WHERE server_id = ?1",
                 params![server_id],
             )?;
+            crate::navidrome_identity::delete_inactive_alias_baseline_markers(&tx, server_id)?;
             tx.execute("DELETE FROM track WHERE server_id = ?1", params![server_id])?;
             tx.execute("DELETE FROM album WHERE server_id = ?1", params![server_id])?;
             tx.execute(

--- a/src-tauri/crates/psysonic-library/src/enrichment.rs
+++ b/src-tauri/crates/psysonic-library/src/enrichment.rs
@@ -34,7 +34,10 @@ pub fn plan_track_enrichment(
     let facts = repo.get(
         server_id,
         track_id,
-        &ENRICHMENT_KINDS.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        &ENRICHMENT_KINDS
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>(),
         now,
     )?;
 
@@ -42,7 +45,13 @@ pub fn plan_track_enrichment(
         let mut need_moods = !fact_current(&facts, "moods", content_hash);
         if OXIMEDIA_MOOD_TAGS_ENABLED {
             if !mood_tags_current(&facts, content_hash)
-                && !backfill_mood_tags_from_stored_facts(store, server_id, track_id, content_hash, now)?
+                && !backfill_mood_tags_from_stored_facts(
+                    store,
+                    server_id,
+                    track_id,
+                    content_hash,
+                    now,
+                )?
                 && !need_moods
             {
                 need_moods = true;
@@ -209,7 +218,8 @@ fn mood_tags_need_va_refresh(facts: &[crate::dto::TrackFactDto], content_hash: &
         .filter(|f| {
             f.fact_kind == "mood_tag"
                 && f.source_kind == OXIMEDIA_ENRICHMENT_SOURCE_KIND
-                && f.source_id.starts_with(&format!("{OXIMEDIA_ENRICHMENT_SOURCE_ID}:"))
+                && f.source_id
+                    .starts_with(&format!("{OXIMEDIA_ENRICHMENT_SOURCE_ID}:"))
                 && f.content_hash.as_deref() == Some(content_hash)
         })
         .filter_map(|f| f.value_text.clone())
@@ -231,6 +241,9 @@ fn replace_mood_tag_facts(
     let like_prefix = format!("{OXIMEDIA_ENRICHMENT_SOURCE_ID}:%");
     store
         .with_conn("enrichment.mood_tags_clear", |conn| {
+            let track_id = crate::navidrome_identity::resolve_remapped_id_with_conn(
+                conn, server_id, "track", track_id,
+            )?;
             conn.execute(
                 "DELETE FROM track_fact \
                  WHERE server_id = ?1 AND track_id = ?2 \
@@ -253,12 +266,7 @@ fn replace_mood_tag_facts(
         if !mood_groups::is_oximedia_mood_tag(tag) {
             continue;
         }
-        repo.put(
-            server_id,
-            track_id,
-            &mood_tag_fact(tag, content_hash),
-            now,
-        )?;
+        repo.put(server_id, track_id, &mood_tag_fact(tag, content_hash), now)?;
     }
     Ok(())
 }
@@ -282,11 +290,7 @@ fn is_oximedia_primary_fact(f: &crate::dto::TrackFactDto) -> bool {
     f.source_kind == OXIMEDIA_ENRICHMENT_SOURCE_KIND && f.source_id == OXIMEDIA_ENRICHMENT_SOURCE_ID
 }
 
-fn fact_current(
-    facts: &[crate::dto::TrackFactDto],
-    fact_kind: &str,
-    content_hash: &str,
-) -> bool {
+fn fact_current(facts: &[crate::dto::TrackFactDto], fact_kind: &str, content_hash: &str) -> bool {
     facts.iter().any(|f| {
         is_oximedia_primary_fact(f)
             && f.fact_kind == fact_kind
@@ -298,7 +302,8 @@ fn mood_tags_current(facts: &[crate::dto::TrackFactDto], content_hash: &str) -> 
     facts.iter().any(|f| {
         f.fact_kind == "mood_tag"
             && f.source_kind == OXIMEDIA_ENRICHMENT_SOURCE_KIND
-            && f.source_id.starts_with(&format!("{OXIMEDIA_ENRICHMENT_SOURCE_ID}:"))
+            && f.source_id
+                .starts_with(&format!("{OXIMEDIA_ENRICHMENT_SOURCE_ID}:"))
             && f.content_hash.as_deref() == Some(content_hash)
     })
 }
@@ -428,7 +433,14 @@ mod tests {
     fn plan_refreshes_stale_quadrant_mood_tags_when_valence_arousal_present() {
         let store = LibraryStore::open_in_memory();
         seed_track(&store, "s1", "t1");
-        put_analysis_fact(&store, "moods", "abc", None, None, Some(r#"{"happy":0.9,"excited":0.8}"#));
+        put_analysis_fact(
+            &store,
+            "moods",
+            "abc",
+            None,
+            None,
+            Some(r#"{"happy":0.9,"excited":0.8}"#),
+        );
         put_analysis_fact(&store, "valence", "abc", None, Some(0.55), None);
         put_analysis_fact(&store, "arousal", "abc", None, Some(0.42), None);
         let repo = FactRepository::new(&store);
@@ -468,7 +480,14 @@ mod tests {
     fn plan_backfills_mood_tags_from_valence_arousal_over_quadrant_moods_json() {
         let store = LibraryStore::open_in_memory();
         seed_track(&store, "s1", "t1");
-        put_analysis_fact(&store, "moods", "abc", None, None, Some(r#"{"happy":0.9,"excited":0.8}"#));
+        put_analysis_fact(
+            &store,
+            "moods",
+            "abc",
+            None,
+            None,
+            Some(r#"{"happy":0.9,"excited":0.8}"#),
+        );
         put_analysis_fact(&store, "valence", "abc", None, Some(0.55), None);
         put_analysis_fact(&store, "arousal", "abc", None, Some(0.42), None);
         let plan = plan_track_enrichment(&store, "s1", "t1", "abc", 2).unwrap();
@@ -615,7 +634,9 @@ mod tests {
         let repo = FactRepository::new(&store);
         let rows = repo.get("s1", "t1", &[], 20).unwrap();
         assert_eq!(rows.len(), 1);
-        assert!(rows.iter().any(|r| r.fact_kind == "bpm" && r.value_int == Some(128)));
+        assert!(rows
+            .iter()
+            .any(|r| r.fact_kind == "bpm" && r.value_int == Some(128)));
         assert!(!rows.iter().any(|r| r.fact_kind == "valence"));
         assert!(!rows.iter().any(|r| r.fact_kind == "arousal"));
     }

--- a/src-tauri/crates/psysonic-library/src/lib.rs
+++ b/src-tauri/crates/psysonic-library/src/lib.rs
@@ -9,8 +9,8 @@
 
 pub mod advanced_search;
 mod advanced_search_mood;
-pub mod album_overlay;
 pub mod album_compilation_filter;
+pub mod album_overlay;
 pub mod analysis_backfill;
 pub mod analysis_backfill_policy;
 pub mod artist_artwork;
@@ -40,6 +40,7 @@ pub mod lossless_formats;
 pub mod mainstage_browse;
 pub mod mood_groups;
 pub mod most_played;
+pub mod navidrome_identity;
 pub mod orphan_cleanup;
 pub mod payload;
 #[cfg(test)]

--- a/src-tauri/crates/psysonic-library/src/navidrome_identity.rs
+++ b/src-tauri/crates/psysonic-library/src/navidrome_identity.rs
@@ -6,7 +6,7 @@
 //! only records durable evidence. An explicit migration command later drains
 //! sync work and moves all library references in one deferred-FK transaction.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 
@@ -17,7 +17,27 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use crate::store::LibraryStore;
 
-pub const CANONICAL_ID_VERSION: i64 = 1;
+pub const CANONICAL_ID_VERSION: i64 = 2;
+const MAX_PROBE_CANDIDATES: usize = 8;
+const MAX_PROBE_ATTEMPT_CANDIDATES: usize = MAX_PROBE_CANDIDATES + 1;
+const ALIAS_BASELINE_BATCH_SIZE: i64 = 256;
+const ALIAS_BASELINE_BATCHES_PER_ATTEMPT: usize = 4;
+const ALIAS_BASELINE_MIGRATION_PREFIX: &str = "navidrome_inactive_alias_baseline_v1";
+const ALIAS_BASELINE_PROGRESS_ERROR: &str =
+    "canonical-ID inactive alias baseline is still progressing";
+const ALIAS_BASELINE_NO_LEGACY_PROGRESS_ERROR: &str =
+    "canonical-ID inactive alias baseline is still progressing; resume no_legacy_ids";
+
+pub(crate) fn delete_inactive_alias_baseline_markers(
+    conn: &Connection,
+    server_id: &str,
+) -> rusqlite::Result<()> {
+    let mut statement = conn.prepare_cached("DELETE FROM library_data_migration WHERE id = ?1")?;
+    for source in ALIAS_BASELINE_SOURCES {
+        statement.execute(params![alias_baseline_marker(server_id, source)])?;
+    }
+    Ok(())
+}
 
 #[derive(Debug, Clone, serde::Serialize, specta::Type, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -37,10 +57,11 @@ pub struct IdentityProbeCandidateDto {
     pub id: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum EntityKind {
     Track,
     Album,
+    Artist,
 }
 
 #[derive(Debug, Clone)]
@@ -48,6 +69,39 @@ struct ProbeCandidate {
     kind: EntityKind,
     old_id: String,
     new_id: String,
+    cursor_after: Option<ProbeCursor>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct ProbeCursor {
+    source: usize,
+    after_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ProbeCandidateBatch {
+    candidates: Vec<ProbeCandidate>,
+    next_cursor: ProbeCursor,
+    exhausted: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DeterministicWriteGuard {
+    enabled: bool,
+    probe_old_id: Option<String>,
+    probe_new_id: Option<String>,
+}
+
+impl DeterministicWriteGuard {
+    pub(crate) fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub(crate) fn hinted_old_id<'a>(&'a self, incoming_id: &str) -> Option<&'a str> {
+        (self.probe_new_id.as_deref() == Some(incoming_id))
+            .then_some(self.probe_old_id.as_deref())
+            .flatten()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -104,6 +158,7 @@ pub fn transition_status(
 }
 
 pub fn assert_sync_ready(store: &LibraryStore, server_id: &str) -> Result<(), String> {
+    upgrade_completed_state_if_needed(store, server_id)?;
     let status = transition_status(store, server_id)?;
     match status.state.as_str() {
         "awaiting_supplemental_probe" => Err(format!(
@@ -118,6 +173,10 @@ pub fn assert_sync_ready(store: &LibraryStore, server_id: &str) -> Result<(), St
         "retryable" | "blocked" => Err(format!(
             "server `{server_id}` canonical-ID migration is blocked: {}",
             status.last_error.as_deref().unwrap_or("unknown reason")
+        )),
+        _ if status.canonical_version != CANONICAL_ID_VERSION => Err(format!(
+            "server `{server_id}` canonical-ID readiness version {} is stale",
+            status.canonical_version
         )),
         _ => Ok(()),
     }
@@ -158,6 +217,7 @@ pub(crate) fn resolve_remapped_id_with_conn(
 }
 
 pub fn acknowledge_frontend(store: &LibraryStore, server_id: &str) -> Result<(), String> {
+    upgrade_completed_state_if_needed(store, server_id)?;
     let now = now_unix_ms();
     store
         .with_conn("navidrome_identity.ack_frontend", |conn| {
@@ -232,8 +292,44 @@ pub async fn ensure_transition(
     subsonic: &SubsonicClient,
     server_id: &str,
 ) -> Result<IdentityTransitionDto, String> {
-    let candidates = probe_candidates(store, server_id)?;
-    ensure_transition_with_candidates(
+    let lock = transition_probe_lock(server_id);
+    let _guard = lock.lock().await;
+    upgrade_completed_state_if_needed(store, server_id)?;
+    let existing = transition_status(store, server_id)?;
+    if matches!(
+        existing.state.as_str(),
+        "transition_detected" | "pending_frontend" | "ready"
+    ) && existing.canonical_version == CANONICAL_ID_VERSION
+    {
+        return Ok(existing);
+    }
+    let resume_no_legacy = existing.state == "no_legacy_ids"
+        || existing.last_error.as_deref() == Some(ALIAS_BASELINE_NO_LEGACY_PROGRESS_ERROR);
+    if !ensure_inactive_alias_baseline(store, server_id)? {
+        record_state(
+            store,
+            server_id,
+            "retryable",
+            existing.probe_old_id.as_deref(),
+            existing.probe_new_id.as_deref(),
+            Some(if resume_no_legacy {
+                ALIAS_BASELINE_NO_LEGACY_PROGRESS_ERROR
+            } else {
+                ALIAS_BASELINE_PROGRESS_ERROR
+            }),
+            false,
+        )?;
+        return transition_status(store, server_id);
+    }
+    if resume_no_legacy {
+        record_state(store, server_id, "no_legacy_ids", None, None, None, false)?;
+        return transition_status(store, server_id);
+    }
+    if no_legacy_state_is_current(&existing) {
+        return Ok(existing);
+    }
+    let candidates = probe_candidates_for_status(store, &existing)?;
+    bounded_transition_probe(
         store,
         subsonic,
         server_id,
@@ -249,7 +345,54 @@ pub async fn ensure_transition_with_probe_candidates(
     server_id: &str,
     supplied: Vec<IdentityProbeCandidateDto>,
 ) -> Result<IdentityTransitionDto, String> {
-    let mut candidates = probe_candidates(store, server_id)?;
+    let lock = transition_probe_lock(server_id);
+    let _guard = lock.lock().await;
+    upgrade_completed_state_if_needed(store, server_id)?;
+    let existing = transition_status(store, server_id)?;
+    if matches!(
+        existing.state.as_str(),
+        "transition_detected" | "pending_frontend" | "ready"
+    ) && existing.canonical_version == CANONICAL_ID_VERSION
+    {
+        return Ok(existing);
+    }
+    let resume_no_legacy = existing.state == "no_legacy_ids"
+        || existing.last_error.as_deref() == Some(ALIAS_BASELINE_NO_LEGACY_PROGRESS_ERROR);
+    if !ensure_inactive_alias_baseline(store, server_id)? {
+        record_state(
+            store,
+            server_id,
+            "retryable",
+            existing.probe_old_id.as_deref(),
+            existing.probe_new_id.as_deref(),
+            Some(if resume_no_legacy {
+                ALIAS_BASELINE_NO_LEGACY_PROGRESS_ERROR
+            } else {
+                ALIAS_BASELINE_PROGRESS_ERROR
+            }),
+            false,
+        )?;
+        return transition_status(store, server_id);
+    }
+    if resume_no_legacy {
+        record_state(store, server_id, "no_legacy_ids", None, None, None, false)?;
+        return transition_status(store, server_id);
+    }
+    if supplied.is_empty() && no_legacy_state_is_current(&existing) {
+        return Ok(existing);
+    }
+    let retrying_persisted = matches!(existing.state.as_str(), "legacy" | "retryable")
+        && existing.probe_old_id.is_some()
+        && existing.probe_new_id.is_some();
+    let mut batch = if supplied.is_empty() || retrying_persisted {
+        probe_candidates_for_status(store, &existing)?
+    } else {
+        ProbeCandidateBatch {
+            candidates: Vec::new(),
+            next_cursor: ProbeCursor::default(),
+            exhausted: true,
+        }
+    };
     for candidate in supplied {
         let kind = match candidate.entity_kind.as_str() {
             "track" => EntityKind::Track,
@@ -260,22 +403,85 @@ pub async fn ensure_transition_with_probe_candidates(
         let new_id = canonical_id(&old_id);
         if old_id.is_empty()
             || old_id == new_id
-            || candidates
+            || batch
+                .candidates
                 .iter()
                 .any(|existing| existing.kind == kind && existing.old_id == old_id)
         {
             continue;
         }
-        candidates.push(ProbeCandidate {
+        batch.candidates.push(ProbeCandidate {
             kind,
             old_id,
             new_id,
+            cursor_after: None,
         });
-        if candidates.len() >= 8 {
+        if batch.candidates.len() >= MAX_PROBE_ATTEMPT_CANDIDATES {
             break;
         }
     }
-    ensure_transition_with_candidates(
+    bounded_transition_probe(
+        store,
+        subsonic,
+        server_id,
+        batch,
+        EmptyCandidateOutcome::NoLegacyIds,
+    )
+    .await
+}
+
+/// Revalidate the active Navidrome namespace immediately before any sync ingest.
+/// Stable terminal states avoid candidate scans, persisted legacy evidence probes
+/// one old/new pair, and an empty `no_legacy_ids` catalog stays network-neutral.
+pub(crate) async fn revalidate_before_ingest(
+    store: &LibraryStore,
+    subsonic: &SubsonicClient,
+    server_id: &str,
+) -> Result<IdentityTransitionDto, String> {
+    let lock = transition_probe_lock(server_id);
+    let _guard = lock.lock().await;
+    upgrade_completed_state_if_needed(store, server_id)?;
+    let existing = transition_status(store, server_id)?;
+    match existing.state.as_str() {
+        "transition_detected" | "pending_frontend" | "ready"
+            if existing.canonical_version == CANONICAL_ID_VERSION =>
+        {
+            return Ok(existing);
+        }
+        "blocked" | "awaiting_supplemental_probe"
+            if existing.canonical_version == CANONICAL_ID_VERSION =>
+        {
+            return Ok(existing);
+        }
+        _ => {}
+    }
+    let resume_no_legacy = existing.state == "no_legacy_ids"
+        || existing.last_error.as_deref() == Some(ALIAS_BASELINE_NO_LEGACY_PROGRESS_ERROR);
+    if !ensure_inactive_alias_baseline(store, server_id)? {
+        record_state(
+            store,
+            server_id,
+            "retryable",
+            existing.probe_old_id.as_deref(),
+            existing.probe_new_id.as_deref(),
+            Some(if resume_no_legacy {
+                ALIAS_BASELINE_NO_LEGACY_PROGRESS_ERROR
+            } else {
+                ALIAS_BASELINE_PROGRESS_ERROR
+            }),
+            false,
+        )?;
+        return transition_status(store, server_id);
+    }
+    if resume_no_legacy {
+        record_state(store, server_id, "no_legacy_ids", None, None, None, false)?;
+        return transition_status(store, server_id);
+    }
+    if no_legacy_state_is_current(&existing) {
+        return Ok(existing);
+    }
+    let candidates = probe_candidates_for_status(store, &existing)?;
+    bounded_transition_probe(
         store,
         subsonic,
         server_id,
@@ -283,6 +489,277 @@ pub async fn ensure_transition_with_probe_candidates(
         EmptyCandidateOutcome::NoLegacyIds,
     )
     .await
+}
+
+fn probe_candidates_for_status(
+    store: &LibraryStore,
+    status: &IdentityTransitionDto,
+) -> Result<ProbeCandidateBatch, String> {
+    let mut batch = probe_candidates(store, &status.server_id)?;
+    if matches!(status.state.as_str(), "legacy" | "retryable") {
+        if let (Some(old_id), Some(new_id)) =
+            (status.probe_old_id.as_ref(), status.probe_new_id.as_ref())
+        {
+            if old_id != new_id {
+                if let Some(kind) = persisted_probe_kind(store, &status.server_id, old_id)? {
+                    if let Some(index) = batch
+                        .candidates
+                        .iter()
+                        .position(|candidate| candidate.kind == kind && candidate.old_id == *old_id)
+                    {
+                        let persisted = batch.candidates.remove(index);
+                        batch.candidates.insert(0, persisted);
+                    } else {
+                        batch.candidates.insert(
+                            0,
+                            ProbeCandidate {
+                                kind,
+                                old_id: old_id.clone(),
+                                new_id: new_id.clone(),
+                                cursor_after: None,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+    }
+    batch
+        .candidates
+        .truncate(MAX_PROBE_ATTEMPT_CANDIDATES);
+    Ok(batch)
+}
+
+fn persisted_probe_kind(
+    store: &LibraryStore,
+    server_id: &str,
+    old_id: &str,
+) -> Result<Option<EntityKind>, String> {
+    store.with_read_conn(|conn| {
+        let track_exists: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM track WHERE server_id = ?1 AND id = ?2 AND deleted = 0) \
+             OR EXISTS(SELECT 1 FROM track_offline WHERE server_id = ?1 AND track_id = ?2)",
+            params![server_id, old_id],
+            |row| row.get(0),
+        )?;
+        if track_exists {
+            return Ok(Some(EntityKind::Track));
+        }
+        conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM album WHERE server_id = ?1 AND id = ?2)",
+            params![server_id, old_id],
+            |row| row.get::<_, bool>(0),
+        )
+        .map(|exists| exists.then_some(EntityKind::Album))
+    })
+}
+
+fn no_legacy_state_is_current(status: &IdentityTransitionDto) -> bool {
+    status.state == "no_legacy_ids" && status.canonical_version == CANONICAL_ID_VERSION
+}
+
+struct AliasBaselineSource {
+    name: &'static str,
+    kind: EntityKind,
+    table: &'static str,
+    column: &'static str,
+    filter: &'static str,
+}
+
+const ALIAS_BASELINE_SOURCES: &[AliasBaselineSource] = &[
+    AliasBaselineSource {
+        name: "track",
+        kind: EntityKind::Track,
+        table: "track",
+        column: "id",
+        filter: "AND deleted = 0",
+    },
+    AliasBaselineSource {
+        name: "offline",
+        kind: EntityKind::Track,
+        table: "track_offline",
+        column: "track_id",
+        filter: "",
+    },
+    AliasBaselineSource {
+        name: "album",
+        kind: EntityKind::Album,
+        table: "album",
+        column: "id",
+        filter: "",
+    },
+    AliasBaselineSource {
+        name: "artist",
+        kind: EntityKind::Artist,
+        table: "artist",
+        column: "id",
+        filter: "",
+    },
+    AliasBaselineSource {
+        name: "track_album_ref",
+        kind: EntityKind::Album,
+        table: "track",
+        column: "album_id",
+        filter: "AND deleted = 0",
+    },
+    AliasBaselineSource {
+        name: "track_artist_ref",
+        kind: EntityKind::Artist,
+        table: "track",
+        column: "artist_id",
+        filter: "AND deleted = 0",
+    },
+    AliasBaselineSource {
+        name: "album_artist_ref",
+        kind: EntityKind::Artist,
+        table: "album",
+        column: "artist_id",
+        filter: "",
+    },
+];
+
+fn alias_baseline_marker(server_id: &str, source: &AliasBaselineSource) -> String {
+    format!("{ALIAS_BASELINE_MIGRATION_PREFIX}:{server_id}:{}", source.name)
+}
+
+fn ensure_inactive_alias_baseline(store: &LibraryStore, server_id: &str) -> Result<bool, String> {
+    store.with_conn_mut("navidrome_identity.alias_baseline", |conn| {
+        let mut batches = 0usize;
+        for source in ALIAS_BASELINE_SOURCES {
+            let marker = alias_baseline_marker(server_id, source);
+            loop {
+                let completed: Option<Option<i64>> = conn
+                    .query_row(
+                        "SELECT completed_at FROM library_data_migration WHERE id = ?1",
+                        params![marker],
+                        |row| row.get(0),
+                    )
+                    .optional()?;
+                if completed.flatten().is_some() {
+                    break;
+                }
+                conn.execute(
+                    "INSERT INTO library_data_migration (id, cursor_rowid, started_at) \
+                     VALUES (?1, 0, strftime('%s','now')) \
+                     ON CONFLICT(id) DO UPDATE SET \
+                       started_at = COALESCE(library_data_migration.started_at, excluded.started_at)",
+                    params![marker],
+                )?;
+                let cursor: Option<String> = conn.query_row(
+                    "SELECT cursor_text FROM library_data_migration WHERE id = ?1",
+                    params![marker],
+                    |row| row.get(0),
+                )?;
+                let sql = format!(
+                    "SELECT DISTINCT {column} FROM {table} \
+                     WHERE server_id = ?1 AND {column} > COALESCE(?2, '') \
+                        AND {column} IS NOT NULL AND {column} != '' {filter} \
+                     ORDER BY {column} LIMIT ?3",
+                    column = source.column,
+                    table = source.table,
+                    filter = source.filter,
+                );
+                let rows = conn
+                    .prepare(&sql)?
+                    .query_map(
+                        params![server_id, cursor, ALIAS_BASELINE_BATCH_SIZE],
+                        |row| row.get::<_, String>(0),
+                    )?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                if rows.is_empty() {
+                    conn.execute(
+                        "UPDATE library_data_migration \
+                         SET completed_at = strftime('%s','now') WHERE id = ?1",
+                        params![marker],
+                    )?;
+                    break;
+                }
+                let last_value = rows.last().cloned().or(cursor);
+                let tx = conn.unchecked_transaction()?;
+                insert_inactive_legacy_aliases(
+                    &tx,
+                    server_id,
+                    source.kind,
+                    rows.iter().map(String::as_str),
+                    now_unix_ms(),
+                )?;
+                tx.execute(
+                    "UPDATE library_data_migration SET cursor_text = ?2 WHERE id = ?1",
+                    params![marker, last_value],
+                )?;
+                tx.commit()?;
+                batches += 1;
+                if batches >= ALIAS_BASELINE_BATCHES_PER_ATTEMPT {
+                    return Ok(false);
+                }
+            }
+        }
+        Ok(true)
+    })
+}
+
+fn load_probe_cursor(store: &LibraryStore, server_id: &str) -> Result<ProbeCursor, String> {
+    store.with_read_conn(|conn| {
+        let encoded: Option<String> = conn
+            .query_row(
+            "SELECT probe_cursor FROM server_identity_transition WHERE server_id = ?1",
+            params![server_id],
+            |row| row.get(0),
+        )
+            .optional()?
+            .flatten();
+        Ok(encoded
+            .as_deref()
+            .and_then(|value| serde_json::from_str(value).ok())
+            .unwrap_or_default())
+    })
+}
+
+fn store_probe_cursor(
+    store: &LibraryStore,
+    server_id: &str,
+    cursor: &ProbeCursor,
+) -> Result<(), String> {
+    let encoded = (cursor != &ProbeCursor::default())
+        .then(|| serde_json::to_string(cursor))
+        .transpose()
+        .map_err(|error| error.to_string())?;
+    store.with_conn("navidrome_identity.store_probe_cursor", |conn| {
+        conn.execute(
+            "UPDATE server_identity_transition \
+             SET probe_cursor = ?2 \
+             WHERE server_id = ?1",
+            params![server_id, encoded],
+        )?;
+        Ok(())
+    })
+}
+
+fn clear_probe_cursor(store: &LibraryStore, server_id: &str) -> Result<(), String> {
+    store_probe_cursor(store, server_id, &ProbeCursor::default())
+}
+
+async fn bounded_transition_probe(
+    store: &LibraryStore,
+    subsonic: &SubsonicClient,
+    server_id: &str,
+    candidates: ProbeCandidateBatch,
+    empty_candidate_outcome: EmptyCandidateOutcome,
+) -> Result<IdentityTransitionDto, String> {
+    const REVALIDATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+    tokio::time::timeout(
+        REVALIDATION_TIMEOUT,
+        ensure_transition_with_candidates(
+            store,
+            subsonic,
+            server_id,
+            candidates,
+            empty_candidate_outcome,
+        ),
+    )
+    .await
+    .map_err(|_| "canonical-ID namespace revalidation timed out".to_string())?
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -295,27 +772,41 @@ async fn ensure_transition_with_candidates(
     store: &LibraryStore,
     subsonic: &SubsonicClient,
     server_id: &str,
-    candidates: Vec<ProbeCandidate>,
+    batch: ProbeCandidateBatch,
     empty_candidate_outcome: EmptyCandidateOutcome,
 ) -> Result<IdentityTransitionDto, String> {
     let existing = transition_status(store, server_id)?;
     if matches!(
         existing.state.as_str(),
         "transition_detected" | "pending_frontend" | "ready"
-    ) {
+    ) && existing.canonical_version == CANONICAL_ID_VERSION
+    {
         return Ok(existing);
     }
 
-    if candidates.is_empty() {
+    if batch.candidates.is_empty() {
+        if !batch.exhausted {
+            let error = "canonical-ID candidate scan has more catalog rows to inspect";
+            record_state(store, server_id, "retryable", None, None, Some(error), false)?;
+            store_probe_cursor(store, server_id, &batch.next_cursor)?;
+            return transition_status(store, server_id);
+        }
         let state = match empty_candidate_outcome {
             EmptyCandidateOutcome::AwaitSupplemental => "awaiting_supplemental_probe",
             EmptyCandidateOutcome::NoLegacyIds => "no_legacy_ids",
         };
-        record_state(store, server_id, state, None, None, None, false)?;
+        if state == "no_legacy_ids" {
+            record_state(store, server_id, state, None, None, None, false)?;
+            clear_probe_cursor(store, server_id)?;
+        } else {
+            record_state(store, server_id, state, None, None, None, false)?;
+        }
         return transition_status(store, server_id);
     }
 
-    for candidate in &candidates {
+    let mut first_retryable: Option<(ProbeCandidate, String)> = None;
+    let mut conclusive_cursor: Option<ProbeCursor> = None;
+    for candidate in &batch.candidates {
         let (old, new) = tokio::join!(
             probe_entity(subsonic, candidate.kind, &candidate.old_id),
             probe_entity(subsonic, candidate.kind, &candidate.new_id),
@@ -338,11 +829,16 @@ async fn ensure_transition_with_candidates(
                     store,
                     server_id,
                     candidate,
-                    &candidates,
+                    &batch.candidates,
                 )?;
                 return transition_status(store, server_id);
             }
-            (Err(SubsonicError::NotFound), Err(SubsonicError::NotFound)) => {}
+            (Err(SubsonicError::NotFound), Err(SubsonicError::NotFound)) => {
+                if let Some(cursor) = &candidate.cursor_after {
+                    store_probe_cursor(store, server_id, cursor)?;
+                    conclusive_cursor = Some(cursor.clone());
+                }
+            }
             (Ok(()), Ok(())) => {
                 let error = "legacy and canonical forms both resolved; refusing ambiguous identity evidence";
                 record_state(
@@ -362,18 +858,26 @@ async fn ensure_transition_with_candidates(
                     probe_result_label(&old),
                     probe_result_label(&new)
                 );
-                record_state(
-                    store,
-                    server_id,
-                    "retryable",
-                    Some(&candidate.old_id),
-                    Some(&candidate.new_id),
-                    Some(&error),
-                    false,
-                )?;
-                return transition_status(store, server_id);
+                if first_retryable.is_none() {
+                    first_retryable = Some((candidate.clone(), error));
+                }
             }
         }
+    }
+    if let Some((candidate, error)) = first_retryable {
+        record_state(
+            store,
+            server_id,
+            "retryable",
+            Some(&candidate.old_id),
+            Some(&candidate.new_id),
+            Some(&error),
+            false,
+        )?;
+        if let Some(cursor) = &conclusive_cursor {
+            store_probe_cursor(store, server_id, cursor)?;
+        }
+        return transition_status(store, server_id);
     }
     let error = "no live probe candidate established the active Navidrome ID namespace";
     record_state(
@@ -385,6 +889,7 @@ async fn ensure_transition_with_candidates(
         Some(error),
         false,
     )?;
+    store_probe_cursor(store, server_id, &batch.next_cursor)?;
     transition_status(store, server_id)
 }
 
@@ -412,6 +917,8 @@ pub(crate) async fn resolve_unexpected_not_found(
     }
     let lock = targeted_probe_lock(server_id, kind, old_id);
     let _guard = lock.lock().await;
+    let transition_lock = transition_probe_lock(server_id);
+    let _transition_guard = transition_lock.lock().await;
     let existing = transition_status(store, server_id)?;
     match existing.state.as_str() {
         "transition_detected" | "pending_frontend" => {
@@ -422,12 +929,6 @@ pub(crate) async fn resolve_unexpected_not_found(
                 "canonical-ID state `{}` prevents destructive reconciliation",
                 existing.state
             ));
-        }
-        "legacy"
-            if existing.probe_old_id.as_deref() == Some(old_id)
-                && existing.probe_new_id.as_deref() == Some(new_id.as_str()) =>
-        {
-            return Ok(TargetedNotFoundOutcome::ConfirmedMissing);
         }
         _ => {}
     }
@@ -443,6 +944,7 @@ pub(crate) async fn resolve_unexpected_not_found(
                 kind,
                 old_id: old_id.to_string(),
                 new_id: new_id.clone(),
+                cursor_after: None,
             };
             record_transition_detected(
                 store,
@@ -508,6 +1010,20 @@ fn targeted_probe_lock(server_id: &str, kind: EntityKind, old_id: &str) -> Arc<A
     lock
 }
 
+pub(crate) fn transition_probe_lock(server_id: &str) -> Arc<AsyncMutex<()>> {
+    static LOCKS: OnceLock<Mutex<HashMap<String, Weak<AsyncMutex<()>>>>> = OnceLock::new();
+    let mut locks = LOCKS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(lock) = locks.get(server_id).and_then(Weak::upgrade) {
+        return lock;
+    }
+    let lock = Arc::new(AsyncMutex::new(()));
+    locks.insert(server_id.to_string(), Arc::downgrade(&lock));
+    lock
+}
+
 async fn probe_entity(
     subsonic: &SubsonicClient,
     kind: EntityKind,
@@ -516,6 +1032,9 @@ async fn probe_entity(
     match kind {
         EntityKind::Track => subsonic.get_song(id).await.map(|_| ()),
         EntityKind::Album => subsonic.get_album(id).await.map(|_| ()),
+        EntityKind::Artist => Err(SubsonicError::Decode(
+            "artist identity candidates are not directly probeable".to_string(),
+        )),
     }
 }
 
@@ -526,40 +1045,203 @@ fn probe_result_label(result: &Result<(), SubsonicError>) -> String {
     }
 }
 
-fn probe_candidates(store: &LibraryStore, server_id: &str) -> Result<Vec<ProbeCandidate>, String> {
-    const MAX_CANDIDATES: usize = 8;
+fn probe_candidates(
+    store: &LibraryStore,
+    server_id: &str,
+) -> Result<ProbeCandidateBatch, String> {
+    const PAGE_SIZE: usize = 64;
+    const MAX_SCANNED_ROWS: usize = 512;
+    let cursor = load_probe_cursor(store, server_id)?;
     store.with_read_conn(|conn| {
-        let mut candidates = Vec::new();
-        for (kind, table) in [(EntityKind::Track, "track"), (EntityKind::Album, "album")] {
+        let mut candidates: Vec<ProbeCandidate> = Vec::new();
+        let sources = [
+            (EntityKind::Track, "track", "id"),
+            (EntityKind::Track, "track_offline", "track_id"),
+            (EntityKind::Album, "album", "id"),
+        ];
+        let mut scanned_rows = 0usize;
+        for (source, (kind, table, column)) in sources.iter().copied().enumerate().skip(cursor.source)
+        {
             let live_filter = if table == "track" {
                 " AND deleted = 0"
             } else {
                 ""
             };
-            let mut statement = conn.prepare(&format!(
-                "SELECT id FROM {table} WHERE server_id = ?1{live_filter} ORDER BY id LIMIT 64"
-            ))?;
-            let mut rows = statement.query(params![server_id])?;
-            while let Some(row) = rows.next()? {
-                let old_id = row.get::<_, String>(0)?;
-                let new_id = canonical_id(&old_id);
-                if new_id != old_id {
-                    candidates.push(ProbeCandidate {
-                        kind,
-                        old_id,
-                        new_id,
+            let mut after = (source == cursor.source)
+                .then(|| cursor.after_id.clone())
+                .flatten();
+            loop {
+                if scanned_rows >= MAX_SCANNED_ROWS
+                    || candidates.len() >= MAX_PROBE_CANDIDATES
+                {
+                    return Ok(ProbeCandidateBatch {
+                        candidates,
+                        next_cursor: ProbeCursor {
+                            source,
+                            after_id: after,
+                        },
+                        exhausted: false,
                     });
-                    if candidates.len() >= MAX_CANDIDATES {
-                        return Ok(candidates);
+                }
+                let limit = PAGE_SIZE.min(MAX_SCANNED_ROWS - scanned_rows);
+                let page = {
+                    let (sql, binds): (String, Vec<&dyn rusqlite::ToSql>) = match after.as_ref() {
+                        Some(after) => (
+                            format!(
+                                "SELECT {column} FROM {table} WHERE server_id = ?1{live_filter} \
+                                 AND {column} > ?2 ORDER BY {column} LIMIT {limit}"
+                            ),
+                            vec![&server_id, after],
+                        ),
+                        None => (
+                            format!(
+                                "SELECT {column} FROM {table} WHERE server_id = ?1{live_filter} \
+                                 ORDER BY {column} LIMIT {limit}"
+                            ),
+                            vec![&server_id],
+                        ),
+                    };
+                    conn.prepare(&sql)?
+                        .query_map(binds.as_slice(), |row| row.get::<_, String>(0))?
+                        .collect::<rusqlite::Result<Vec<_>>>()?
+                };
+                if page.is_empty() {
+                    break;
+                }
+                let page_len = page.len();
+                for old_id in page {
+                    scanned_rows += 1;
+                    after = Some(old_id.clone());
+                    let new_id = canonical_id(&old_id);
+                    if new_id != old_id
+                        && !candidates
+                            .iter()
+                            .any(|candidate| candidate.kind == kind && candidate.old_id == old_id)
+                    {
+                        candidates.push(ProbeCandidate {
+                            kind,
+                            old_id,
+                            new_id,
+                            cursor_after: Some(ProbeCursor {
+                                source,
+                                after_id: after.clone(),
+                            }),
+                        });
+                        if candidates.len() >= MAX_PROBE_CANDIDATES {
+                            return Ok(ProbeCandidateBatch {
+                                candidates,
+                                next_cursor: ProbeCursor {
+                                    source,
+                                    after_id: after,
+                                },
+                                exhausted: false,
+                            });
+                        }
                     }
+                }
+                if page_len < limit {
+                    break;
                 }
             }
         }
-        Ok(candidates)
+        Ok(ProbeCandidateBatch {
+            candidates,
+            next_cursor: ProbeCursor::default(),
+            exhausted: true,
+        })
     })
 }
 
+fn upgrade_completed_state_if_needed(
+    store: &LibraryStore,
+    server_id: &str,
+) -> Result<(), String> {
+    let status = transition_status(store, server_id)?;
+    if status.canonical_version >= CANONICAL_ID_VERSION
+        || !matches!(status.state.as_str(), "pending_frontend" | "ready")
+    {
+        return Ok(());
+    }
+
+    let result = store.with_conn_mut("navidrome_identity.upgrade_completed_state", |conn| {
+        let tx = conn.transaction()?;
+        reconcile_orphan_offline_ids(&tx, server_id, now_unix_ms())?;
+        tx.execute(
+            "UPDATE server_identity_transition \
+             SET canonical_version = ?2, last_error = NULL \
+             WHERE server_id = ?1 AND state IN ('pending_frontend', 'ready')",
+            params![server_id, CANONICAL_ID_VERSION],
+        )?;
+        tx.commit()
+    });
+    if let Err(error) = result {
+        record_state(
+            store,
+            server_id,
+            "blocked",
+            status.probe_old_id.as_deref(),
+            status.probe_new_id.as_deref(),
+            Some(&format!("canonical-ID version upgrade failed: {error}")),
+            status.state == "pending_frontend" || status.state == "ready",
+        )?;
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn reconcile_orphan_offline_ids(
+    tx: &Transaction<'_>,
+    server_id: &str,
+    now: i64,
+) -> rusqlite::Result<()> {
+    let offline_ids = tx
+        .prepare("SELECT track_id FROM track_offline WHERE server_id = ?1 ORDER BY track_id")?
+        .query_map(params![server_id], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    for old_id in offline_ids {
+        let new_id = canonical_id(&old_id);
+        if new_id == old_id {
+            continue;
+        }
+        let destination_exists: bool = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM track_offline WHERE server_id = ?1 AND track_id = ?2)",
+            params![server_id, new_id],
+            |row| row.get(0),
+        )?;
+        if destination_exists {
+            return Err(rusqlite::Error::ToSqlConversionFailure(Box::new(
+                io::Error::other(format!(
+                    "canonical offline track id collision at `{new_id}`"
+                )),
+            )));
+        }
+        tx.execute(
+            "UPDATE track_offline SET track_id = ?3 \
+             WHERE server_id = ?1 AND track_id = ?2",
+            params![server_id, old_id, new_id],
+        )?;
+        tx.execute(
+            "INSERT INTO track_id_history \
+             (server_id, old_id, new_id, content_hash, server_path, remapped_at) \
+             VALUES (?1, ?2, ?3, NULL, NULL, ?4) \
+             ON CONFLICT(server_id, old_id) DO UPDATE SET \
+               new_id = excluded.new_id, remapped_at = excluded.remapped_at",
+            params![server_id, old_id, new_id, now],
+        )?;
+        tx.execute(
+            "INSERT INTO entity_id_remap \
+             (server_id, entity_kind, old_id, new_id, remapped_at, active) \
+             VALUES (?1, 'track', ?2, ?3, ?4, 1) \
+             ON CONFLICT(server_id, entity_kind, old_id) DO UPDATE SET \
+               new_id = excluded.new_id, remapped_at = excluded.remapped_at, active = 1",
+            params![server_id, old_id, new_id, now],
+        )?;
+    }
+    Ok(())
+}
+
 pub fn run_native_migration(store: &LibraryStore, server_id: &str) -> Result<(), String> {
+    upgrade_completed_state_if_needed(store, server_id)?;
     let status = transition_status(store, server_id)?;
     match status.state.as_str() {
         "pending_frontend" | "ready" => return Ok(()),
@@ -695,15 +1377,16 @@ pub fn run_native_migration(store: &LibraryStore, server_id: &str) -> Result<(),
         tx.commit()
     });
     if let Err(error) = result {
-        record_state(
-            store,
-            server_id,
-            "blocked",
-            status.probe_old_id.as_deref(),
-            status.probe_new_id.as_deref(),
-            Some(&error),
-            false,
-        )?;
+        let now = now_unix_ms();
+        store.with_conn("navidrome_identity.block_failed_migration", |conn| {
+            conn.execute(
+                "UPDATE server_identity_transition \
+                 SET state = 'blocked', last_error = ?2, detected_at = ?3 \
+                 WHERE server_id = ?1 AND state = 'transition_detected'",
+                params![server_id, error, now],
+            )?;
+            Ok(())
+        })?;
         return Err(error);
     }
     Ok(())
@@ -712,7 +1395,22 @@ pub fn run_native_migration(store: &LibraryStore, server_id: &str) -> Result<(),
 fn collect_library_maps(conn: &Connection, server_id: &str) -> rusqlite::Result<LibraryIdMaps> {
     let artists = collect_entity_map(conn, "artist", server_id)?;
     let albums = collect_entity_map(conn, "album", server_id)?;
-    let tracks = collect_entity_map(conn, "track", server_id)?;
+    let mut track_values = collect_column_values(conn, "track", "id", server_id)?;
+    track_values.extend(collect_column_values(
+        conn,
+        "track_offline",
+        "track_id",
+        server_id,
+    )?);
+    track_values.sort();
+    track_values.dedup();
+    let tracks = track_values
+        .into_iter()
+        .filter_map(|old_id| {
+            let new_id = canonical_id(&old_id);
+            (new_id != old_id).then_some(IdMap { old_id, new_id })
+        })
+        .collect::<Vec<_>>();
     let mut folder_values = collect_column_values(conn, "track", "library_id", server_id)?;
     folder_values.extend(collect_column_values(
         conn,
@@ -808,16 +1506,25 @@ fn insert_temp_map(tx: &Transaction<'_>, table: &str, mappings: &[IdMap]) -> rus
 }
 
 fn reject_collisions(tx: &Transaction<'_>, server_id: &str) -> rusqlite::Result<()> {
-    for (table, map) in [
-        ("artist", "canonical_artist_map"),
-        ("album", "canonical_album_map"),
-        ("track", "canonical_track_map"),
+    for (table, map, require_old_entity) in [
+        ("artist", "canonical_artist_map", false),
+        ("album", "canonical_album_map", false),
+        ("track", "canonical_track_map", true),
     ] {
+        let old_entity_filter = if require_old_entity {
+            format!(
+                " AND EXISTS (SELECT 1 FROM {table} old_entity \
+                   WHERE old_entity.server_id = entity.server_id \
+                     AND old_entity.id = mapping.old_id)"
+            )
+        } else {
+            String::new()
+        };
         let collision: Option<String> = tx
             .query_row(
                 &format!(
                     "SELECT entity.id FROM {table} entity JOIN {map} mapping ON mapping.new_id = entity.id \
-                     WHERE entity.server_id = ?1 LIMIT 1"
+                     WHERE entity.server_id = ?1{old_entity_filter} LIMIT 1"
                 ),
                 params![server_id],
                 |row| row.get(0),
@@ -1015,9 +1722,10 @@ fn record_transition_detected(
     mappings: &[ProbeCandidate],
 ) -> Result<(), String> {
     let now = now_unix_ms();
-    store.with_conn("navidrome_identity.record_transition", |conn| {
-        write_state(
-            conn,
+    store.with_conn_mut("navidrome_identity.record_transition", |conn| {
+        let tx = conn.transaction()?;
+        let applied = write_state(
+            &tx,
             server_id,
             "transition_detected",
             Some(&evidence.old_id),
@@ -1026,29 +1734,270 @@ fn record_transition_detected(
             false,
             now,
         )?;
-        let mut statement = conn.prepare(
-            "INSERT INTO entity_id_remap(server_id, entity_kind, old_id, new_id, remapped_at, active) \
-             VALUES (?1, ?2, ?3, ?4, ?5, 0) \
-             ON CONFLICT(server_id, entity_kind, old_id) DO UPDATE SET \
-               new_id = excluded.new_id, remapped_at = excluded.remapped_at, active = 0",
-        )?;
-        for mapping in mappings {
-            statement.execute(params![
-                server_id,
-                entity_kind_label(mapping.kind),
-                mapping.old_id,
-                mapping.new_id,
-                now
-            ])?;
+        if !applied {
+            tx.rollback()?;
+            return Ok(());
         }
-        Ok(())
+        {
+            let mut statement = tx.prepare(
+                "INSERT INTO entity_id_remap(server_id, entity_kind, old_id, new_id, remapped_at, active) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, 0) \
+                 ON CONFLICT(server_id, entity_kind, old_id) DO UPDATE SET \
+                   new_id = excluded.new_id, remapped_at = excluded.remapped_at, active = 0",
+            )?;
+            for mapping in mappings {
+                statement.execute(params![
+                    server_id,
+                    entity_kind_label(mapping.kind),
+                    mapping.old_id,
+                    mapping.new_id,
+                    now
+                ])?;
+            }
+        }
+        tx.commit()
     })
+}
+
+pub(crate) fn record_deterministic_transition_if_legacy_state(
+    conn: &Connection,
+    server_id: &str,
+    entity_kind: &str,
+    old_id: &str,
+    new_id: &str,
+) -> rusqlite::Result<bool> {
+    let state: Option<String> = conn
+        .query_row(
+            "SELECT state FROM server_identity_transition WHERE server_id = ?1",
+            params![server_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if !matches!(state.as_deref(), Some("legacy" | "no_legacy_ids")) {
+        return Ok(false);
+    }
+
+    let now = now_unix_ms();
+    let applied = write_state(
+        conn,
+        server_id,
+        "transition_detected",
+        Some(old_id),
+        Some(new_id),
+        None,
+        false,
+        now,
+    )?;
+    if !applied {
+        return Ok(false);
+    }
+    conn.execute(
+        "INSERT INTO entity_id_remap(server_id, entity_kind, old_id, new_id, remapped_at, active) \
+         VALUES (?1, ?2, ?3, ?4, ?5, 0) \
+         ON CONFLICT(server_id, entity_kind, old_id) DO UPDATE SET \
+           new_id = excluded.new_id, remapped_at = excluded.remapped_at, active = 0",
+        params![server_id, entity_kind, old_id, new_id, now],
+    )?;
+    Ok(true)
+}
+
+pub(crate) fn load_deterministic_write_guard(
+    conn: &Connection,
+    server_id: &str,
+) -> rusqlite::Result<DeterministicWriteGuard> {
+    conn.query_row(
+        "SELECT state, probe_old_id, probe_new_id \
+         FROM server_identity_transition WHERE server_id = ?1",
+        params![server_id],
+        |row| {
+            let state: String = row.get(0)?;
+            Ok(DeterministicWriteGuard {
+                enabled: matches!(state.as_str(), "legacy" | "no_legacy_ids"),
+                probe_old_id: row.get(1)?,
+                probe_new_id: row.get(2)?,
+            })
+        },
+    )
+    .optional()
+    .map(|guard| guard.unwrap_or_default())
+}
+
+pub(crate) fn register_inactive_legacy_aliases<'a>(
+    conn: &Connection,
+    server_id: &str,
+    guard: &DeterministicWriteGuard,
+    aliases: impl IntoIterator<Item = (EntityKind, &'a str)>,
+    observed_at: i64,
+) -> rusqlite::Result<usize> {
+    if !guard.enabled() {
+        return Ok(0);
+    }
+    let mut grouped = HashMap::<EntityKind, HashSet<&str>>::new();
+    for (kind, observed_id) in aliases {
+        grouped.entry(kind).or_default().insert(observed_id);
+    }
+    let mut inserted = 0usize;
+    for (kind, ids) in grouped {
+        inserted += insert_inactive_legacy_aliases(
+            conn,
+            server_id,
+            kind,
+            ids,
+            observed_at,
+        )?;
+    }
+    Ok(inserted)
+}
+
+fn insert_inactive_legacy_aliases<'a>(
+    conn: &Connection,
+    server_id: &str,
+    kind: EntityKind,
+    observed_ids: impl IntoIterator<Item = &'a str>,
+    observed_at: i64,
+) -> rusqlite::Result<usize> {
+    let mut statement = conn.prepare_cached(
+        "INSERT INTO entity_id_remap \
+         (server_id, entity_kind, old_id, new_id, remapped_at, active) \
+         VALUES (?1, ?2, ?3, ?4, ?5, 0) \
+         ON CONFLICT(server_id, entity_kind, old_id) DO UPDATE SET \
+           new_id = excluded.new_id, remapped_at = excluded.remapped_at, \
+           active = entity_id_remap.active",
+    )?;
+    let mut inserted = 0usize;
+    let entity_kind = entity_kind_label(kind);
+    for observed_id in observed_ids {
+        let canonical = canonical_id(observed_id);
+        if canonical == observed_id {
+            continue;
+        }
+        statement.execute(params![
+            server_id,
+            entity_kind,
+            observed_id,
+            canonical,
+            observed_at
+        ])?;
+        inserted += 1;
+    }
+    Ok(inserted)
+}
+
+pub(crate) fn find_deterministic_legacy_id_with_guard(
+    conn: &Connection,
+    server_id: &str,
+    guard: &DeterministicWriteGuard,
+    kind: EntityKind,
+    incoming_id: &str,
+) -> rusqlite::Result<Option<String>> {
+    if !guard.enabled() {
+        return Ok(None);
+    }
+    find_deterministic_legacy_id(
+        conn,
+        server_id,
+        kind,
+        incoming_id,
+        guard.hinted_old_id(incoming_id),
+    )
+}
+
+pub(crate) fn find_deterministic_legacy_id(
+    conn: &Connection,
+    server_id: &str,
+    kind: EntityKind,
+    incoming_id: &str,
+    hinted_old_id: Option<&str>,
+) -> rusqlite::Result<Option<String>> {
+    if let Some(old_id) = hinted_old_id {
+        if old_id != incoming_id
+            && canonical_id(old_id) == incoming_id
+            && legacy_entity_exists(conn, server_id, kind, old_id)?
+        {
+            return Ok(Some(old_id.to_string()));
+        }
+    }
+
+    let entity_kind = entity_kind_label(kind);
+    let persisted: Option<String> = conn
+        .query_row(
+            "SELECT old_id FROM entity_id_remap \
+             WHERE server_id = ?1 AND entity_kind = ?2 AND new_id = ?3 \
+             ORDER BY active DESC, remapped_at DESC LIMIT 1",
+            params![server_id, entity_kind, incoming_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if let Some(old_id) = persisted {
+        if legacy_entity_exists(conn, server_id, kind, &old_id)? {
+            return Ok(Some(old_id));
+        }
+    }
+
+    for old_id in reversible_legacy_ids(incoming_id) {
+        if old_id != incoming_id && legacy_entity_exists(conn, server_id, kind, &old_id)? {
+            return Ok(Some(old_id));
+        }
+    }
+    Ok(None)
+}
+
+fn legacy_entity_exists(
+    conn: &Connection,
+    server_id: &str,
+    kind: EntityKind,
+    old_id: &str,
+) -> rusqlite::Result<bool> {
+    match kind {
+        EntityKind::Track => conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM track \
+               WHERE server_id = ?1 AND id = ?2 AND deleted = 0) \
+             OR EXISTS(SELECT 1 FROM track_offline \
+               WHERE server_id = ?1 AND track_id = ?2)",
+            params![server_id, old_id],
+            |row| row.get(0),
+        ),
+        EntityKind::Album => conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM album WHERE server_id = ?1 AND id = ?2)",
+            params![server_id, old_id],
+            |row| row.get(0),
+        ),
+        EntityKind::Artist => conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM artist WHERE server_id = ?1 AND id = ?2)",
+            params![server_id, old_id],
+            |row| row.get(0),
+        ),
+    }
+}
+
+fn reversible_legacy_ids(canonical: &str) -> Vec<String> {
+    if canonical.len() != 22 {
+        return Vec::new();
+    }
+    let Ok(value) = decode_base62_u128(canonical) else {
+        return Vec::new();
+    };
+    let bytes = value.to_be_bytes();
+    let hex = bytes
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    let uuid = format!(
+        "{}-{}-{}-{}-{}",
+        &hex[0..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..32]
+    );
+    vec![hex.clone(), hex.to_uppercase(), uuid.clone(), uuid.to_uppercase()]
 }
 
 fn entity_kind_label(kind: EntityKind) -> &'static str {
     match kind {
         EntityKind::Track => "track",
         EntityKind::Album => "album",
+        EntityKind::Artist => "artist",
     }
 }
 
@@ -1072,7 +2021,8 @@ fn record_state(
             last_error,
             migrated,
             now,
-        )
+        )?;
+        Ok(())
     })
 }
 
@@ -1086,8 +2036,8 @@ fn write_state(
     last_error: Option<&str>,
     migrated: bool,
     now: i64,
-) -> rusqlite::Result<()> {
-    conn.execute(
+) -> rusqlite::Result<bool> {
+    let changed = conn.execute(
         "INSERT INTO server_identity_transition \
          (server_id, canonical_version, state, probe_old_id, probe_new_id, detected_at, native_migrated_at, last_error) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8) \
@@ -1097,7 +2047,14 @@ fn write_state(
            detected_at = excluded.detected_at, \
            native_migrated_at = COALESCE(excluded.native_migrated_at, server_identity_transition.native_migrated_at), \
            frontend_acked_at = CASE WHEN excluded.state = 'pending_frontend' THEN NULL ELSE server_identity_transition.frontend_acked_at END, \
-           last_error = excluded.last_error",
+            last_error = excluded.last_error \
+           WHERE server_identity_transition.canonical_version != excluded.canonical_version \
+              OR server_identity_transition.state NOT IN ('transition_detected', 'pending_frontend', 'ready') \
+              OR server_identity_transition.state = 'transition_detected' \
+                 AND excluded.state IN ('transition_detected', 'pending_frontend') \
+              OR server_identity_transition.state = 'pending_frontend' \
+                 AND excluded.state IN ('pending_frontend', 'ready', 'blocked') \
+              OR server_identity_transition.state = 'ready' AND excluded.state = 'ready'",
         params![
             server_id,
             CANONICAL_ID_VERSION,
@@ -1109,7 +2066,7 @@ fn write_state(
             last_error,
         ],
     )?;
-    Ok(())
+    Ok(changed > 0)
 }
 
 fn sql_string(value: &str) -> String {
@@ -1245,6 +2202,47 @@ mod tests {
             .unwrap();
     }
 
+    fn incoming_track(id: &str) -> crate::repos::TrackRow {
+        crate::repos::TrackRow {
+            server_id: "s1".into(),
+            id: id.into(),
+            title: "Track".into(),
+            title_sort: None,
+            artist: None,
+            artist_id: None,
+            album: "Album".into(),
+            album_id: None,
+            album_artist: None,
+            duration_sec: 0,
+            track_number: None,
+            disc_number: None,
+            year: None,
+            genre: None,
+            suffix: None,
+            bit_rate: None,
+            size_bytes: None,
+            cover_art_id: None,
+            starred_at: None,
+            user_rating: None,
+            play_count: None,
+            played_at: None,
+            server_path: None,
+            library_id: None,
+            isrc: None,
+            mbid_recording: None,
+            bpm: None,
+            replay_gain_track_db: None,
+            replay_gain_album_db: None,
+            replay_gain_peak: None,
+            content_hash: None,
+            server_updated_at: None,
+            server_created_at: None,
+            deleted: false,
+            synced_at: 1,
+            raw_json: "{}".into(),
+        }
+    }
+
     fn song_response(id: &str) -> serde_json::Value {
         serde_json::json!({
             "subsonic-response": {
@@ -1289,6 +2287,72 @@ mod tests {
             canonical_id("not-a-uuid-----------------------"),
             "not-a-uuid-----------------------"
         );
+    }
+
+    #[test]
+    fn reversible_legacy_ids_round_trip_hex_and_uuid_forms() {
+        for old in [
+            "e3b7fc2ae9447bbec37a13bf916e3cf6",
+            "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        ] {
+            assert!(reversible_legacy_ids(&canonical_id(old))
+                .into_iter()
+                .any(|candidate| candidate.eq_ignore_ascii_case(old)));
+        }
+    }
+
+    #[test]
+    fn album_guard_uses_bounded_primary_key_lookups() {
+        let store = LibraryStore::open_in_memory();
+        let old = "11112222333344445555666677778888";
+        let new = canonical_id(old);
+        store
+            .with_conn("test.album_guard_plan", |conn| {
+                conn.execute(
+                    "INSERT INTO album(server_id,id,name,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Legacy',1,'{}')",
+                    params![old],
+                )?;
+                let plan = conn
+                    .prepare(
+                        "EXPLAIN QUERY PLAN SELECT EXISTS(SELECT 1 FROM album \
+                         WHERE server_id = ?1 AND id = ?2)",
+                    )?
+                    .query_map(params!["s1", old], |row| row.get::<_, String>(3))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                assert!(plan.iter().any(|detail| detail.contains("sqlite_autoindex_album_1")));
+                assert!(!plan.iter().any(|detail| detail.contains("SCAN album")));
+                assert_eq!(
+                    find_deterministic_legacy_id(conn, "s1", EntityKind::Album, &new, None)?,
+                    Some(old.to_string())
+                );
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn canonical_alias_reverse_lookup_uses_the_new_id_index() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_read_conn(|conn| {
+                let plan = conn
+                    .prepare(
+                        "EXPLAIN QUERY PLAN SELECT old_id FROM entity_id_remap \
+                         WHERE server_id = ?1 AND entity_kind = ?2 AND new_id = ?3 \
+                         ORDER BY active DESC, remapped_at DESC LIMIT 1",
+                    )?
+                    .query_map(params!["s1", "artist", "canonical"], |row| {
+                        row.get::<_, String>(3)
+                    })?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                assert!(plan
+                    .iter()
+                    .any(|detail| detail.contains("idx_entity_id_remap_new")));
+                assert!(!plan.iter().any(|detail| detail.contains("SCAN entity_id_remap")));
+                Ok(())
+            })
+            .unwrap();
     }
 
     #[test]
@@ -1369,6 +2433,531 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn retries_advance_past_eight_dead_candidates_to_the_ninth() {
+        let server = MockServer::start().await;
+        let ids: Vec<String> = (0..9).map(|index| format!("{index:032x}")).collect();
+        for old in &ids[..8] {
+            let new = canonical_id(old);
+            for id in [old.as_str(), new.as_str()] {
+                Mock::given(method("GET"))
+                    .and(path("/rest/getSong.view"))
+                    .and(query_param("id", id))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
+                    .expect(1)
+                    .mount(&server)
+                    .await;
+            }
+        }
+        let decisive_old = &ids[8];
+        let decisive_new = canonical_id(decisive_old);
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", decisive_old.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", decisive_new.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(song_response(&decisive_new)))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let store = LibraryStore::open_in_memory();
+        for id in &ids {
+            seed_legacy_track(&store, id);
+        }
+
+        let client = test_client(&server.uri());
+        let first = ensure_transition(&store, &client, "s1").await.unwrap();
+        assert_eq!(first.state, "retryable");
+        let cursor_after_first = load_probe_cursor(&store, "s1").unwrap();
+        assert_eq!(cursor_after_first.after_id.as_deref(), Some(ids[7].as_str()));
+
+        let second = ensure_transition(&store, &client, "s1").await.unwrap();
+        assert_eq!(second.state, "transition_detected");
+        assert_eq!(second.probe_old_id.as_deref(), Some(decisive_old.as_str()));
+        assert_eq!(second.probe_new_id.as_deref(), Some(decisive_new.as_str()));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn persisted_transient_is_probed_with_next_eight_and_ninth_is_decisive() {
+        let server = MockServer::start().await;
+        let ids: Vec<String> = (0..9).map(|index| format!("{index:032x}")).collect();
+        let persisted_old = &ids[0];
+        let persisted_new = canonical_id(persisted_old);
+        for id in [persisted_old.as_str(), persisted_new.as_str()] {
+            Mock::given(method("GET"))
+                .and(path("/rest/getSong.view"))
+                .and(query_param("id", id))
+                .respond_with(ResponseTemplate::new(503))
+                .expect(2)
+                .mount(&server)
+                .await;
+        }
+        for old in &ids[1..8] {
+            let new = canonical_id(old);
+            for id in [old.as_str(), new.as_str()] {
+                Mock::given(method("GET"))
+                    .and(path("/rest/getSong.view"))
+                    .and(query_param("id", id))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
+                    .expect(1)
+                    .mount(&server)
+                    .await;
+            }
+        }
+        let decisive_old = &ids[8];
+        let decisive_new = canonical_id(decisive_old);
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", decisive_old.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", decisive_new.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(song_response(&decisive_new)))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let store = LibraryStore::open_in_memory();
+        for id in &ids {
+            seed_legacy_track(&store, id);
+        }
+        record_state(
+            &store,
+            "s1",
+            "retryable",
+            Some(persisted_old),
+            Some(&persisted_new),
+            Some("transient"),
+            false,
+        )
+        .unwrap();
+
+        let client = test_client(&server.uri());
+        let first = ensure_transition(&store, &client, "s1").await.unwrap();
+        assert_eq!(first.state, "retryable");
+        assert_eq!(first.probe_old_id.as_deref(), Some(persisted_old.as_str()));
+        assert_eq!(
+            load_probe_cursor(&store, "s1").unwrap().after_id.as_deref(),
+            Some(ids[7].as_str())
+        );
+
+        let second = ensure_transition(&store, &client, "s1").await.unwrap();
+        assert_eq!(second.state, "transition_detected");
+        assert_eq!(second.probe_old_id.as_deref(), Some(decisive_old.as_str()));
+        assert_eq!(second.probe_new_id.as_deref(), Some(decisive_new.as_str()));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn upgrade_baselines_existing_overflow_artist_before_no_legacy_readiness() {
+        let server = MockServer::start().await;
+        let store = LibraryStore::open_in_memory();
+        let old = "ZZZZZZZZZZZZZZZZZZZZZZ";
+        let new = canonical_id(old);
+        store
+            .with_conn("test.seed_existing_overflow_artist", |conn| {
+                conn.execute(
+                    "INSERT INTO artist(server_id,id,name,synced_at) \
+                     VALUES ('s1',?1,'Legacy Artist',1)",
+                    params![old],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        let status = ensure_transition_with_probe_candidates(
+            &store,
+            &test_client(&server.uri()),
+            "s1",
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(status.state, "no_legacy_ids");
+        let alias: (String, i64) = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT old_id, active FROM entity_id_remap \
+                     WHERE server_id = 's1' AND entity_kind = 'artist' AND new_id = ?1",
+                    params![new],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+            })
+            .unwrap();
+        assert_eq!(alias, (old.into(), 0));
+        let completed: i64 = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT COUNT(*) FROM library_data_migration \
+                     WHERE id LIKE ?1 AND completed_at IS NOT NULL",
+                    params![format!("{ALIAS_BASELINE_MIGRATION_PREFIX}:s1:%")],
+                    |row| row.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(completed, ALIAS_BASELINE_SOURCES.len() as i64);
+
+        let repo = crate::repos::ArtistRepository::new(&store);
+        let index = psysonic_integration::subsonic::ArtistIndex {
+            last_modified_ms: Some(1),
+            ignored_articles: None,
+            index: vec![psysonic_integration::subsonic::IndexBucket {
+                name: "A".into(),
+                artist: vec![psysonic_integration::subsonic::ArtistRef {
+                    id: new.clone(),
+                    name: "Canonical Artist".into(),
+                    album_count: Some(1),
+                    cover_art: None,
+                }],
+            }],
+        };
+        let (_, transition) = repo.upsert_index("s1", &index, 2).unwrap();
+        assert_eq!(transition.unwrap().old_id, old);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn alias_baseline_resumes_from_durable_artist_cursor() {
+        let server = MockServer::start().await;
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn("test.seed_large_artist_alias_baseline", |conn| {
+                let mut insert = conn.prepare(
+                    "INSERT INTO artist(server_id,id,name,synced_at) VALUES ('s1',?1,?2,1)",
+                )?;
+                for index in 0..1_025 {
+                    insert.execute(params![format!("{index:032x}"), format!("Artist {index}")])?;
+                }
+                Ok(())
+            })
+            .unwrap();
+        let client = test_client(&server.uri());
+
+        let first = ensure_transition_with_probe_candidates(&store, &client, "s1", Vec::new())
+            .await
+            .unwrap();
+        assert_eq!(first.state, "retryable");
+        assert_eq!(first.last_error.as_deref(), Some(ALIAS_BASELINE_PROGRESS_ERROR));
+        let artist_marker = alias_baseline_marker(
+            "s1",
+            ALIAS_BASELINE_SOURCES
+                .iter()
+                .find(|source| source.name == "artist")
+                .unwrap(),
+        );
+        let (cursor, completed, aliases): (Option<String>, Option<i64>, i64) = store
+            .with_read_conn(|conn| {
+                let (cursor, completed) = conn.query_row(
+                    "SELECT cursor_text, completed_at FROM library_data_migration WHERE id = ?1",
+                    params![artist_marker],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )?;
+                let aliases = conn.query_row(
+                    "SELECT COUNT(*) FROM entity_id_remap \
+                     WHERE server_id = 's1' AND entity_kind = 'artist'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                Ok((cursor, completed, aliases))
+            })
+            .unwrap();
+        assert_eq!(cursor, Some(format!("{:032x}", 1_023)));
+        assert!(completed.is_none());
+        assert_eq!(aliases, 1_024);
+
+        let second = ensure_transition_with_probe_candidates(&store, &client, "s1", Vec::new())
+            .await
+            .unwrap();
+        assert_eq!(second.state, "no_legacy_ids");
+        let (completed, aliases): (Option<i64>, i64) = store
+            .with_read_conn(|conn| {
+                Ok((
+                    conn.query_row(
+                        "SELECT completed_at FROM library_data_migration WHERE id = ?1",
+                        params![artist_marker],
+                        |row| row.get(0),
+                    )?,
+                    conn.query_row(
+                        "SELECT COUNT(*) FROM entity_id_remap \
+                         WHERE server_id = 's1' AND entity_kind = 'artist'",
+                        [],
+                        |row| row.get(0),
+                    )?,
+                ))
+            })
+            .unwrap();
+        assert!(completed.is_some());
+        assert_eq!(aliases, 1_025);
+    }
+
+    #[test]
+    fn transition_state_cannot_downgrade_after_detection() {
+        let store = LibraryStore::open_in_memory();
+        record_state(
+            &store,
+            "s1",
+            "transition_detected",
+            Some("old"),
+            Some("new"),
+            None,
+            false,
+        )
+        .unwrap();
+        record_state(
+            &store,
+            "s1",
+            "legacy",
+            Some("old"),
+            Some("new"),
+            None,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(transition_status(&store, "s1").unwrap().state, "transition_detected");
+    }
+
+    #[test]
+    fn transient_probe_failure_replaces_pretransition_ready_states() {
+        for initial in ["legacy", "no_legacy_ids", "blocked"] {
+            let store = LibraryStore::open_in_memory();
+            record_state(&store, "s1", initial, Some("old"), Some("new"), None, false)
+                .unwrap();
+            record_state(
+                &store,
+                "s1",
+                "retryable",
+                Some("old"),
+                Some("new"),
+                Some("transient probe failure"),
+                false,
+            )
+            .unwrap();
+
+            let status = transition_status(&store, "s1").unwrap();
+            assert_eq!(status.state, "retryable", "initial state: {initial}");
+            assert!(assert_sync_ready(&store, "s1").is_err());
+        }
+    }
+
+    #[test]
+    fn stale_transition_detection_cannot_deactivate_ready_remaps() {
+        let store = LibraryStore::open_in_memory();
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = canonical_id(old);
+        let candidate = ProbeCandidate {
+            kind: EntityKind::Track,
+            old_id: old.to_string(),
+            new_id: new.clone(),
+            cursor_after: None,
+        };
+        record_transition_detected(&store, "s1", &candidate, std::slice::from_ref(&candidate))
+            .unwrap();
+        run_native_migration(&store, "s1").unwrap();
+        acknowledge_frontend(&store, "s1").unwrap();
+
+        record_transition_detected(&store, "s1", &candidate, std::slice::from_ref(&candidate))
+            .unwrap();
+
+        assert_eq!(transition_status(&store, "s1").unwrap().state, "ready");
+        assert_eq!(resolve_remapped_id(&store, "s1", "track", old).unwrap(), new);
+    }
+
+    #[test]
+    fn alias_baseline_sources_use_indexed_keyset_plans() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_read_conn(|conn| {
+                for source in ALIAS_BASELINE_SOURCES {
+                    let sql = format!(
+                        "EXPLAIN QUERY PLAN SELECT DISTINCT {column} FROM {table} \
+                         WHERE server_id = ?1 AND {column} > COALESCE(?2, '') \
+                           AND {column} IS NOT NULL AND {column} != '' {filter} \
+                         ORDER BY {column} LIMIT ?3",
+                        column = source.column,
+                        table = source.table,
+                        filter = source.filter,
+                    );
+                    let plan = conn
+                        .prepare(&sql)?
+                        .query_map(params!["s1", Option::<String>::None, 256], |row| {
+                            row.get::<_, String>(3)
+                        })?
+                        .collect::<rusqlite::Result<Vec<_>>>()?;
+                    assert!(
+                        plan.iter().any(|detail| detail.contains("SEARCH")),
+                        "{} baseline plan was not indexed: {plan:?}",
+                        source.name,
+                    );
+                    assert!(
+                        !plan.iter().any(|detail| detail.contains("USE TEMP B-TREE")),
+                        "{} baseline plan sorted through a temp B-tree: {plan:?}",
+                        source.name,
+                    );
+                }
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn transient_candidate_does_not_hide_decisive_later_candidate() {
+        let server = MockServer::start().await;
+        let transient_old = "00112233445566778899aabbccddeeff";
+        let transient_new = canonical_id(transient_old);
+        for id in [transient_old, transient_new.as_str()] {
+            Mock::given(method("GET"))
+                .and(path("/rest/getSong.view"))
+                .and(query_param("id", id))
+                .respond_with(ResponseTemplate::new(503))
+                .expect(1)
+                .mount(&server)
+                .await;
+        }
+        let decisive_old = "11112222333344445555666677778888";
+        let decisive_new = canonical_id(decisive_old);
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", decisive_old))
+            .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", decisive_new.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(song_response(&decisive_new)))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let store = LibraryStore::open_in_memory();
+        seed_legacy_track(&store, transient_old);
+        seed_legacy_track(&store, decisive_old);
+        let batch = ProbeCandidateBatch {
+            candidates: vec![
+                ProbeCandidate {
+                    kind: EntityKind::Track,
+                    old_id: transient_old.into(),
+                    new_id: transient_new,
+                    cursor_after: Some(ProbeCursor {
+                        source: 0,
+                        after_id: Some(transient_old.into()),
+                    }),
+                },
+                ProbeCandidate {
+                    kind: EntityKind::Track,
+                    old_id: decisive_old.into(),
+                    new_id: decisive_new.clone(),
+                    cursor_after: Some(ProbeCursor {
+                        source: 0,
+                        after_id: Some(decisive_old.into()),
+                    }),
+                },
+            ],
+            next_cursor: ProbeCursor {
+                source: 0,
+                after_id: Some(decisive_old.into()),
+            },
+            exhausted: false,
+        };
+
+        let status = ensure_transition_with_candidates(
+            &store,
+            &test_client(&server.uri()),
+            "s1",
+            batch,
+            EmptyCandidateOutcome::NoLegacyIds,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(status.state, "transition_detected");
+        assert_eq!(status.probe_old_id.as_deref(), Some(decisive_old));
+        assert_eq!(status.probe_new_id.as_deref(), Some(decisive_new.as_str()));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dead_candidate_advances_cursor_after_earlier_transient() {
+        let server = MockServer::start().await;
+        let transient_old = "00112233445566778899aabbccddeeff";
+        let transient_new = canonical_id(transient_old);
+        for id in [transient_old, transient_new.as_str()] {
+            Mock::given(method("GET"))
+                .and(path("/rest/getSong.view"))
+                .and(query_param("id", id))
+                .respond_with(ResponseTemplate::new(503))
+                .expect(1)
+                .mount(&server)
+                .await;
+        }
+        let dead_old = "11112222333344445555666677778888";
+        let dead_new = canonical_id(dead_old);
+        for id in [dead_old, dead_new.as_str()] {
+            Mock::given(method("GET"))
+                .and(path("/rest/getSong.view"))
+                .and(query_param("id", id))
+                .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
+                .expect(1)
+                .mount(&server)
+                .await;
+        }
+        let store = LibraryStore::open_in_memory();
+        seed_legacy_track(&store, transient_old);
+        seed_legacy_track(&store, dead_old);
+        let batch = ProbeCandidateBatch {
+            candidates: vec![
+                ProbeCandidate {
+                    kind: EntityKind::Track,
+                    old_id: transient_old.into(),
+                    new_id: transient_new.clone(),
+                    cursor_after: Some(ProbeCursor {
+                        source: 0,
+                        after_id: Some(transient_old.into()),
+                    }),
+                },
+                ProbeCandidate {
+                    kind: EntityKind::Track,
+                    old_id: dead_old.into(),
+                    new_id: dead_new,
+                    cursor_after: Some(ProbeCursor {
+                        source: 0,
+                        after_id: Some(dead_old.into()),
+                    }),
+                },
+            ],
+            next_cursor: ProbeCursor {
+                source: 0,
+                after_id: Some(dead_old.into()),
+            },
+            exhausted: false,
+        };
+
+        let status = ensure_transition_with_candidates(
+            &store,
+            &test_client(&server.uri()),
+            "s1",
+            batch,
+            EmptyCandidateOutcome::NoLegacyIds,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(status.state, "retryable");
+        assert_eq!(status.probe_old_id.as_deref(), Some(transient_old));
+        assert_eq!(status.probe_new_id.as_deref(), Some(transient_new.as_str()));
+        assert_eq!(
+            load_probe_cursor(&store, "s1").unwrap().after_id.as_deref(),
+            Some(dead_old)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn canonical_evidence_records_transition_without_running_migration() {
         let server = MockServer::start().await;
         let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
@@ -1446,37 +3035,308 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn no_legacy_ids_state_is_rechecked_after_sync_adds_a_legacy_candidate() {
+    async fn no_legacy_ids_write_guard_detects_a_later_canonical_transition() {
         let store = LibraryStore::open_in_memory();
         let unreachable = test_client("http://127.0.0.1:9");
         ensure_transition_with_probe_candidates(&store, &unreachable, "s1", Vec::new())
             .await
             .unwrap();
 
-        let server = MockServer::start().await;
         let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
         let new = canonical_id(old);
-        Mock::given(method("GET"))
-            .and(path("/rest/getSong.view"))
-            .and(query_param("id", old))
-            .respond_with(ResponseTemplate::new(200).set_body_json(song_response(old)))
-            .expect(1)
-            .mount(&server)
-            .await;
-        Mock::given(method("GET"))
-            .and(path("/rest/getSong.view"))
-            .and(query_param("id", new.as_str()))
-            .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
-            .expect(1)
-            .mount(&server)
-            .await;
-        seed_legacy_track(&store, old);
+        let repo = crate::repos::TrackRepository::new(&store);
+        let legacy = repo
+            .upsert_delta_batch_with_remap(&[incoming_track(old)], false)
+            .unwrap();
+        assert!(legacy.identity_transition.is_none());
+        assert_eq!(transition_status(&store, "s1").unwrap().state, "no_legacy_ids");
 
-        let status = ensure_transition(&store, &test_client(&server.uri()), "s1")
+        let stats = repo
+            .upsert_delta_batch_with_remap(&[incoming_track(&new)], false)
+            .unwrap();
+
+        assert!(stats.identity_transition.is_some());
+        assert_eq!(transition_status(&store, "s1").unwrap().state, "transition_detected");
+    }
+
+    #[test]
+    fn overflowing_base62_track_alias_detects_later_canonical_id() {
+        let store = LibraryStore::open_in_memory();
+        record_state(
+            &store,
+            "s1",
+            "no_legacy_ids",
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+        let old = "ZZZZZZZZZZZZZZZZZZZZZZ";
+        let new = canonical_id(old);
+        let repo = crate::repos::TrackRepository::new(&store);
+
+        assert!(repo
+            .upsert_delta_batch_with_remap(&[incoming_track(old)], false)
+            .unwrap()
+            .identity_transition
+            .is_none());
+        let alias: (String, i64) = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT old_id, active FROM entity_id_remap \
+                     WHERE server_id = 's1' AND entity_kind = 'track' AND new_id = ?1",
+                    params![new],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+            })
+            .unwrap();
+        assert_eq!(alias, (old.into(), 0));
+
+        let transition = repo
+            .upsert_delta_batch_with_remap(&[incoming_track(&new)], false)
+            .unwrap()
+            .identity_transition
+            .unwrap();
+        assert_eq!(transition.old_id, old);
+        assert_eq!(transition.new_id, new);
+        assert_eq!(transition_status(&store, "s1").unwrap().state, "transition_detected");
+    }
+
+    #[tokio::test]
+    async fn delta_revalidation_preserves_no_legacy_ids_for_empty_catalog() {
+        let store = LibraryStore::open_in_memory();
+        record_state(
+            &store,
+            "s1",
+            "no_legacy_ids",
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+        let status = revalidate_before_ingest(
+            &store,
+            &test_client("http://127.0.0.1:9"),
+            "s1",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(status.state, "no_legacy_ids");
+        assert!(assert_sync_ready(&store, "s1").is_ok());
+    }
+
+    #[tokio::test]
+    async fn current_no_legacy_state_ignores_routine_catalog_timestamp_updates() {
+        let store = LibraryStore::open_in_memory();
+        let canonical = canonical_id("e3b7fc2ae9447bbec37a13bf916e3cf6");
+        store
+            .with_conn("test.seed_canonical_only", |conn| {
+                for index in 0..1_000 {
+                    conn.execute(
+                        "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                         VALUES ('s1',?1,'Canonical','Album',?2,'{}')",
+                        params![format!("canonical-{index:04}"), index],
+                    )?;
+                }
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Canonical','Album',2000,'{}')",
+                    params![canonical],
+                )?;
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, detected_at) \
+                     VALUES ('s1',?1,'no_legacy_ids',1)",
+                    params![CANONICAL_ID_VERSION],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        let client = test_client("http://127.0.0.1:9");
+        revalidate_before_ingest(&store, &client, "s1")
+            .await
+            .unwrap();
+        store
+            .with_conn("test.bump_routine_synced_at", |conn| {
+                conn.execute(
+                    "UPDATE track SET synced_at = synced_at + 10000 WHERE server_id = 's1'",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        revalidate_before_ingest(&store, &client, "s1")
             .await
             .unwrap();
 
-        assert_eq!(status.state, "legacy");
+        assert!(no_legacy_state_is_current(
+            &transition_status(&store, "s1").unwrap()
+        ));
+    }
+
+    #[tokio::test]
+    async fn large_canonical_only_catalog_converges_by_bounded_cursor_pages() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn("test.seed_large_canonical_only", |conn| {
+                for index in 0..1_025 {
+                    conn.execute(
+                        "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                         VALUES ('s1',?1,'Canonical','Album',1,'{}')",
+                        params![format!("canonical-{index:04}")],
+                    )?;
+                }
+                Ok(())
+            })
+            .unwrap();
+        let client = test_client("http://127.0.0.1:9");
+
+        let first = ensure_transition_with_probe_candidates(&store, &client, "s1", Vec::new())
+            .await
+            .unwrap();
+        assert_eq!(first.state, "retryable");
+        assert_eq!(load_probe_cursor(&store, "s1").unwrap(), ProbeCursor::default());
+
+        let second = ensure_transition_with_probe_candidates(&store, &client, "s1", Vec::new())
+            .await
+            .unwrap();
+        assert_eq!(second.state, "retryable");
+        assert_eq!(
+            load_probe_cursor(&store, "s1").unwrap().after_id.as_deref(),
+            Some("canonical-0511")
+        );
+        let third = ensure_transition_with_probe_candidates(&store, &client, "s1", Vec::new())
+            .await
+            .unwrap();
+        assert_eq!(third.state, "retryable");
+        assert_eq!(
+            load_probe_cursor(&store, "s1").unwrap().after_id.as_deref(),
+            Some("canonical-1023")
+        );
+        let fourth = ensure_transition_with_probe_candidates(&store, &client, "s1", Vec::new())
+            .await
+            .unwrap();
+
+        assert_eq!(fourth.state, "no_legacy_ids");
+        assert_eq!(load_probe_cursor(&store, "s1").unwrap(), ProbeCursor::default());
+    }
+
+    #[test]
+    fn version_one_pending_frontend_is_upgraded_and_remains_ackable() {
+        let store = LibraryStore::open_in_memory();
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = canonical_id(old);
+        store
+            .with_conn("test.seed_v1_pending", |conn| {
+                conn.execute(
+                    "INSERT INTO track_offline(server_id,track_id,local_path,cached_at) \
+                     VALUES ('s1',?1,'/offline.flac',1)",
+                    params![old],
+                )?;
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, detected_at, native_migrated_at) \
+                     VALUES ('s1',1,'pending_frontend',1,1)",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        acknowledge_frontend(&store, "s1").unwrap();
+
+        let status = transition_status(&store, "s1").unwrap();
+        assert_eq!(status.canonical_version, CANONICAL_ID_VERSION);
+        assert_eq!(status.state, "ready");
+        assert_eq!(resolve_remapped_id(&store, "s1", "track", old).unwrap(), new);
+    }
+
+    #[test]
+    fn version_one_ready_runs_orphan_offline_reconciliation_once() {
+        let store = LibraryStore::open_in_memory();
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = canonical_id(old);
+        store
+            .with_conn("test.seed_v1_ready", |conn| {
+                conn.execute(
+                    "INSERT INTO track_offline(server_id,track_id,local_path,cached_at) \
+                     VALUES ('s1',?1,'/offline.flac',1)",
+                    params![old],
+                )?;
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, detected_at, native_migrated_at, frontend_acked_at) \
+                     VALUES ('s1',1,'ready',1,1,1)",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        assert_sync_ready(&store, "s1").unwrap();
+        assert_sync_ready(&store, "s1").unwrap();
+
+        let status = transition_status(&store, "s1").unwrap();
+        assert_eq!(status.canonical_version, CANONICAL_ID_VERSION);
+        assert_eq!(status.state, "ready");
+        let offline_id = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT track_id FROM track_offline WHERE server_id = 's1'",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(offline_id, new);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn version_one_legacy_and_retryable_states_are_reprobed() {
+        for stale_state in ["legacy", "retryable"] {
+            let server = MockServer::start().await;
+            let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+            let new = canonical_id(old);
+            Mock::given(method("GET"))
+                .and(path("/rest/getSong.view"))
+                .and(query_param("id", old))
+                .respond_with(ResponseTemplate::new(200).set_body_json(song_response(old)))
+                .expect(1)
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/rest/getSong.view"))
+                .and(query_param("id", new.as_str()))
+                .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
+                .expect(1)
+                .mount(&server)
+                .await;
+            let store = LibraryStore::open_in_memory();
+            seed_legacy_track(&store, old);
+            store
+                .with_conn("test.seed_v1_probe_state", |conn| {
+                    conn.execute(
+                        "INSERT INTO server_identity_transition \
+                         (server_id, canonical_version, state, probe_old_id, probe_new_id, detected_at) \
+                         VALUES ('s1',1,?1,?2,?3,1)",
+                        params![stale_state, old, new],
+                    )?;
+                    Ok(())
+                })
+                .unwrap();
+
+            let status = revalidate_before_ingest(&store, &test_client(&server.uri()), "s1")
+                .await
+                .unwrap();
+
+            assert_eq!(status.state, "legacy");
+            assert_eq!(status.canonical_version, CANONICAL_ID_VERSION);
+        }
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1565,7 +3425,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn targeted_not_found_probe_is_single_flight() {
+    async fn targeted_not_found_probe_serializes_but_rechecks_cached_legacy_evidence() {
         let server = MockServer::start().await;
         let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
         let new = canonical_id(old);
@@ -1573,7 +3433,7 @@ mod tests {
             .and(path("/rest/getSong.view"))
             .and(query_param("id", new.as_str()))
             .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
-            .expect(1)
+            .expect(2)
             .mount(&server)
             .await;
         let store = LibraryStore::open_in_memory();
@@ -1586,6 +3446,95 @@ mod tests {
 
         assert_eq!(first.unwrap(), TargetedNotFoundOutcome::ConfirmedMissing);
         assert_eq!(second.unwrap(), TargetedNotFoundOutcome::ConfirmedMissing);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn targeted_not_found_reprobes_canonical_after_cached_legacy_result() {
+        let server = MockServer::start().await;
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = canonical_id(old);
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", new.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(song_response(&new)))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let store = LibraryStore::open_in_memory();
+        record_state(
+            &store,
+            "s1",
+            "legacy",
+            Some(old),
+            Some(&new),
+            None,
+            false,
+        )
+        .unwrap();
+
+        let outcome = resolve_unexpected_not_found(
+            &store,
+            &test_client(&server.uri()),
+            "s1",
+            EntityKind::Track,
+            old,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, TargetedNotFoundOutcome::TransitionDetected);
+        assert_eq!(transition_status(&store, "s1").unwrap().state, "transition_detected");
+    }
+
+    #[test]
+    fn probe_candidates_page_past_non_transformable_prefix() {
+        let store = LibraryStore::open_in_memory();
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        store
+            .with_conn("test.seed_probe_candidates", |conn| {
+                for index in 0..64 {
+                    conn.execute(
+                        "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                         VALUES ('s1',?1,'Track','Album',1,'{}')",
+                        params![format!("a-{index:02}")],
+                    )?;
+                }
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Track','Album',1,'{}')",
+                    params![old],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        let candidates = probe_candidates(&store, "s1").unwrap();
+
+        assert_eq!(candidates.candidates.len(), 1);
+        assert_eq!(candidates.candidates[0].old_id, old);
+        assert_eq!(candidates.candidates[0].new_id, canonical_id(old));
+    }
+
+    #[test]
+    fn probe_candidates_include_orphan_offline_tracks() {
+        let store = LibraryStore::open_in_memory();
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        store
+            .with_conn("test.seed_offline_probe_candidate", |conn| {
+                conn.execute(
+                    "INSERT INTO track_offline(server_id,track_id,local_path,cached_at) \
+                     VALUES ('s1',?1,'/music/orphan.flac',1)",
+                    params![old],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        let candidates = probe_candidates(&store, "s1").unwrap();
+
+        assert_eq!(candidates.candidates.len(), 1);
+        assert_eq!(candidates.candidates[0].kind, EntityKind::Track);
+        assert_eq!(candidates.candidates[0].old_id, old);
     }
 
     #[test]
@@ -1784,6 +3733,152 @@ mod tests {
                 Ok(())
             })
             .unwrap();
+    }
+
+    #[test]
+    fn migration_rewrites_orphan_offline_track_and_records_alias_history() {
+        let store = LibraryStore::open_in_memory();
+        let old_track = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new_track = canonical_id(old_track);
+        store
+            .with_conn("test.seed_orphan_offline", |conn| {
+                conn.execute(
+                    "INSERT INTO track_offline(server_id,track_id,local_path,cached_at) \
+                     VALUES ('s1',?1,'/music/orphan.flac',1)",
+                    params![old_track],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        record_state(
+            &store,
+            "s1",
+            "transition_detected",
+            Some(old_track),
+            Some(&new_track),
+            None,
+            false,
+        )
+        .unwrap();
+
+        run_native_migration(&store, "s1").unwrap();
+
+        store
+            .with_read_conn(|conn| {
+                let path: String = conn.query_row(
+                    "SELECT local_path FROM track_offline \
+                     WHERE server_id = 's1' AND track_id = ?1",
+                    params![new_track],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(path, "/music/orphan.flac");
+                let history: String = conn.query_row(
+                    "SELECT new_id FROM track_id_history \
+                     WHERE server_id = 's1' AND old_id = ?1",
+                    params![old_track],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(history, new_track);
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(
+            resolve_remapped_id(&store, "s1", "track", old_track).unwrap(),
+            new_track
+        );
+    }
+
+    #[test]
+    fn migration_retargets_orphan_offline_when_canonical_track_already_exists() {
+        let store = LibraryStore::open_in_memory();
+        let old_track = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new_track = canonical_id(old_track);
+        store
+            .with_conn("test.seed_canonical_track_and_orphan_offline", |conn| {
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Canonical','Album',1,'{}')",
+                    params![new_track],
+                )?;
+                conn.execute(
+                    "INSERT INTO track_offline(server_id,track_id,local_path,cached_at) \
+                     VALUES ('s1',?1,'/music/orphan.flac',1)",
+                    params![old_track],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        record_state(
+            &store,
+            "s1",
+            "transition_detected",
+            Some(old_track),
+            Some(&new_track),
+            None,
+            false,
+        )
+        .unwrap();
+
+        run_native_migration(&store, "s1").unwrap();
+
+        store
+            .with_read_conn(|conn| {
+                let ids: Vec<String> = conn
+                    .prepare("SELECT id FROM track WHERE server_id = 's1'")?
+                    .query_map([], |row| row.get(0))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                assert_eq!(ids, vec![new_track.clone()]);
+                let offline_id: String = conn.query_row(
+                    "SELECT track_id FROM track_offline WHERE server_id = 's1'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(offline_id, new_track);
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn migration_blocks_when_old_and_canonical_track_rows_both_exist() {
+        let store = LibraryStore::open_in_memory();
+        let old_track = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new_track = canonical_id(old_track);
+        store
+            .with_conn("test.seed_track_pk_collision", |conn| {
+                for (id, title) in [(old_track, "Legacy"), (new_track.as_str(), "Canonical")] {
+                    conn.execute(
+                        "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                         VALUES ('s1',?1,?2,'Album',1,'{}')",
+                        params![id, title],
+                    )?;
+                }
+                Ok(())
+            })
+            .unwrap();
+        record_state(
+            &store,
+            "s1",
+            "transition_detected",
+            Some(old_track),
+            Some(&new_track),
+            None,
+            false,
+        )
+        .unwrap();
+
+        assert!(run_native_migration(&store, "s1").is_err());
+        assert_eq!(transition_status(&store, "s1").unwrap().state, "blocked");
+        let count = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT COUNT(*) FROM track WHERE server_id = 's1'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(count, 2);
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/navidrome_identity.rs
+++ b/src-tauri/crates/psysonic-library/src/navidrome_identity.rs
@@ -1,0 +1,1883 @@
+//! Navidrome's 2026 canonical-ID transition.
+//!
+//! The server migration is deterministic, but applying it merely because an ID
+//! looks old is unsafe. We first prove the active server namespace by probing one
+//! locally-known entity under both its old and computed canonical ID. Detection
+//! only records durable evidence. An explicit migration command later drains
+//! sync work and moves all library references in one deferred-FK transaction.
+
+use std::collections::HashMap;
+use std::io;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+use psysonic_integration::subsonic::{SubsonicClient, SubsonicError};
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
+use serde_json::Value;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::store::LibraryStore;
+
+pub const CANONICAL_ID_VERSION: i64 = 1;
+
+#[derive(Debug, Clone, serde::Serialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityTransitionDto {
+    pub server_id: String,
+    pub state: String,
+    pub canonical_version: i64,
+    pub probe_old_id: Option<String>,
+    pub probe_new_id: Option<String>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityProbeCandidateDto {
+    pub entity_kind: String,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EntityKind {
+    Track,
+    Album,
+}
+
+#[derive(Debug, Clone)]
+struct ProbeCandidate {
+    kind: EntityKind,
+    old_id: String,
+    new_id: String,
+}
+
+#[derive(Debug, Clone)]
+struct IdMap {
+    old_id: String,
+    new_id: String,
+}
+
+#[derive(Debug, Clone, Default)]
+struct LibraryIdMaps {
+    artists: Vec<IdMap>,
+    albums: Vec<IdMap>,
+    tracks: Vec<IdMap>,
+    folders: Vec<IdMap>,
+    global: Vec<IdMap>,
+}
+
+pub fn transition_status(
+    store: &LibraryStore,
+    server_id: &str,
+) -> Result<IdentityTransitionDto, String> {
+    let server_id = server_id.trim();
+    if server_id.is_empty() {
+        return Err("server id is required".to_string());
+    }
+    store.with_read_conn(|conn| {
+        conn.query_row(
+            "SELECT state, canonical_version, probe_old_id, probe_new_id, last_error \
+             FROM server_identity_transition WHERE server_id = ?1",
+            params![server_id],
+            |row| {
+                Ok(IdentityTransitionDto {
+                    server_id: server_id.to_string(),
+                    state: row.get(0)?,
+                    canonical_version: row.get(1)?,
+                    probe_old_id: row.get(2)?,
+                    probe_new_id: row.get(3)?,
+                    last_error: row.get(4)?,
+                })
+            },
+        )
+        .optional()
+        .map(|status| {
+            status.unwrap_or(IdentityTransitionDto {
+                server_id: server_id.to_string(),
+                state: "unseen".to_string(),
+                canonical_version: CANONICAL_ID_VERSION,
+                probe_old_id: None,
+                probe_new_id: None,
+                last_error: None,
+            })
+        })
+    })
+}
+
+pub fn assert_sync_ready(store: &LibraryStore, server_id: &str) -> Result<(), String> {
+    let status = transition_status(store, server_id)?;
+    match status.state.as_str() {
+        "awaiting_supplemental_probe" => Err(format!(
+            "server `{server_id}` canonical-ID readiness is waiting for persisted frontend candidates"
+        )),
+        "transition_detected" => Err(format!(
+            "server `{server_id}` canonical-ID migration is ready to run"
+        )),
+        "pending_frontend" => Err(format!(
+            "server `{server_id}` canonical-ID migration is waiting for frontend reconciliation"
+        )),
+        "retryable" | "blocked" => Err(format!(
+            "server `{server_id}` canonical-ID migration is blocked: {}",
+            status.last_error.as_deref().unwrap_or("unknown reason")
+        )),
+        _ => Ok(()),
+    }
+}
+
+pub fn resolve_remapped_id(
+    store: &LibraryStore,
+    server_id: &str,
+    entity_kind: &str,
+    id: &str,
+) -> Result<String, String> {
+    store.with_read_conn(|conn| {
+        conn.query_row(
+            "SELECT new_id FROM entity_id_remap \
+             WHERE server_id = ?1 AND entity_kind = ?2 AND old_id = ?3 AND active = 1",
+            params![server_id, entity_kind, id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map(|mapped| mapped.unwrap_or_else(|| id.to_string()))
+    })
+}
+
+pub(crate) fn resolve_remapped_id_with_conn(
+    conn: &Connection,
+    server_id: &str,
+    entity_kind: &str,
+    id: &str,
+) -> rusqlite::Result<String> {
+    conn.query_row(
+        "SELECT new_id FROM entity_id_remap \
+         WHERE server_id = ?1 AND entity_kind = ?2 AND old_id = ?3 AND active = 1",
+        params![server_id, entity_kind, id],
+        |row| row.get(0),
+    )
+    .optional()
+    .map(|mapped| mapped.unwrap_or_else(|| id.to_string()))
+}
+
+pub fn acknowledge_frontend(store: &LibraryStore, server_id: &str) -> Result<(), String> {
+    let now = now_unix_ms();
+    store
+        .with_conn("navidrome_identity.ack_frontend", |conn| {
+            let changed = conn.execute(
+                "UPDATE server_identity_transition \
+             SET state = 'ready', frontend_acked_at = ?2, last_error = NULL \
+             WHERE server_id = ?1 AND canonical_version = ?3 AND state = 'pending_frontend'",
+                params![server_id.trim(), now, CANONICAL_ID_VERSION],
+            )?;
+            if changed == 0 {
+                let state: Option<String> = conn
+                    .query_row(
+                        "SELECT state FROM server_identity_transition WHERE server_id = ?1",
+                        params![server_id.trim()],
+                        |row| row.get(0),
+                    )
+                    .optional()?;
+                if !matches!(state.as_deref(), Some("ready")) {
+                    return Err(rusqlite::Error::InvalidQuery);
+                }
+            }
+            Ok(())
+        })
+        .map_err(|error| {
+            if error.contains("Invalid query") {
+                format!(
+                    "server `{}` has no pending canonical-ID transition",
+                    server_id.trim()
+                )
+            } else {
+                error
+            }
+        })
+}
+
+/// Canonicalize only documented entity-ID fields in a Subsonic song payload.
+/// Metadata identifiers such as MusicBrainz IDs must remain untouched.
+pub fn canonicalize_song_payload(value: &mut Value) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                canonicalize_song_payload(value);
+            }
+        }
+        Value::Object(values) => {
+            for (key, value) in values {
+                if is_entity_id_field(key) {
+                    if let Value::String(id) = value {
+                        *id = canonical_id(id);
+                        continue;
+                    }
+                }
+                canonicalize_song_payload(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_entity_id_field(key: &str) -> bool {
+    matches!(
+        key,
+        "id" | "parent" | "albumId" | "artistId" | "coverArt" | "musicFolderId"
+    )
+}
+
+/// Re-check a Navidrome server at bind time. Native candidate absence waits for
+/// the supplemental frontend probe; legacy and previously blocked states are
+/// probed again so an upgrade or transient failure can converge on the next bind.
+pub async fn ensure_transition(
+    store: &LibraryStore,
+    subsonic: &SubsonicClient,
+    server_id: &str,
+) -> Result<IdentityTransitionDto, String> {
+    let candidates = probe_candidates(store, server_id)?;
+    ensure_transition_with_candidates(
+        store,
+        subsonic,
+        server_id,
+        candidates,
+        EmptyCandidateOutcome::AwaitSupplemental,
+    )
+    .await
+}
+
+pub async fn ensure_transition_with_probe_candidates(
+    store: &LibraryStore,
+    subsonic: &SubsonicClient,
+    server_id: &str,
+    supplied: Vec<IdentityProbeCandidateDto>,
+) -> Result<IdentityTransitionDto, String> {
+    let mut candidates = probe_candidates(store, server_id)?;
+    for candidate in supplied {
+        let kind = match candidate.entity_kind.as_str() {
+            "track" => EntityKind::Track,
+            "album" => EntityKind::Album,
+            _ => continue,
+        };
+        let old_id = candidate.id.trim().to_string();
+        let new_id = canonical_id(&old_id);
+        if old_id.is_empty()
+            || old_id == new_id
+            || candidates
+                .iter()
+                .any(|existing| existing.kind == kind && existing.old_id == old_id)
+        {
+            continue;
+        }
+        candidates.push(ProbeCandidate {
+            kind,
+            old_id,
+            new_id,
+        });
+        if candidates.len() >= 8 {
+            break;
+        }
+    }
+    ensure_transition_with_candidates(
+        store,
+        subsonic,
+        server_id,
+        candidates,
+        EmptyCandidateOutcome::NoLegacyIds,
+    )
+    .await
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EmptyCandidateOutcome {
+    AwaitSupplemental,
+    NoLegacyIds,
+}
+
+async fn ensure_transition_with_candidates(
+    store: &LibraryStore,
+    subsonic: &SubsonicClient,
+    server_id: &str,
+    candidates: Vec<ProbeCandidate>,
+    empty_candidate_outcome: EmptyCandidateOutcome,
+) -> Result<IdentityTransitionDto, String> {
+    let existing = transition_status(store, server_id)?;
+    if matches!(
+        existing.state.as_str(),
+        "transition_detected" | "pending_frontend" | "ready"
+    ) {
+        return Ok(existing);
+    }
+
+    if candidates.is_empty() {
+        let state = match empty_candidate_outcome {
+            EmptyCandidateOutcome::AwaitSupplemental => "awaiting_supplemental_probe",
+            EmptyCandidateOutcome::NoLegacyIds => "no_legacy_ids",
+        };
+        record_state(store, server_id, state, None, None, None, false)?;
+        return transition_status(store, server_id);
+    }
+
+    for candidate in &candidates {
+        let (old, new) = tokio::join!(
+            probe_entity(subsonic, candidate.kind, &candidate.old_id),
+            probe_entity(subsonic, candidate.kind, &candidate.new_id),
+        );
+        match (&old, &new) {
+            (Ok(()), Err(SubsonicError::NotFound)) => {
+                record_state(
+                    store,
+                    server_id,
+                    "legacy",
+                    Some(&candidate.old_id),
+                    Some(&candidate.new_id),
+                    None,
+                    false,
+                )?;
+                return transition_status(store, server_id);
+            }
+            (Err(SubsonicError::NotFound), Ok(())) => {
+                record_transition_detected(
+                    store,
+                    server_id,
+                    candidate,
+                    &candidates,
+                )?;
+                return transition_status(store, server_id);
+            }
+            (Err(SubsonicError::NotFound), Err(SubsonicError::NotFound)) => {}
+            (Ok(()), Ok(())) => {
+                let error = "legacy and canonical forms both resolved; refusing ambiguous identity evidence";
+                record_state(
+                    store,
+                    server_id,
+                    "blocked",
+                    Some(&candidate.old_id),
+                    Some(&candidate.new_id),
+                    Some(error),
+                    false,
+                )?;
+                return transition_status(store, server_id);
+            }
+            _ => {
+                let error = format!(
+                    "canonical-ID probe failed (legacy: {}; canonical: {})",
+                    probe_result_label(&old),
+                    probe_result_label(&new)
+                );
+                record_state(
+                    store,
+                    server_id,
+                    "retryable",
+                    Some(&candidate.old_id),
+                    Some(&candidate.new_id),
+                    Some(&error),
+                    false,
+                )?;
+                return transition_status(store, server_id);
+            }
+        }
+    }
+    let error = "no live probe candidate established the active Navidrome ID namespace";
+    record_state(
+        store,
+        server_id,
+        "retryable",
+        None,
+        None,
+        Some(error),
+        false,
+    )?;
+    transition_status(store, server_id)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TargetedNotFoundOutcome {
+    ConfirmedMissing,
+    TransitionDetected,
+}
+
+/// A locally live legacy-shaped entity unexpectedly disappeared under its old
+/// ID. The caller already observed that NotFound, so issue exactly one bounded
+/// request for the canonical form before allowing a tombstone.
+pub(crate) async fn resolve_unexpected_not_found(
+    store: &LibraryStore,
+    subsonic: &SubsonicClient,
+    server_id: &str,
+    kind: EntityKind,
+    old_id: &str,
+) -> Result<TargetedNotFoundOutcome, String> {
+    const TARGETED_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+    let new_id = canonical_id(old_id);
+    if new_id == old_id {
+        return Ok(TargetedNotFoundOutcome::ConfirmedMissing);
+    }
+    let lock = targeted_probe_lock(server_id, kind, old_id);
+    let _guard = lock.lock().await;
+    let existing = transition_status(store, server_id)?;
+    match existing.state.as_str() {
+        "transition_detected" | "pending_frontend" => {
+            return Ok(TargetedNotFoundOutcome::TransitionDetected);
+        }
+        "awaiting_supplemental_probe" | "retryable" | "blocked" => {
+            return Err(format!(
+                "canonical-ID state `{}` prevents destructive reconciliation",
+                existing.state
+            ));
+        }
+        "legacy"
+            if existing.probe_old_id.as_deref() == Some(old_id)
+                && existing.probe_new_id.as_deref() == Some(new_id.as_str()) =>
+        {
+            return Ok(TargetedNotFoundOutcome::ConfirmedMissing);
+        }
+        _ => {}
+    }
+
+    let result = tokio::time::timeout(
+        TARGETED_PROBE_TIMEOUT,
+        probe_entity(subsonic, kind, &new_id),
+    )
+    .await;
+    match result {
+        Ok(Ok(())) => {
+            let candidate = ProbeCandidate {
+                kind,
+                old_id: old_id.to_string(),
+                new_id: new_id.clone(),
+            };
+            record_transition_detected(
+                store,
+                server_id,
+                &candidate,
+                std::slice::from_ref(&candidate),
+            )?;
+            Ok(TargetedNotFoundOutcome::TransitionDetected)
+        }
+        Ok(Err(SubsonicError::NotFound)) => {
+            record_state(
+                store,
+                server_id,
+                "legacy",
+                Some(old_id),
+                Some(&new_id),
+                None,
+                false,
+            )?;
+            Ok(TargetedNotFoundOutcome::ConfirmedMissing)
+        }
+        Ok(Err(error)) => {
+            let message = format!("targeted canonical-ID probe failed: {error}");
+            record_state(
+                store,
+                server_id,
+                "retryable",
+                Some(old_id),
+                Some(&new_id),
+                Some(&message),
+                false,
+            )?;
+            Err(message)
+        }
+        Err(_) => {
+            let message = "targeted canonical-ID probe timed out";
+            record_state(
+                store,
+                server_id,
+                "retryable",
+                Some(old_id),
+                Some(&new_id),
+                Some(message),
+                false,
+            )?;
+            Err(message.to_string())
+        }
+    }
+}
+
+fn targeted_probe_lock(server_id: &str, kind: EntityKind, old_id: &str) -> Arc<AsyncMutex<()>> {
+    static LOCKS: OnceLock<Mutex<HashMap<String, Weak<AsyncMutex<()>>>>> = OnceLock::new();
+    let key = format!("{server_id}:{kind:?}:{old_id}");
+    let mut locks = LOCKS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
+        return lock;
+    }
+    let lock = Arc::new(AsyncMutex::new(()));
+    locks.insert(key, Arc::downgrade(&lock));
+    lock
+}
+
+async fn probe_entity(
+    subsonic: &SubsonicClient,
+    kind: EntityKind,
+    id: &str,
+) -> Result<(), SubsonicError> {
+    match kind {
+        EntityKind::Track => subsonic.get_song(id).await.map(|_| ()),
+        EntityKind::Album => subsonic.get_album(id).await.map(|_| ()),
+    }
+}
+
+fn probe_result_label(result: &Result<(), SubsonicError>) -> String {
+    match result {
+        Ok(()) => "ok".to_string(),
+        Err(error) => error.to_string(),
+    }
+}
+
+fn probe_candidates(store: &LibraryStore, server_id: &str) -> Result<Vec<ProbeCandidate>, String> {
+    const MAX_CANDIDATES: usize = 8;
+    store.with_read_conn(|conn| {
+        let mut candidates = Vec::new();
+        for (kind, table) in [(EntityKind::Track, "track"), (EntityKind::Album, "album")] {
+            let live_filter = if table == "track" {
+                " AND deleted = 0"
+            } else {
+                ""
+            };
+            let mut statement = conn.prepare(&format!(
+                "SELECT id FROM {table} WHERE server_id = ?1{live_filter} ORDER BY id LIMIT 64"
+            ))?;
+            let mut rows = statement.query(params![server_id])?;
+            while let Some(row) = rows.next()? {
+                let old_id = row.get::<_, String>(0)?;
+                let new_id = canonical_id(&old_id);
+                if new_id != old_id {
+                    candidates.push(ProbeCandidate {
+                        kind,
+                        old_id,
+                        new_id,
+                    });
+                    if candidates.len() >= MAX_CANDIDATES {
+                        return Ok(candidates);
+                    }
+                }
+            }
+        }
+        Ok(candidates)
+    })
+}
+
+pub fn run_native_migration(store: &LibraryStore, server_id: &str) -> Result<(), String> {
+    let status = transition_status(store, server_id)?;
+    match status.state.as_str() {
+        "pending_frontend" | "ready" => return Ok(()),
+        "transition_detected" => {}
+        other => {
+            return Err(format!(
+                "server `{server_id}` canonical-ID migration cannot run from state `{other}`"
+            ));
+        }
+    }
+    let result = store.with_conn_mut("navidrome_identity.migrate", |conn| {
+        let maps = collect_library_maps(conn, server_id)?;
+        let now = now_unix_ms();
+        let tx = conn.transaction()?;
+        tx.execute_batch(
+            "PRAGMA defer_foreign_keys = ON;
+             DROP TABLE IF EXISTS temp.canonical_artist_map;
+             DROP TABLE IF EXISTS temp.canonical_album_map;
+             DROP TABLE IF EXISTS temp.canonical_track_map;
+             DROP TABLE IF EXISTS temp.canonical_folder_map;
+             DROP TABLE IF EXISTS temp.canonical_global_map;
+             CREATE TEMP TABLE canonical_artist_map(old_id TEXT PRIMARY KEY, new_id TEXT NOT NULL);
+             CREATE TEMP TABLE canonical_album_map(old_id TEXT PRIMARY KEY, new_id TEXT NOT NULL);
+             CREATE TEMP TABLE canonical_track_map(old_id TEXT PRIMARY KEY, new_id TEXT NOT NULL);
+             CREATE TEMP TABLE canonical_folder_map(old_id TEXT PRIMARY KEY, new_id TEXT NOT NULL);
+             CREATE TEMP TABLE canonical_global_map(old_id TEXT PRIMARY KEY, new_id TEXT NOT NULL);",
+        )?;
+        insert_temp_map(&tx, "canonical_artist_map", &maps.artists)?;
+        insert_temp_map(&tx, "canonical_album_map", &maps.albums)?;
+        insert_temp_map(&tx, "canonical_track_map", &maps.tracks)?;
+        insert_temp_map(&tx, "canonical_folder_map", &maps.folders)?;
+        insert_temp_map(&tx, "canonical_global_map", &maps.global)?;
+        reject_collisions(&tx, server_id)?;
+
+        tx.execute_batch(&format!(
+            "UPDATE artist SET id = (SELECT new_id FROM canonical_artist_map WHERE old_id = artist.id)
+               WHERE server_id = {sid} AND id IN (SELECT old_id FROM canonical_artist_map);
+             UPDATE artist_artwork_lookup SET artist_id = (SELECT new_id FROM canonical_artist_map WHERE old_id = artist_artwork_lookup.artist_id)
+               WHERE server_id = {sid} AND artist_id IN (SELECT old_id FROM canonical_artist_map);
+             UPDATE album SET
+               id = COALESCE((SELECT new_id FROM canonical_album_map WHERE old_id = album.id), id),
+               artist_id = COALESCE((SELECT new_id FROM canonical_artist_map WHERE old_id = album.artist_id), artist_id),
+               cover_art_id = COALESCE((SELECT new_id FROM canonical_global_map WHERE old_id = album.cover_art_id), cover_art_id)
+               WHERE server_id = {sid};
+             UPDATE track SET
+               id = COALESCE((SELECT new_id FROM canonical_track_map WHERE old_id = track.id), id),
+               artist_id = COALESCE((SELECT new_id FROM canonical_artist_map WHERE old_id = track.artist_id), artist_id),
+               album_id = COALESCE((SELECT new_id FROM canonical_album_map WHERE old_id = track.album_id), album_id),
+               library_id = COALESCE((SELECT new_id FROM canonical_folder_map WHERE old_id = track.library_id), library_id),
+               cover_art_id = COALESCE((SELECT new_id FROM canonical_global_map WHERE old_id = track.cover_art_id), cover_art_id)
+               WHERE server_id = {sid};
+             UPDATE track_extension SET track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = track_extension.track_id)
+               WHERE server_id = {sid} AND track_id IN (SELECT old_id FROM canonical_track_map);
+             UPDATE track_offline SET track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = track_offline.track_id)
+               WHERE server_id = {sid} AND track_id IN (SELECT old_id FROM canonical_track_map);
+             UPDATE track_fact SET track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = track_fact.track_id)
+               WHERE server_id = {sid} AND track_id IN (SELECT old_id FROM canonical_track_map);
+             UPDATE track_artifact SET track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = track_artifact.track_id)
+               WHERE server_id = {sid} AND track_id IN (SELECT old_id FROM canonical_track_map);
+             UPDATE track_canonical_link SET track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = track_canonical_link.track_id)
+               WHERE server_id = {sid} AND track_id IN (SELECT old_id FROM canonical_track_map);
+             UPDATE canonical_enrichment_link SET owner_track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = canonical_enrichment_link.owner_track_id)
+               WHERE owner_server_id = {sid} AND owner_track_id IN (SELECT old_id FROM canonical_track_map);
+             UPDATE play_session SET track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = play_session.track_id)
+               WHERE server_id = {sid} AND track_id IN (SELECT old_id FROM canonical_track_map);
+             UPDATE track_genre SET
+                track_id = COALESCE((SELECT new_id FROM canonical_track_map WHERE old_id = track_genre.track_id), track_id),
+                album_id = COALESCE((SELECT new_id FROM canonical_album_map WHERE old_id = track_genre.album_id), album_id),
+                library_id = COALESCE((SELECT new_id FROM canonical_folder_map WHERE old_id = track_genre.library_id), library_id)
+                WHERE server_id = {sid};
+             UPDATE entity_user_rating SET entity_id = CASE entity_kind
+               WHEN 'artist' THEN COALESCE((SELECT new_id FROM canonical_artist_map WHERE old_id = entity_user_rating.entity_id), entity_id)
+               WHEN 'album' THEN COALESCE((SELECT new_id FROM canonical_album_map WHERE old_id = entity_user_rating.entity_id), entity_id)
+               WHEN 'track' THEN COALESCE((SELECT new_id FROM canonical_track_map WHERE old_id = entity_user_rating.entity_id), entity_id)
+               ELSE entity_id END
+               WHERE server_id = {sid};
+             UPDATE track_id_history SET new_id = COALESCE((SELECT new_id FROM canonical_track_map WHERE old_id = track_id_history.new_id), new_id)
+               WHERE server_id = {sid};
+             UPDATE sync_state SET library_scope = (SELECT new_id FROM canonical_folder_map WHERE old_id = sync_state.library_scope)
+               WHERE server_id = {sid} AND library_scope IN (SELECT old_id FROM canonical_folder_map);
+             DELETE FROM library_tag_state WHERE server_id = {sid};
+             DELETE FROM library_tag_cursor WHERE server_id = {sid};
+             DELETE FROM cluster.track_cluster_key WHERE server_id = {sid};
+             DELETE FROM identity_invalidation WHERE server_id = {sid};
+             INSERT INTO identity_invalidation(server_id, kind, entity_id) VALUES ({sid}, 'server', '');
+             UPDATE sync_state SET initial_sync_cursor_json = '{{}}' WHERE server_id = {sid};",
+            sid = sql_string(server_id),
+        ))?;
+
+        rewrite_raw_json(&tx, server_id, &maps.global)?;
+        crate::browse_projection::rebuild_server(&tx, server_id)?;
+        record_remaps(&tx, server_id, "artist", &maps.artists, now)?;
+        record_remaps(&tx, server_id, "album", &maps.albums, now)?;
+        record_remaps(&tx, server_id, "track", &maps.tracks, now)?;
+        record_remaps(&tx, server_id, "folder", &maps.folders, now)?;
+        tx.execute(
+            "UPDATE entity_id_remap SET active = 1 WHERE server_id = ?1",
+            params![server_id],
+        )?;
+        for mapping in &maps.tracks {
+            tx.execute(
+                "INSERT INTO track_id_history \
+                 (server_id, old_id, new_id, content_hash, server_path, remapped_at) \
+                 VALUES (?1, ?2, ?3, NULL, NULL, ?4) \
+                 ON CONFLICT(server_id, old_id) DO UPDATE SET \
+                   new_id = excluded.new_id, remapped_at = excluded.remapped_at",
+                params![server_id, mapping.old_id, mapping.new_id, now],
+            )?;
+        }
+        tx.execute(
+            "INSERT INTO server_identity_transition \
+             (server_id, canonical_version, state, detected_at, native_migrated_at) \
+             VALUES (?1, ?2, 'pending_frontend', ?3, ?3) \
+             ON CONFLICT(server_id) DO UPDATE SET \
+               canonical_version = excluded.canonical_version, state = excluded.state, \
+               detected_at = excluded.detected_at, native_migrated_at = excluded.native_migrated_at, \
+               frontend_acked_at = NULL, last_error = NULL",
+            params![server_id, CANONICAL_ID_VERSION, now],
+        )?;
+
+        let fk_error: Option<String> = tx
+            .query_row("PRAGMA foreign_key_check", [], |row| {
+                let table: String = row.get(0)?;
+                let rowid: i64 = row.get(1)?;
+                Ok(format!("{table} row {rowid}"))
+            })
+            .optional()?;
+        if let Some(error) = fk_error {
+            return Err(rusqlite::Error::ToSqlConversionFailure(Box::new(
+                io::Error::other(format!("foreign key check failed: {error}")),
+            )));
+        }
+        tx.commit()
+    });
+    if let Err(error) = result {
+        record_state(
+            store,
+            server_id,
+            "blocked",
+            status.probe_old_id.as_deref(),
+            status.probe_new_id.as_deref(),
+            Some(&error),
+            false,
+        )?;
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn collect_library_maps(conn: &Connection, server_id: &str) -> rusqlite::Result<LibraryIdMaps> {
+    let artists = collect_entity_map(conn, "artist", server_id)?;
+    let albums = collect_entity_map(conn, "album", server_id)?;
+    let tracks = collect_entity_map(conn, "track", server_id)?;
+    let mut folder_values = collect_column_values(conn, "track", "library_id", server_id)?;
+    folder_values.extend(collect_column_values(
+        conn,
+        "sync_state",
+        "library_scope",
+        server_id,
+    )?);
+    folder_values.sort();
+    folder_values.dedup();
+    let folders = folder_values
+        .into_iter()
+        .filter_map(|old_id| {
+            let new_id = canonical_id(&old_id);
+            (new_id != old_id).then_some(IdMap { old_id, new_id })
+        })
+        .collect::<Vec<_>>();
+    let mut global_by_old = HashMap::<String, String>::new();
+    for mapping in artists
+        .iter()
+        .chain(albums.iter())
+        .chain(tracks.iter())
+        .chain(folders.iter())
+    {
+        global_by_old.insert(mapping.old_id.clone(), mapping.new_id.clone());
+    }
+    for (table, column) in [
+        ("album", "artist_id"),
+        ("album", "cover_art_id"),
+        ("track", "artist_id"),
+        ("track", "album_id"),
+        ("track", "cover_art_id"),
+    ] {
+        for value in collect_column_values(conn, table, column, server_id)? {
+            let canonical = canonical_id(&value);
+            if canonical != value {
+                global_by_old.insert(value, canonical);
+            }
+        }
+    }
+    let mut global = global_by_old
+        .into_iter()
+        .map(|(old_id, new_id)| IdMap { old_id, new_id })
+        .collect::<Vec<_>>();
+    global.sort_by(|a, b| a.old_id.cmp(&b.old_id));
+    Ok(LibraryIdMaps {
+        artists,
+        albums,
+        tracks,
+        folders,
+        global,
+    })
+}
+
+fn collect_entity_map(
+    conn: &Connection,
+    table: &str,
+    server_id: &str,
+) -> rusqlite::Result<Vec<IdMap>> {
+    let values = collect_column_values(conn, table, "id", server_id)?;
+    Ok(values
+        .into_iter()
+        .filter_map(|old_id| {
+            let new_id = canonical_id(&old_id);
+            (new_id != old_id).then_some(IdMap { old_id, new_id })
+        })
+        .collect())
+}
+
+fn collect_column_values(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    server_id: &str,
+) -> rusqlite::Result<Vec<String>> {
+    let mut statement = conn.prepare(&format!(
+        "SELECT DISTINCT {column} FROM {table} \
+         WHERE server_id = ?1 AND {column} IS NOT NULL AND {column} <> ''"
+    ))?;
+    let values = statement
+        .query_map(params![server_id], |row| row.get(0))?
+        .collect();
+    values
+}
+
+fn insert_temp_map(tx: &Transaction<'_>, table: &str, mappings: &[IdMap]) -> rusqlite::Result<()> {
+    let mut statement = tx.prepare(&format!(
+        "INSERT INTO {table}(old_id, new_id) VALUES (?1, ?2)"
+    ))?;
+    for mapping in mappings {
+        statement.execute(params![mapping.old_id, mapping.new_id])?;
+    }
+    Ok(())
+}
+
+fn reject_collisions(tx: &Transaction<'_>, server_id: &str) -> rusqlite::Result<()> {
+    for (table, map) in [
+        ("artist", "canonical_artist_map"),
+        ("album", "canonical_album_map"),
+        ("track", "canonical_track_map"),
+    ] {
+        let collision: Option<String> = tx
+            .query_row(
+                &format!(
+                    "SELECT entity.id FROM {table} entity JOIN {map} mapping ON mapping.new_id = entity.id \
+                     WHERE entity.server_id = ?1 LIMIT 1"
+                ),
+                params![server_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if let Some(id) = collision {
+            return Err(rusqlite::Error::ToSqlConversionFailure(Box::new(
+                io::Error::other(format!("canonical {table} id collision at `{id}`")),
+            )));
+        }
+        let duplicate: Option<String> = tx
+            .query_row(
+                &format!("SELECT new_id FROM {map} GROUP BY new_id HAVING COUNT(*) > 1 LIMIT 1"),
+                [],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if let Some(id) = duplicate {
+            return Err(rusqlite::Error::ToSqlConversionFailure(Box::new(
+                io::Error::other(format!("multiple {table} ids map to `{id}`")),
+            )));
+        }
+    }
+    for (label, query) in [
+        (
+            "sync scope",
+            "SELECT 1 FROM sync_state old \
+             JOIN canonical_folder_map mapping ON mapping.old_id = old.library_scope \
+             JOIN sync_state destination \
+               ON destination.server_id = old.server_id \
+              AND destination.library_scope = mapping.new_id \
+             WHERE old.server_id = ?1 LIMIT 1",
+        ),
+        (
+            "artist artwork",
+            "SELECT 1 FROM artist_artwork_lookup old \
+             JOIN canonical_artist_map mapping ON mapping.old_id = old.artist_id \
+             JOIN artist_artwork_lookup destination \
+               ON destination.server_id = old.server_id \
+              AND destination.artist_id = mapping.new_id \
+              AND destination.surface_kind = old.surface_kind \
+             WHERE old.server_id = ?1 LIMIT 1",
+        ),
+        (
+            "offline track",
+            "SELECT 1 FROM track_offline old \
+             JOIN canonical_track_map mapping ON mapping.old_id = old.track_id \
+             JOIN track_offline destination \
+               ON destination.server_id = old.server_id \
+              AND destination.track_id = mapping.new_id \
+             WHERE old.server_id = ?1 LIMIT 1",
+        ),
+        (
+            "entity rating",
+            "SELECT 1 FROM entity_user_rating old \
+             JOIN canonical_global_map mapping ON mapping.old_id = old.entity_id \
+             JOIN entity_user_rating destination \
+               ON destination.server_id = old.server_id \
+              AND destination.entity_kind = old.entity_kind \
+              AND destination.entity_id = mapping.new_id \
+             WHERE old.server_id = ?1 LIMIT 1",
+        ),
+        (
+            "canonical enrichment owner",
+            "SELECT 1 FROM canonical_enrichment_link old \
+             JOIN canonical_track_map mapping ON mapping.old_id = old.owner_track_id \
+             JOIN canonical_enrichment_link destination \
+               ON destination.canonical_id = old.canonical_id \
+              AND destination.enrichment_kind = old.enrichment_kind \
+              AND destination.owner_server_id = old.owner_server_id \
+              AND destination.owner_track_id = mapping.new_id \
+             WHERE old.owner_server_id = ?1 LIMIT 1",
+        ),
+    ] {
+        let collision = tx
+            .query_row(query, params![server_id], |row| row.get::<_, i64>(0))
+            .optional()?
+            .is_some();
+        if collision {
+            return Err(rusqlite::Error::ToSqlConversionFailure(Box::new(
+                io::Error::other(format!("canonical-ID migration found a {label} collision")),
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn record_remaps(
+    tx: &Transaction<'_>,
+    server_id: &str,
+    kind: &str,
+    mappings: &[IdMap],
+    now: i64,
+) -> rusqlite::Result<()> {
+    let mut statement = tx.prepare(
+        "INSERT INTO entity_id_remap(server_id, entity_kind, old_id, new_id, remapped_at, active) \
+         VALUES (?1, ?2, ?3, ?4, ?5, 1) \
+         ON CONFLICT(server_id, entity_kind, old_id) DO UPDATE SET \
+            new_id = excluded.new_id, remapped_at = excluded.remapped_at, active = 1",
+    )?;
+    for mapping in mappings {
+        statement.execute(params![
+            server_id,
+            kind,
+            mapping.old_id,
+            mapping.new_id,
+            now
+        ])?;
+    }
+    Ok(())
+}
+
+fn rewrite_raw_json(
+    tx: &Transaction<'_>,
+    server_id: &str,
+    mappings: &[IdMap],
+) -> rusqlite::Result<()> {
+    let replacements = mappings
+        .iter()
+        .map(|mapping| (mapping.old_id.as_str(), mapping.new_id.as_str()))
+        .collect::<HashMap<_, _>>();
+    if replacements.is_empty() {
+        return Ok(());
+    }
+    const BATCH_SIZE: i64 = 256;
+    for table in ["artist", "album", "track"] {
+        let mut cursor = 0_i64;
+        let mut update = tx.prepare(&format!(
+            "UPDATE {table} SET raw_json = ?1 WHERE rowid = ?2"
+        ))?;
+        loop {
+            let rows = {
+                let mut statement = tx.prepare(&format!(
+                    "SELECT rowid, raw_json FROM {table} \
+                     WHERE server_id = ?1 AND raw_json IS NOT NULL AND rowid > ?2 \
+                     ORDER BY rowid LIMIT ?3"
+                ))?;
+                let rows = statement
+                    .query_map(params![server_id, cursor, BATCH_SIZE], |row| {
+                        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+                    })?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                rows
+            };
+            if rows.is_empty() {
+                break;
+            }
+            for (rowid, raw) in rows {
+                cursor = rowid;
+                let Ok(mut value) = serde_json::from_str::<Value>(&raw) else {
+                    continue;
+                };
+                if rewrite_entity_id_fields(&mut value, &replacements) {
+                    update.execute(params![value.to_string(), rowid])?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn rewrite_entity_id_fields(value: &mut Value, replacements: &HashMap<&str, &str>) -> bool {
+    match value {
+        Value::Array(values) => {
+            let mut changed = false;
+            for value in values {
+                changed |= rewrite_entity_id_fields(value, replacements);
+            }
+            changed
+        }
+        Value::Object(values) => {
+            let mut changed = false;
+            for (key, value) in values {
+                if is_entity_id_field(key) {
+                    if let Value::String(text) = value {
+                        if let Some(replacement) = replacements.get(text.as_str()) {
+                            *text = (*replacement).to_string();
+                            changed = true;
+                            continue;
+                        }
+                    }
+                }
+                changed |= rewrite_entity_id_fields(value, replacements);
+            }
+            changed
+        }
+        _ => false,
+    }
+}
+
+fn record_transition_detected(
+    store: &LibraryStore,
+    server_id: &str,
+    evidence: &ProbeCandidate,
+    mappings: &[ProbeCandidate],
+) -> Result<(), String> {
+    let now = now_unix_ms();
+    store.with_conn("navidrome_identity.record_transition", |conn| {
+        write_state(
+            conn,
+            server_id,
+            "transition_detected",
+            Some(&evidence.old_id),
+            Some(&evidence.new_id),
+            None,
+            false,
+            now,
+        )?;
+        let mut statement = conn.prepare(
+            "INSERT INTO entity_id_remap(server_id, entity_kind, old_id, new_id, remapped_at, active) \
+             VALUES (?1, ?2, ?3, ?4, ?5, 0) \
+             ON CONFLICT(server_id, entity_kind, old_id) DO UPDATE SET \
+               new_id = excluded.new_id, remapped_at = excluded.remapped_at, active = 0",
+        )?;
+        for mapping in mappings {
+            statement.execute(params![
+                server_id,
+                entity_kind_label(mapping.kind),
+                mapping.old_id,
+                mapping.new_id,
+                now
+            ])?;
+        }
+        Ok(())
+    })
+}
+
+fn entity_kind_label(kind: EntityKind) -> &'static str {
+    match kind {
+        EntityKind::Track => "track",
+        EntityKind::Album => "album",
+    }
+}
+
+fn record_state(
+    store: &LibraryStore,
+    server_id: &str,
+    state: &str,
+    probe_old_id: Option<&str>,
+    probe_new_id: Option<&str>,
+    last_error: Option<&str>,
+    migrated: bool,
+) -> Result<(), String> {
+    let now = now_unix_ms();
+    store.with_conn("navidrome_identity.record_state", |conn| {
+        write_state(
+            conn,
+            server_id,
+            state,
+            probe_old_id,
+            probe_new_id,
+            last_error,
+            migrated,
+            now,
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_state(
+    conn: &Connection,
+    server_id: &str,
+    state: &str,
+    probe_old_id: Option<&str>,
+    probe_new_id: Option<&str>,
+    last_error: Option<&str>,
+    migrated: bool,
+    now: i64,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO server_identity_transition \
+         (server_id, canonical_version, state, probe_old_id, probe_new_id, detected_at, native_migrated_at, last_error) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8) \
+         ON CONFLICT(server_id) DO UPDATE SET \
+           canonical_version = excluded.canonical_version, state = excluded.state, \
+           probe_old_id = excluded.probe_old_id, probe_new_id = excluded.probe_new_id, \
+           detected_at = excluded.detected_at, \
+           native_migrated_at = COALESCE(excluded.native_migrated_at, server_identity_transition.native_migrated_at), \
+           frontend_acked_at = CASE WHEN excluded.state = 'pending_frontend' THEN NULL ELSE server_identity_transition.frontend_acked_at END, \
+           last_error = excluded.last_error",
+        params![
+            server_id,
+            CANONICAL_ID_VERSION,
+            state,
+            probe_old_id,
+            probe_new_id,
+            now,
+            migrated.then_some(now),
+            last_error,
+        ],
+    )?;
+    Ok(())
+}
+
+fn sql_string(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn now_unix_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or(0)
+}
+
+/// Exact port of Navidrome's `canonicalID` migration helper.
+pub fn canonical_id(value: &str) -> String {
+    let bytes = match value.len() {
+        22 => match decode_base62_u128(value) {
+            Ok(_) => return value.to_string(),
+            Err(Base62Error::Overflow) => md5::compute(value.as_bytes()).0,
+            Err(Base62Error::Invalid) => return value.to_string(),
+        },
+        32 => match decode_hex_16(value) {
+            Some(bytes) => bytes,
+            None => return value.to_string(),
+        },
+        36 => {
+            if value.as_bytes().get(8) != Some(&b'-')
+                || value.as_bytes().get(13) != Some(&b'-')
+                || value.as_bytes().get(18) != Some(&b'-')
+                || value.as_bytes().get(23) != Some(&b'-')
+            {
+                return value.to_string();
+            }
+            let compact = value
+                .chars()
+                .filter(|character| *character != '-')
+                .collect::<String>();
+            match decode_hex_16(&compact) {
+                Some(bytes) => bytes,
+                None => return value.to_string(),
+            }
+        }
+        _ => return value.to_string(),
+    };
+    encode_base62(bytes)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Base62Error {
+    Invalid,
+    Overflow,
+}
+
+fn decode_base62_u128(value: &str) -> Result<u128, Base62Error> {
+    let mut out = 0u128;
+    for byte in value.bytes() {
+        let digit = match byte {
+            b'0'..=b'9' => (byte - b'0') as u128,
+            b'a'..=b'z' => (byte - b'a' + 10) as u128,
+            b'A'..=b'Z' => (byte - b'A' + 36) as u128,
+            _ => return Err(Base62Error::Invalid),
+        };
+        out = out
+            .checked_mul(62)
+            .and_then(|current| current.checked_add(digit))
+            .ok_or(Base62Error::Overflow)?;
+    }
+    Ok(out)
+}
+
+fn decode_hex_16(value: &str) -> Option<[u8; 16]> {
+    if value.len() != 32 {
+        return None;
+    }
+    let mut out = [0u8; 16];
+    for (index, slot) in out.iter_mut().enumerate() {
+        let high = hex_digit(value.as_bytes()[index * 2])?;
+        let low = hex_digit(value.as_bytes()[index * 2 + 1])?;
+        *slot = (high << 4) | low;
+    }
+    Some(out)
+}
+
+fn hex_digit(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn encode_base62(bytes: [u8; 16]) -> String {
+    const DIGITS: &[u8; 62] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    let mut value = u128::from_be_bytes(bytes);
+    let mut encoded = [b'0'; 22];
+    let mut index = encoded.len();
+    while value > 0 {
+        index -= 1;
+        encoded[index] = DIGITS[(value % 62) as usize];
+        value /= 62;
+    }
+    String::from_utf8(encoded.to_vec()).expect("base62 alphabet is UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dto::{ArtifactInputDto, FactInputDto, PlaySessionInputDto};
+    use crate::repos::{ArtifactRepository, FactRepository, PlaySessionRepository};
+    use psysonic_integration::subsonic::SubsonicCredentials;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_client(uri: &str) -> SubsonicClient {
+        SubsonicClient::with_static_credentials(
+            uri,
+            SubsonicCredentials::with_static("user", "token", "salt"),
+            reqwest::Client::new(),
+        )
+    }
+
+    fn seed_legacy_track(store: &LibraryStore, id: &str) {
+        store
+            .with_conn("test.seed_legacy_track", |conn| {
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Track','Album',1,'{}')",
+                    params![id],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    fn song_response(id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "subsonic-response": {
+                "status": "ok",
+                "song": { "id": id, "title": "Track", "album": "Album" }
+            }
+        })
+    }
+
+    fn not_found_response() -> serde_json::Value {
+        serde_json::json!({
+            "subsonic-response": {
+                "status": "failed",
+                "error": { "code": 70, "message": "Song not found" }
+            }
+        })
+    }
+
+    #[test]
+    fn matches_upstream_canonical_id_vectors() {
+        for (input, expected) in [
+            ("5cLJPkLA5DK2BADhoeotPk", "5cLJPkLA5DK2BADhoeotPk"),
+            ("zzzzzzzzzzzzzzzzzzzzzz", "3LyqmwQBm5IRqlVjNYASwb"),
+            ("e3b7fc2ae9447bbec37a13bf916e3cf6", "6VHl3uR4kss6sUPKA8Cwnk"),
+            (
+                "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+                "7rke2SAWaicSeSYzkhww6R",
+            ),
+        ] {
+            assert_eq!(canonical_id(input), expected);
+        }
+    }
+
+    #[test]
+    fn canonical_id_preserves_valid_and_unrecognized_values() {
+        assert_eq!(
+            canonical_id("0000000000000000000001"),
+            "0000000000000000000001"
+        );
+        assert_eq!(canonical_id("share-id"), "share-id");
+        assert_eq!(
+            canonical_id("not-a-uuid-----------------------"),
+            "not-a-uuid-----------------------"
+        );
+    }
+
+    #[test]
+    fn overflowing_nanoid_is_hashed_deterministically() {
+        let overflowing = "ZZZZZZZZZZZZZZZZZZZZZZ";
+        let canonical = canonical_id(overflowing);
+        assert_ne!(canonical, overflowing);
+        assert_eq!(canonical.len(), 22);
+        assert_eq!(canonical, canonical_id(overflowing));
+    }
+
+    #[test]
+    fn song_payload_rewrites_entity_ids_without_touching_metadata_ids() {
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let mut payload = serde_json::json!({
+            "id": old,
+            "albumId": old,
+            "artists": [{ "id": old, "musicBrainzId": old }],
+            "musicBrainzId": old,
+        });
+        canonicalize_song_payload(&mut payload);
+        assert_eq!(payload["id"], canonical_id(old));
+        assert_eq!(payload["albumId"], canonical_id(old));
+        assert_eq!(payload["artists"][0]["id"], canonical_id(old));
+        assert_eq!(payload["artists"][0]["musicBrainzId"], old);
+        assert_eq!(payload["musicBrainzId"], old);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn both_missing_candidates_remain_retryable_and_sync_blocked() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
+            .expect(2)
+            .mount(&server)
+            .await;
+        let store = LibraryStore::open_in_memory();
+        seed_legacy_track(&store, "e3b7fc2ae9447bbec37a13bf916e3cf6");
+
+        let status = ensure_transition(&store, &test_client(&server.uri()), "s1")
+            .await
+            .unwrap();
+
+        assert_eq!(status.state, "retryable");
+        assert!(assert_sync_ready(&store, "s1").is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn legacy_evidence_stops_after_first_decisive_candidate() {
+        let server = MockServer::start().await;
+        let old = "00112233445566778899aabbccddeeff";
+        let new = canonical_id(old);
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", old))
+            .respond_with(ResponseTemplate::new(200).set_body_json(song_response(old)))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", new.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let store = LibraryStore::open_in_memory();
+        seed_legacy_track(&store, old);
+        seed_legacy_track(&store, "11112222333344445555666677778888");
+
+        let status = ensure_transition(&store, &test_client(&server.uri()), "s1")
+            .await
+            .unwrap();
+
+        assert_eq!(status.state, "legacy");
+        assert_eq!(server.received_requests().await.unwrap().len(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn canonical_evidence_records_transition_without_running_migration() {
+        let server = MockServer::start().await;
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = canonical_id(old);
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", old))
+            .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", new.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(song_response(&new)))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let store = LibraryStore::open_in_memory();
+        seed_legacy_track(&store, old);
+
+        let status = ensure_transition(&store, &test_client(&server.uri()), "s1")
+            .await
+            .unwrap();
+
+        assert_eq!(status.state, "transition_detected");
+        let old_still_exists = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM track WHERE server_id = 's1' AND id = ?1)",
+                    params![old],
+                    |row| row.get::<_, bool>(0),
+                )
+            })
+            .unwrap();
+        assert!(old_still_exists);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn both_forms_resolving_is_blocked_as_ambiguous() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(song_response("track")))
+            .expect(2)
+            .mount(&server)
+            .await;
+        let store = LibraryStore::open_in_memory();
+        seed_legacy_track(&store, "e3b7fc2ae9447bbec37a13bf916e3cf6");
+
+        let status = ensure_transition(&store, &test_client(&server.uri()), "s1")
+            .await
+            .unwrap();
+
+        assert_eq!(status.state, "blocked");
+        assert!(assert_sync_ready(&store, "s1").is_err());
+    }
+
+    #[tokio::test]
+    async fn bind_without_native_candidates_waits_for_an_explicit_supplemental_probe() {
+        let store = LibraryStore::open_in_memory();
+        seed_legacy_track(&store, "already-canonical-or-custom");
+
+        let client = test_client("http://127.0.0.1:9");
+        let status = ensure_transition(&store, &client, "s1").await.unwrap();
+
+        assert_eq!(status.state, "awaiting_supplemental_probe");
+        assert!(assert_sync_ready(&store, "s1").is_err());
+
+        let status = ensure_transition_with_probe_candidates(&store, &client, "s1", Vec::new())
+            .await
+            .unwrap();
+        assert_eq!(status.state, "no_legacy_ids");
+        assert!(assert_sync_ready(&store, "s1").is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn no_legacy_ids_state_is_rechecked_after_sync_adds_a_legacy_candidate() {
+        let store = LibraryStore::open_in_memory();
+        let unreachable = test_client("http://127.0.0.1:9");
+        ensure_transition_with_probe_candidates(&store, &unreachable, "s1", Vec::new())
+            .await
+            .unwrap();
+
+        let server = MockServer::start().await;
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = canonical_id(old);
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", old))
+            .respond_with(ResponseTemplate::new(200).set_body_json(song_response(old)))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", new.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        seed_legacy_track(&store, old);
+
+        let status = ensure_transition(&store, &test_client(&server.uri()), "s1")
+            .await
+            .unwrap();
+
+        assert_eq!(status.state, "legacy");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn supplemental_frontend_only_candidate_can_detect_the_transition() {
+        let server = MockServer::start().await;
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let second_old = "00112233445566778899aabbccddeeff";
+        let new = canonical_id(old);
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", old))
+            .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", new.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(song_response(&new)))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let store = LibraryStore::open_in_memory();
+        let client = test_client(&server.uri());
+
+        let bind_status = ensure_transition(&store, &client, "s1").await.unwrap();
+        assert_eq!(bind_status.state, "awaiting_supplemental_probe");
+
+        let status = ensure_transition_with_probe_candidates(
+            &store,
+            &client,
+            "s1",
+            vec![
+                IdentityProbeCandidateDto {
+                    entity_kind: "track".to_string(),
+                    id: old.to_string(),
+                },
+                IdentityProbeCandidateDto {
+                    entity_kind: "track".to_string(),
+                    id: second_old.to_string(),
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(status.state, "transition_detected");
+        assert_eq!(status.probe_old_id.as_deref(), Some(old));
+        assert_eq!(status.probe_new_id.as_deref(), Some(new.as_str()));
+        assert!(assert_sync_ready(&store, "s1").is_err());
+        assert_eq!(resolve_remapped_id(&store, "s1", "track", old).unwrap(), old);
+
+        run_native_migration(&store, "s1").unwrap();
+        assert_eq!(resolve_remapped_id(&store, "s1", "track", old).unwrap(), new);
+        assert_eq!(
+            resolve_remapped_id(&store, "s1", "track", second_old).unwrap(),
+            canonical_id(second_old)
+        );
+        store
+            .with_conn("test.seed_canonical_track", |conn| {
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,album,duration_sec,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Track','Album',240,1,'{}')",
+                    params![new],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        PlaySessionRepository::new(&store)
+            .insert(&PlaySessionInputDto {
+                server_id: "s1".into(),
+                track_id: old.into(),
+                started_at_ms: 1_000,
+                listened_sec: 30.0,
+                position_max_sec: 20.0,
+                end_reason: "ended".into(),
+                duration_sec_hint: None,
+            })
+            .unwrap();
+        let stored_id = store
+            .with_read_conn(|conn| {
+                conn.query_row("SELECT track_id FROM play_session", [], |row| row.get::<_, String>(0))
+            })
+            .unwrap();
+        assert_eq!(stored_id, canonical_id(old));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn targeted_not_found_probe_is_single_flight() {
+        let server = MockServer::start().await;
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = canonical_id(old);
+        Mock::given(method("GET"))
+            .and(path("/rest/getSong.view"))
+            .and(query_param("id", new.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(not_found_response()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let store = LibraryStore::open_in_memory();
+        let client = test_client(&server.uri());
+
+        let (first, second) = tokio::join!(
+            resolve_unexpected_not_found(&store, &client, "s1", EntityKind::Track, old),
+            resolve_unexpected_not_found(&store, &client, "s1", EntityKind::Track, old),
+        );
+
+        assert_eq!(first.unwrap(), TargetedNotFoundOutcome::ConfirmedMissing);
+        assert_eq!(second.unwrap(), TargetedNotFoundOutcome::ConfirmedMissing);
+    }
+
+    #[test]
+    fn migration_records_pending_state_and_rewrites_primary_ids() {
+        let store = LibraryStore::open_in_memory();
+        let old_artist = "00112233445566778899aabbccddeeff";
+        let old_album = "11112222333344445555666677778888";
+        let old_track = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let old_folder = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        store
+            .with_conn("test.seed", |conn| {
+                conn.execute(
+                    "INSERT INTO artist(server_id,id,name,synced_at,raw_json) VALUES ('s1',?1,'Artist',1,?2)",
+                    params![old_artist, format!(r#"{{"id":"{old_artist}"}}"#)],
+                )?;
+                conn.execute(
+                    "INSERT INTO album(server_id,id,name,artist_id,synced_at,raw_json) VALUES ('s1',?1,'Album',?2,1,?3)",
+                    params![old_album, old_artist, format!(r#"{{"id":"{old_album}","artistId":"{old_artist}"}}"#)],
+                )?;
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,artist_id,album,album_id,library_id,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Track',?2,'Album',?3,?4,1,?5)",
+                    params![old_track, old_artist, old_album, old_folder, format!(r#"{{"id":"{old_track}","albumId":"{old_album}","artistId":"{old_artist}","musicFolderId":"{old_folder}","musicBrainzId":"{old_track}"}}"#)],
+                )?;
+                conn.execute(
+                    "INSERT INTO sync_state(server_id,library_scope) VALUES ('s1',?1)",
+                    params![old_folder],
+                )?;
+                conn.execute(
+                    "INSERT INTO track_offline(server_id,track_id,local_path,cached_at) VALUES ('s1',?1,'/music/track.flac',1)",
+                    params![old_track],
+                )?;
+                conn.execute(
+                    "INSERT INTO play_session(server_id,track_id,started_at_ms,listened_sec,position_max_sec,completion,end_reason) \
+                     VALUES ('s1',?1,1,10,10,'full','ended')",
+                    params![old_track],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        record_state(
+            &store,
+            "s1",
+            "transition_detected",
+            Some(old_track),
+            Some(&canonical_id(old_track)),
+            None,
+            false,
+        )
+        .unwrap();
+        run_native_migration(&store, "s1").unwrap();
+        run_native_migration(&store, "s1").unwrap();
+        let status = transition_status(&store, "s1").unwrap();
+        assert_eq!(status.state, "pending_frontend");
+        store
+            .with_read_conn(|conn| {
+                let ids: (String, String, String, String) = conn.query_row(
+                    "SELECT artist_id, album_id, id, library_id FROM track WHERE server_id = 's1'",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )?;
+                assert_eq!(ids.0, canonical_id(old_artist));
+                assert_eq!(ids.1, canonical_id(old_album));
+                assert_eq!(ids.2, canonical_id(old_track));
+                assert_eq!(ids.3, canonical_id(old_folder));
+                let scope: String = conn.query_row(
+                    "SELECT library_scope FROM sync_state WHERE server_id = 's1'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(scope, canonical_id(old_folder));
+                let projection: (String, String, String) = conn.query_row(
+                    "SELECT library_id, album_id, representative_track_id FROM album_browse_projection WHERE server_id = 's1'",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )?;
+                assert_eq!(projection.0, canonical_id(old_folder));
+                assert_eq!(projection.1, canonical_id(old_album));
+                assert_eq!(projection.2, canonical_id(old_track));
+                let offline_id: String = conn.query_row(
+                    "SELECT track_id FROM track_offline WHERE server_id = 's1'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(offline_id, canonical_id(old_track));
+                let session_id: String = conn.query_row(
+                    "SELECT track_id FROM play_session WHERE server_id = 's1'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(session_id, canonical_id(old_track));
+                let raw: String = conn.query_row(
+                    "SELECT raw_json FROM track WHERE server_id = 's1'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                let raw: Value = serde_json::from_str(&raw).unwrap();
+                assert_eq!(raw["id"], canonical_id(old_track));
+                assert_eq!(raw["albumId"], canonical_id(old_album));
+                assert_eq!(raw["artistId"], canonical_id(old_artist));
+                assert_eq!(raw["musicBrainzId"], old_track);
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn late_play_fact_and_artifact_writes_resolve_through_durable_remaps() {
+        let store = LibraryStore::open_in_memory();
+        let old_track = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new_track = canonical_id(old_track);
+        store
+            .with_conn("test.seed", |conn| {
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,album,duration_sec,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Track','Album',240,1,'{}')",
+                    params![old_track],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        record_state(
+            &store,
+            "s1",
+            "transition_detected",
+            Some(old_track),
+            Some(&new_track),
+            None,
+            false,
+        )
+        .unwrap();
+        run_native_migration(&store, "s1").unwrap();
+
+        PlaySessionRepository::new(&store)
+            .insert(&PlaySessionInputDto {
+                server_id: "s1".into(),
+                track_id: old_track.into(),
+                started_at_ms: 1_000,
+                listened_sec: 30.0,
+                position_max_sec: 20.0,
+                end_reason: "ended".into(),
+                duration_sec_hint: None,
+            })
+            .unwrap();
+        FactRepository::new(&store)
+            .put(
+                "s1",
+                old_track,
+                &FactInputDto {
+                    fact_kind: "bpm".into(),
+                    value_real: None,
+                    value_int: Some(120),
+                    value_text: None,
+                    unit: Some("bpm".into()),
+                    source_kind: "user".into(),
+                    source_id: "manual".into(),
+                    confidence: 1.0,
+                    content_hash: None,
+                    expires_at: None,
+                },
+                2_000,
+            )
+            .unwrap();
+        ArtifactRepository::new(&store)
+            .put(
+                "s1",
+                old_track,
+                &ArtifactInputDto {
+                    artifact_kind: "lyrics".into(),
+                    format: "text".into(),
+                    source_kind: "user".into(),
+                    source_id: "manual".into(),
+                    language: None,
+                    content_text: Some("late lyrics".into()),
+                    content_blob: None,
+                    content_bytes: 11,
+                    not_found: false,
+                    content_hash: None,
+                    expires_at: None,
+                },
+                2_000,
+            )
+            .unwrap();
+
+        store
+            .with_read_conn(|conn| {
+                for table in ["play_session", "track_fact", "track_artifact"] {
+                    let id: String = conn.query_row(
+                        &format!("SELECT track_id FROM {table} WHERE server_id = 's1'"),
+                        [],
+                        |row| row.get(0),
+                    )?;
+                    assert_eq!(id, new_track, "late write in {table}");
+                }
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn migration_rolls_back_when_an_unowned_destination_row_would_collide() {
+        let store = LibraryStore::open_in_memory();
+        let old_track = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new_track = canonical_id(old_track);
+        store
+            .with_conn("test.seed", |conn| {
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Track','Album',1,?2)",
+                    params![old_track, format!(r#"{{"id":"{old_track}"}}"#)],
+                )?;
+                conn.execute(
+                    "INSERT INTO track_offline(server_id,track_id,local_path,cached_at) VALUES ('s1',?1,'/old',1)",
+                    params![old_track],
+                )?;
+                conn.execute(
+                    "INSERT INTO track_offline(server_id,track_id,local_path,cached_at) VALUES ('s1',?1,'/new',2)",
+                    params![new_track],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        record_state(
+            &store,
+            "s1",
+            "transition_detected",
+            Some(old_track),
+            Some(&new_track),
+            None,
+            false,
+        )
+        .unwrap();
+        assert!(run_native_migration(&store, "s1").is_err());
+        assert_eq!(transition_status(&store, "s1").unwrap().state, "blocked");
+        store
+            .with_read_conn(|conn| {
+                let track_exists: bool = conn.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM track WHERE server_id = 's1' AND id = ?1)",
+                    params![old_track],
+                    |row| row.get(0),
+                )?;
+                assert!(track_exists);
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn migration_reuses_one_connection_for_multiple_servers() {
+        let store = LibraryStore::open_in_memory();
+        for (server_id, old_track) in [
+            ("s1", "e3b7fc2ae9447bbec37a13bf916e3cf6"),
+            ("s2", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        ] {
+            store
+                .with_conn("test.seed", |conn| {
+                    conn.execute(
+                        "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                         VALUES (?1,?2,'Track','Album',1,?3)",
+                        params![server_id, old_track, format!(r#"{{"id":"{old_track}"}}"#)],
+                    )?;
+                    Ok(())
+                })
+                .unwrap();
+            record_state(
+                &store,
+                server_id,
+                "transition_detected",
+                Some(old_track),
+                Some(&canonical_id(old_track)),
+                None,
+                false,
+            )
+            .unwrap();
+            run_native_migration(&store, server_id).unwrap();
+        }
+        for (server_id, old_track) in [
+            ("s1", "e3b7fc2ae9447bbec37a13bf916e3cf6"),
+            ("s2", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        ] {
+            let exists = store
+                .with_read_conn(|conn| {
+                    conn.query_row(
+                        "SELECT EXISTS(SELECT 1 FROM track WHERE server_id = ?1 AND id = ?2)",
+                        params![server_id, canonical_id(old_track)],
+                        |row| row.get::<_, bool>(0),
+                    )
+                })
+                .unwrap();
+            assert!(exists);
+        }
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/repos/artifact.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/artifact.rs
@@ -129,8 +129,11 @@ impl<'a> ArtifactRepository<'a> {
         sql.push_str(" ORDER BY fetched_at DESC LIMIT 1");
 
         let mut stmt = conn.prepare(&sql)?;
-        stmt.query_row(rusqlite::params_from_iter(bound.iter()), row_to_artifact_dto)
-            .optional()
+        stmt.query_row(
+            rusqlite::params_from_iter(bound.iter()),
+            row_to_artifact_dto,
+        )
+        .optional()
     }
 
     /// E3 readiness: is there a valid (non-expired, non-`not_found`) lyrics
@@ -182,6 +185,9 @@ impl<'a> ArtifactRepository<'a> {
 
         self.store
             .with_conn("artifact.put", |conn| {
+                let track_id = crate::navidrome_identity::resolve_remapped_id_with_conn(
+                    conn, server_id, "track", track_id,
+                )?;
                 conn.execute(
                     UPSERT_ARTIFACT,
                     params![
@@ -246,12 +252,7 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
-    fn artifact(
-        kind: &str,
-        format: &str,
-        source_kind: &str,
-        source_id: &str,
-    ) -> ArtifactInputDto {
+    fn artifact(kind: &str, format: &str, source_kind: &str, source_id: &str) -> ArtifactInputDto {
         ArtifactInputDto {
             artifact_kind: kind.into(),
             format: format.into(),
@@ -284,8 +285,13 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         seed_track(&store, "s1", "t1");
         let repo = ArtifactRepository::new(&store);
-        repo.put("s1", "t1", &artifact("lyrics", "plain", "lrclib", "lrclib"), 100)
-            .unwrap();
+        repo.put(
+            "s1",
+            "t1",
+            &artifact("lyrics", "plain", "lrclib", "lrclib"),
+            100,
+        )
+        .unwrap();
         let got = repo
             .get("s1", "t1", "lyrics", None, None, None, 200)
             .unwrap()
@@ -304,11 +310,15 @@ mod tests {
         repo.put("s1", "t1", &a, 100).unwrap();
 
         // read at t=200 → expired, dropped + treated as a miss.
-        let got = repo.get("s1", "t1", "lyrics", None, None, None, 200).unwrap();
+        let got = repo
+            .get("s1", "t1", "lyrics", None, None, None, 200)
+            .unwrap();
         assert!(got.is_none());
 
         let total: i64 = store
-            .with_conn("misc", |c| c.query_row("SELECT COUNT(*) FROM track_artifact", [], |r| r.get(0)))
+            .with_conn("misc", |c| {
+                c.query_row("SELECT COUNT(*) FROM track_artifact", [], |r| r.get(0))
+            })
             .unwrap();
         assert_eq!(total, 0, "expired row deleted, not just filtered");
     }
@@ -318,7 +328,12 @@ mod tests {
         let store = Arc::new(LibraryStore::open_in_memory());
         seed_track(&store, "s1", "t1");
         ArtifactRepository::new(&store)
-            .put("s1", "t1", &artifact("lyrics", "plain", "lrclib", "lrclib"), 100)
+            .put(
+                "s1",
+                "t1",
+                &artifact("lyrics", "plain", "lrclib", "lrclib"),
+                100,
+            )
             .unwrap();
         let (writer_started_tx, writer_started_rx) = mpsc::channel();
         let (release_writer_tx, release_writer_rx) = mpsc::channel();
@@ -370,7 +385,10 @@ mod tests {
             .get("s1", "t1", "lyrics", None, None, None, 500)
             .unwrap()
             .expect("negative-cache row still live");
-        assert!(got.not_found, "caller sees the cached miss instead of refetching");
+        assert!(
+            got.not_found,
+            "caller sees the cached miss instead of refetching"
+        );
     }
 
     #[test]
@@ -379,10 +397,21 @@ mod tests {
         let live = LibraryStore::open_in_memory();
         seed_track(&live, "s1", "t1");
         let repo = ArtifactRepository::new(&live);
-        assert!(!repo.lyrics_cached("s1", "t1", 200).unwrap(), "no row → not cached");
-        repo.put("s1", "t1", &artifact("lyrics", "plain", "lrclib", "lrclib"), 100)
-            .unwrap();
-        assert!(repo.lyrics_cached("s1", "t1", 200).unwrap(), "live row → cached");
+        assert!(
+            !repo.lyrics_cached("s1", "t1", 200).unwrap(),
+            "no row → not cached"
+        );
+        repo.put(
+            "s1",
+            "t1",
+            &artifact("lyrics", "plain", "lrclib", "lrclib"),
+            100,
+        )
+        .unwrap();
+        assert!(
+            repo.lyrics_cached("s1", "t1", 200).unwrap(),
+            "live row → cached"
+        );
 
         let neg = LibraryStore::open_in_memory();
         seed_track(&neg, "s1", "t1");
@@ -414,10 +443,20 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         seed_track(&store, "s1", "t1");
         let repo = ArtifactRepository::new(&store);
-        repo.put("s1", "t1", &artifact("lyrics", "plain", "lrclib", "lrclib"), 1)
-            .unwrap();
-        repo.put("s1", "t1", &artifact("lyrics", "plain", "netease", "netease"), 2)
-            .unwrap();
+        repo.put(
+            "s1",
+            "t1",
+            &artifact("lyrics", "plain", "lrclib", "lrclib"),
+            1,
+        )
+        .unwrap();
+        repo.put(
+            "s1",
+            "t1",
+            &artifact("lyrics", "plain", "netease", "netease"),
+            2,
+        )
+        .unwrap();
 
         // source_id without source_kind must bind correctly (running indices).
         let got = repo
@@ -432,10 +471,20 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         seed_track(&store, "s1", "t1");
         let repo = ArtifactRepository::new(&store);
-        repo.put("s1", "t1", &artifact("lyrics", "plain", "lrclib", "lrclib"), 1)
-            .unwrap();
-        repo.put("s1", "t1", &artifact("lyrics", "plain", "netease", "netease"), 9)
-            .unwrap();
+        repo.put(
+            "s1",
+            "t1",
+            &artifact("lyrics", "plain", "lrclib", "lrclib"),
+            1,
+        )
+        .unwrap();
+        repo.put(
+            "s1",
+            "t1",
+            &artifact("lyrics", "plain", "netease", "netease"),
+            9,
+        )
+        .unwrap();
         let got = repo
             .get("s1", "t1", "lyrics", None, None, None, 10)
             .unwrap()
@@ -461,7 +510,8 @@ mod tests {
         let repo = ArtifactRepository::new(&store);
         let mut big = artifact("lyrics", "plain", "user", "user");
         big.content_text = Some("x".repeat(MAX_ARTIFACT_BYTES + 1));
-        repo.put("s1", "t1", &big, 1).expect("user import bypasses the cap");
+        repo.put("s1", "t1", &big, 1)
+            .expect("user import bypasses the cap");
     }
 
     #[test]
@@ -469,16 +519,26 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         seed_track(&store, "s1", "t1");
         let repo = ArtifactRepository::new(&store);
-        repo.put("s1", "t1", &artifact("lyrics", "plain", "lrclib", "lrclib"), 1)
-            .unwrap();
+        repo.put(
+            "s1",
+            "t1",
+            &artifact("lyrics", "plain", "lrclib", "lrclib"),
+            1,
+        )
+        .unwrap();
         let mut updated = artifact("lyrics", "plain", "lrclib", "lrclib");
         updated.content_text = Some("new words".into());
         repo.put("s1", "t1", &updated, 2).unwrap();
         let count: i64 = store
-            .with_conn("misc", |c| c.query_row("SELECT COUNT(*) FROM track_artifact", [], |r| r.get(0)))
+            .with_conn("misc", |c| {
+                c.query_row("SELECT COUNT(*) FROM track_artifact", [], |r| r.get(0))
+            })
             .unwrap();
         assert_eq!(count, 1, "same (kind, source, format) updates in place");
-        let got = repo.get("s1", "t1", "lyrics", None, None, None, 3).unwrap().unwrap();
+        let got = repo
+            .get("s1", "t1", "lyrics", None, None, None, 3)
+            .unwrap()
+            .unwrap();
         assert_eq!(got.content_text.as_deref(), Some("new words"));
     }
 }

--- a/src-tauri/crates/psysonic-library/src/repos/artist.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/artist.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use rusqlite::{params, OptionalExtension, Transaction};
 
 use crate::artist_sort::{ignored_articles_or_default, sort_key_for_display_name};
+use crate::repos::RemapEntry;
 use crate::store::LibraryStore;
 use psysonic_integration::subsonic::ArtistIndex;
 
@@ -23,12 +24,55 @@ impl<'a> ArtistRepository<'a> {
         server_id: &str,
         index: &ArtistIndex,
         synced_at: i64,
-    ) -> Result<u32, String> {
+    ) -> Result<(u32, Option<RemapEntry>), String> {
         let ignored = ignored_articles_or_default(index.ignored_articles.as_deref());
         let mut count = 0u32;
-        self.store.with_conn_mut("artist.upsert_index", |conn| {
+        let transition = self.store.with_conn_mut("artist.upsert_index", |conn| {
             let tx = conn.transaction()?;
+            let identity_guard =
+                crate::navidrome_identity::load_deterministic_write_guard(&tx, server_id)?;
             let mut changed_identity = HashSet::new();
+            for bucket in &index.index {
+                for artist in &bucket.artist {
+                    if let Some(old_id) =
+                        crate::navidrome_identity::find_deterministic_legacy_id_with_guard(
+                            &tx,
+                            server_id,
+                            &identity_guard,
+                            crate::navidrome_identity::EntityKind::Artist,
+                            &artist.id,
+                        )?
+                    {
+                        crate::navidrome_identity::record_deterministic_transition_if_legacy_state(
+                            &tx,
+                            server_id,
+                            "artist",
+                            &old_id,
+                            &artist.id,
+                        )?;
+                        tx.commit()?;
+                        return Ok(Some(RemapEntry {
+                            server_id: server_id.to_string(),
+                            old_id,
+                            new_id: artist.id.clone(),
+                        }));
+                    }
+                }
+            }
+            crate::navidrome_identity::register_inactive_legacy_aliases(
+                &tx,
+                server_id,
+                &identity_guard,
+                index.index.iter().flat_map(|bucket| {
+                    bucket.artist.iter().map(|artist| {
+                        (
+                            crate::navidrome_identity::EntityKind::Artist,
+                            artist.id.as_str(),
+                        )
+                    })
+                }),
+                synced_at,
+            )?;
             let mut previous_name = tx.prepare_cached(
                 "SELECT name FROM artist WHERE server_id = ?1 AND id = ?2",
             )?;
@@ -56,9 +100,9 @@ impl<'a> ArtistRepository<'a> {
             drop(previous_name);
             crate::identity::record_artists(&tx, server_id, changed_identity)?;
             tx.commit()?;
-            Ok(())
+            Ok(None)
         })?;
-        Ok(count)
+        Ok((count, transition))
     }
 
     /// Materialize missing `artist` rows from synced tracks (pre-pass backfill).
@@ -99,6 +143,20 @@ impl<'a> ArtistRepository<'a> {
         let mut count = 0u32;
         self.store.with_conn_mut("artist.backfill_from_tracks", |conn| {
             let tx = conn.transaction()?;
+            let identity_guard =
+                crate::navidrome_identity::load_deterministic_write_guard(&tx, server_id)?;
+            crate::navidrome_identity::register_inactive_legacy_aliases(
+                &tx,
+                server_id,
+                &identity_guard,
+                rows.iter().map(|(id, _)| {
+                    (
+                        crate::navidrome_identity::EntityKind::Artist,
+                        id.as_str(),
+                    )
+                }),
+                synced_at,
+            )?;
             for (id, name) in &rows {
                 let name_sort = sort_key_for_display_name(name, ignored_articles);
                 upsert_artist_row(&tx, server_id, id, name, &name_sort, None, synced_at)?;
@@ -262,6 +320,78 @@ mod tests {
             })
             .unwrap();
         assert_eq!(name_sort, "beatles");
+    }
+
+    fn one_artist_index(id: &str, name: &str) -> ArtistIndex {
+        ArtistIndex {
+            last_modified_ms: Some(1),
+            ignored_articles: None,
+            index: vec![IndexBucket {
+                name: "A".into(),
+                artist: vec![ArtistRef {
+                    id: id.into(),
+                    name: name.into(),
+                    album_count: Some(1),
+                    cover_art: None,
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn artist_only_overflow_alias_blocks_later_canonical_collision() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn("test.seed_artist_identity_state", |conn| {
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, detected_at) \
+                     VALUES ('s1',?1,'no_legacy_ids',1)",
+                    params![crate::navidrome_identity::CANONICAL_ID_VERSION],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        let old = "ZZZZZZZZZZZZZZZZZZZZZZ";
+        let new = crate::navidrome_identity::canonical_id(old);
+        let repo = ArtistRepository::new(&store);
+
+        let (_, first_transition) = repo
+            .upsert_index("s1", &one_artist_index(old, "Legacy Artist"), 1)
+            .unwrap();
+        assert!(first_transition.is_none());
+        let alias: (String, i64) = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT old_id, active FROM entity_id_remap \
+                     WHERE server_id = 's1' AND entity_kind = 'artist' AND new_id = ?1",
+                    params![new],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+            })
+            .unwrap();
+        assert_eq!(alias, (old.into(), 0));
+
+        let (_, transition) = repo
+            .upsert_index("s1", &one_artist_index(&new, "Canonical Artist"), 2)
+            .unwrap();
+        let transition = transition.unwrap();
+        assert_eq!(transition.old_id, old);
+        assert_eq!(transition.new_id, new);
+        let ids: Vec<String> = store
+            .with_read_conn(|conn| {
+                conn.prepare("SELECT id FROM artist WHERE server_id = 's1' ORDER BY id")?
+                    .query_map([], |row| row.get(0))?
+                    .collect()
+            })
+            .unwrap();
+        assert_eq!(ids, vec![old.to_string()]);
+        assert_eq!(
+            crate::navidrome_identity::transition_status(&store, "s1")
+                .unwrap()
+                .state,
+            "transition_detected"
+        );
     }
 
     fn seed_artist(store: &LibraryStore, server: &str, id: &str, name: &str, albums: Option<i64>) {

--- a/src-tauri/crates/psysonic-library/src/repos/fact.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/fact.rs
@@ -114,6 +114,9 @@ impl<'a> FactRepository<'a> {
     ) -> Result<(), String> {
         self.store
             .with_conn("fact.put", |conn| {
+                let track_id = crate::navidrome_identity::resolve_remapped_id_with_conn(
+                    conn, server_id, "track", track_id,
+                )?;
                 conn.execute(
                     UPSERT_FACT,
                     params![
@@ -196,7 +199,12 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
-    fn fact(kind: &str, source_kind: &str, value_int: Option<i64>, expires_at: Option<i64>) -> FactInputDto {
+    fn fact(
+        kind: &str,
+        source_kind: &str,
+        value_int: Option<i64>,
+        expires_at: Option<i64>,
+    ) -> FactInputDto {
         FactInputDto {
             fact_kind: kind.into(),
             value_real: None,
@@ -228,7 +236,8 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         seed_track(&store, "s1", "t1");
         let repo = FactRepository::new(&store);
-        repo.put("s1", "t1", &fact("bpm", "analysis", Some(120), None), 100).unwrap();
+        repo.put("s1", "t1", &fact("bpm", "analysis", Some(120), None), 100)
+            .unwrap();
         let facts = repo.get("s1", "t1", &[], 200).unwrap();
         assert_eq!(facts.len(), 1);
         assert_eq!(facts[0].fact_kind, "bpm");
@@ -241,8 +250,15 @@ mod tests {
         seed_track(&store, "s1", "t1");
         let repo = FactRepository::new(&store);
         // expires at t=150
-        repo.put("s1", "t1", &fact("energy", "external_api", Some(5), Some(150)), 100).unwrap();
-        repo.put("s1", "t1", &fact("bpm", "analysis", Some(120), None), 100).unwrap();
+        repo.put(
+            "s1",
+            "t1",
+            &fact("energy", "external_api", Some(5), Some(150)),
+            100,
+        )
+        .unwrap();
+        repo.put("s1", "t1", &fact("bpm", "analysis", Some(120), None), 100)
+            .unwrap();
 
         // read at t=200 → energy expired, dropped + excluded; bpm survives.
         let facts = repo.get("s1", "t1", &[], 200).unwrap();
@@ -251,7 +267,9 @@ mod tests {
 
         // and it was actually deleted from the table (not just filtered).
         let total: i64 = store
-            .with_conn("misc", |c| c.query_row("SELECT COUNT(*) FROM track_fact", [], |r| r.get(0)))
+            .with_conn("misc", |c| {
+                c.query_row("SELECT COUNT(*) FROM track_fact", [], |r| r.get(0))
+            })
             .unwrap();
         assert_eq!(total, 1);
     }
@@ -289,7 +307,9 @@ mod tests {
         writer.join().unwrap();
         reader.join().unwrap();
 
-        let facts = result.expect("read-only fact lookup blocked on writer").unwrap();
+        let facts = result
+            .expect("read-only fact lookup blocked on writer")
+            .unwrap();
         assert_eq!(facts.len(), 1);
     }
 
@@ -298,8 +318,10 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         seed_track(&store, "s1", "t1");
         let repo = FactRepository::new(&store);
-        repo.put("s1", "t1", &fact("bpm", "analysis", Some(120), None), 1).unwrap();
-        repo.put("s1", "t1", &fact("energy", "analysis", Some(7), None), 1).unwrap();
+        repo.put("s1", "t1", &fact("bpm", "analysis", Some(120), None), 1)
+            .unwrap();
+        repo.put("s1", "t1", &fact("energy", "analysis", Some(7), None), 1)
+            .unwrap();
         let facts = repo.get("s1", "t1", &["bpm".into()], 2).unwrap();
         assert_eq!(facts.len(), 1);
         assert_eq!(facts[0].fact_kind, "bpm");
@@ -310,10 +332,15 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         seed_track(&store, "s1", "t1");
         let repo = FactRepository::new(&store);
-        repo.put("s1", "t1", &fact("bpm", "user", Some(128), None), 1).unwrap();
+        repo.put("s1", "t1", &fact("bpm", "user", Some(128), None), 1)
+            .unwrap();
         let bpm: Option<i64> = store
             .with_conn("misc", |c| {
-                c.query_row("SELECT bpm FROM track WHERE server_id='s1' AND id='t1'", [], |r| r.get(0))
+                c.query_row(
+                    "SELECT bpm FROM track WHERE server_id='s1' AND id='t1'",
+                    [],
+                    |r| r.get(0),
+                )
             })
             .unwrap();
         assert_eq!(bpm, Some(128), "user bpm override must write track.bpm");
@@ -324,13 +351,21 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         seed_track(&store, "s1", "t1");
         let repo = FactRepository::new(&store);
-        repo.put("s1", "t1", &fact("bpm", "analysis", Some(99), None), 1).unwrap();
+        repo.put("s1", "t1", &fact("bpm", "analysis", Some(99), None), 1)
+            .unwrap();
         let bpm: Option<i64> = store
             .with_conn("misc", |c| {
-                c.query_row("SELECT bpm FROM track WHERE server_id='s1' AND id='t1'", [], |r| r.get(0))
+                c.query_row(
+                    "SELECT bpm FROM track WHERE server_id='s1' AND id='t1'",
+                    [],
+                    |r| r.get(0),
+                )
             })
             .unwrap();
-        assert_eq!(bpm, None, "only a user override writes the hot column (§5.12)");
+        assert_eq!(
+            bpm, None,
+            "only a user override writes the hot column (§5.12)"
+        );
     }
 
     #[test]
@@ -338,8 +373,10 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         seed_track(&store, "s1", "t1");
         let repo = FactRepository::new(&store);
-        repo.put("s1", "t1", &fact("bpm", "analysis", Some(120), None), 1).unwrap();
-        repo.put("s1", "t1", &fact("bpm", "analysis", Some(124), None), 2).unwrap();
+        repo.put("s1", "t1", &fact("bpm", "analysis", Some(120), None), 1)
+            .unwrap();
+        repo.put("s1", "t1", &fact("bpm", "analysis", Some(124), None), 2)
+            .unwrap();
         let facts = repo.get("s1", "t1", &[], 3).unwrap();
         assert_eq!(facts.len(), 1, "same (kind, source) updates in place");
         assert_eq!(facts[0].value_int, Some(124));

--- a/src-tauri/crates/psysonic-library/src/repos/play_session/mod.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/play_session/mod.rs
@@ -11,16 +11,14 @@ use std::collections::HashMap;
 use rusqlite::{params, OptionalExtension};
 
 use crate::dto::{
-    PlaySessionDayDetailDto, PlaySessionDayTrackDto, PlaySessionDayTotalsDto,
+    PlaySessionDayDetailDto, PlaySessionDayTotalsDto, PlaySessionDayTrackDto,
     PlaySessionHeatmapDayDto, PlaySessionInputDto, PlaySessionRecentDayDto,
     PlaySessionRecentTrackDto, PlaySessionYearBoundsDto, PlaySessionYearSummaryDto,
 };
 use crate::store::LibraryStore;
 
 use cluster::{count_listening_sessions, PlaySpan};
-use completion::{
-    completion_from_position, effective_duration_sec, MIN_LISTENED_SEC,
-};
+use completion::{completion_from_position, effective_duration_sec, MIN_LISTENED_SEC};
 
 fn map_play_session_track_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PlaySessionDayTrackDto> {
     Ok(PlaySessionDayTrackDto {
@@ -90,11 +88,17 @@ impl<'a> PlaySessionRepository<'a> {
 
         self.store
             .with_conn("play_session.insert", |conn| {
+                let track_id = crate::navidrome_identity::resolve_remapped_id_with_conn(
+                    conn,
+                    &input.server_id,
+                    "track",
+                    &input.track_id,
+                )?;
                 let duration_sec: i64 = conn
                     .query_row(
                         "SELECT duration_sec FROM track \
                          WHERE server_id = ?1 AND id = ?2 AND deleted = 0",
-                        params![input.server_id, input.track_id],
+                        params![input.server_id, track_id],
                         |row| row.get(0),
                     )
                     .optional()?
@@ -111,7 +115,7 @@ impl<'a> PlaySessionRepository<'a> {
                      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                     params![
                         input.server_id,
-                        input.track_id,
+                        track_id,
                         input.started_at_ms,
                         input.listened_sec,
                         input.position_max_sec,

--- a/src-tauri/crates/psysonic-library/src/repos/track.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track.rs
@@ -141,6 +141,7 @@ pub struct RemapEntry {
 #[derive(Debug, Clone, Default)]
 pub struct RemapStats {
     pub remapped: Vec<RemapEntry>,
+    pub identity_transition: Option<RemapEntry>,
 }
 
 pub struct TrackRepository<'a> {
@@ -176,15 +177,34 @@ impl<'a> TrackRepository<'a> {
         rows: &[TrackRow],
         resync_gen: Option<i64>,
     ) -> Result<WriteOpTiming, String> {
-        self.upsert_batch_initial_ingest_timed_with_source(rows, resync_gen, false)
+        self.upsert_batch_initial_ingest_timed_with_source(rows, resync_gen, false, false)
+            .map(|(timing, _)| timing)
     }
 
+    pub(crate) fn upsert_batch_initial_ingest_guarded_timed(
+        &self,
+        rows: &[TrackRow],
+        resync_gen: Option<i64>,
+    ) -> Result<(WriteOpTiming, Option<RemapEntry>), String> {
+        self.upsert_batch_initial_ingest_timed_with_source(rows, resync_gen, false, true)
+    }
+
+    #[cfg(test)]
     pub(crate) fn upsert_sparse_batch_initial_ingest_timed(
         &self,
         rows: &[TrackRow],
         resync_gen: Option<i64>,
     ) -> Result<WriteOpTiming, String> {
-        self.upsert_batch_initial_ingest_timed_with_source(rows, resync_gen, true)
+        self.upsert_batch_initial_ingest_timed_with_source(rows, resync_gen, true, false)
+            .map(|(timing, _)| timing)
+    }
+
+    pub(crate) fn upsert_sparse_batch_initial_ingest_guarded_timed(
+        &self,
+        rows: &[TrackRow],
+        resync_gen: Option<i64>,
+    ) -> Result<(WriteOpTiming, Option<RemapEntry>), String> {
+        self.upsert_batch_initial_ingest_timed_with_source(rows, resync_gen, true, true)
     }
 
     fn upsert_batch_initial_ingest_timed_with_source(
@@ -192,20 +212,40 @@ impl<'a> TrackRepository<'a> {
         rows: &[TrackRow],
         resync_gen: Option<i64>,
         sparse_payload: bool,
-    ) -> Result<WriteOpTiming, String> {
+        guard_canonical_transition: bool,
+    ) -> Result<(WriteOpTiming, Option<RemapEntry>), String> {
         if rows.is_empty() {
-            return Ok(WriteOpTiming::default());
+            return Ok((WriteOpTiming::default(), None));
         }
         let sql = match resync_gen {
             Some(_) => UPSERT_INITIAL_RESYNC_SQL,
             None => UPSERT_SQL,
         };
-        let (_, timing) =
+        let (identity_transition, timing) =
             self.store
                 .with_conn_mut_timed("track.upsert_initial_ingest", |conn| {
                     let tx = conn.transaction()?;
+                    let identity_guards = load_deterministic_write_guards(&tx, rows)?;
+                    if guard_canonical_transition {
+                        if let Some(transition) = detect_deterministic_track_transition(
+                            &tx,
+                            &identity_guards,
+                            rows,
+                        )? {
+                            crate::navidrome_identity::record_deterministic_transition_if_legacy_state(
+                                &tx,
+                                &transition.server_id,
+                                "track",
+                                &transition.old_id,
+                                &transition.new_id,
+                            )?;
+                            tx.commit()?;
+                            return Ok(Some(transition));
+                        }
+                    }
                     let affected_album_scopes =
                         crate::browse_projection::collect_affected_album_scopes(&tx, rows)?;
+                    register_track_row_aliases(&tx, rows, &identity_guards)?;
                     let mut upsert = tx.prepare_cached(sql)?;
                     for r in rows {
                         if let Some(gen) = resync_gen {
@@ -299,9 +339,9 @@ impl<'a> TrackRepository<'a> {
                     )?;
                     crate::browse_projection::refresh_album_scopes(&tx, affected_album_scopes)?;
                     tx.commit()?;
-                    Ok(())
+                    Ok(None)
                 })?;
-        Ok(timing)
+        Ok((timing, identity_transition))
     }
 
     /// Next generation stamp for a full-resync orphan sweep. Empty scope is
@@ -920,12 +960,32 @@ impl<'a> TrackRepository<'a> {
         rows: &[TrackRow],
         unstable_track_ids: bool,
     ) -> Result<RemapStats, String> {
+        self.upsert_batch_with_remap_inner(rows, unstable_track_ids, false)
+    }
+
+    /// Delta-sync variant that detects Navidrome's deterministic old-to-canonical
+    /// transition before the ordinary unstable-ID remap can consume it.
+    pub fn upsert_delta_batch_with_remap(
+        &self,
+        rows: &[TrackRow],
+        unstable_track_ids: bool,
+    ) -> Result<RemapStats, String> {
+        self.upsert_batch_with_remap_inner(rows, unstable_track_ids, true)
+    }
+
+    fn upsert_batch_with_remap_inner(
+        &self,
+        rows: &[TrackRow],
+        unstable_track_ids: bool,
+        guard_canonical_transition: bool,
+    ) -> Result<RemapStats, String> {
         if rows.is_empty() {
             return Ok(RemapStats::default());
         }
         self.store
             .with_conn_mut("track.upsert_batch_remap", |conn| {
                 let tx = conn.transaction()?;
+                let identity_guards = load_deterministic_write_guards(&tx, rows)?;
                 let mut affected_album_scopes =
                     crate::browse_projection::collect_affected_album_scopes(&tx, rows)?;
                 let mut remapped: Vec<RemapEntry> = Vec::new();
@@ -938,20 +998,58 @@ impl<'a> TrackRepository<'a> {
                 } else {
                     None
                 };
+                let detected_old_ids = rows
+                    .iter()
+                    .map(|row| {
+                        if let Some((ref mut by_hash, ref mut by_path)) = remap_lookup {
+                            detect_remap_target_cached(by_hash, by_path, row)
+                        } else {
+                            Ok(None)
+                        }
+                    })
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                if guard_canonical_transition {
+                    let deterministic =
+                        detect_deterministic_track_transition(&tx, &identity_guards, rows)?;
+                    let identity_transition = deterministic.or_else(|| {
+                        rows.iter().zip(&detected_old_ids).find_map(|(incoming, old_id)| {
+                            let old_id = old_id.as_ref()?;
+                            (incoming.id == crate::navidrome_identity::canonical_id(old_id)).then(
+                                || RemapEntry {
+                                    server_id: incoming.server_id.clone(),
+                                    old_id: old_id.clone(),
+                                    new_id: incoming.id.clone(),
+                                },
+                            )
+                        })
+                    });
+                    if let Some(identity_transition) = identity_transition {
+                        if crate::navidrome_identity::record_deterministic_transition_if_legacy_state(
+                            &tx,
+                            &identity_transition.server_id,
+                            "track",
+                            &identity_transition.old_id,
+                            &identity_transition.new_id,
+                        )? {
+                            drop(upsert);
+                            drop(remap_lookup);
+                            tx.commit()?;
+                            return Ok(RemapStats {
+                                remapped: Vec::new(),
+                                identity_transition: Some(identity_transition),
+                            });
+                        }
+                    }
+                }
 
-                for r in rows {
+                register_track_row_aliases(&tx, rows, &identity_guards)?;
+
+                for (r, detected_old) in rows.iter().zip(detected_old_ids) {
                     // Spec §6.9: detect collision BEFORE the upsert so the
                     // old id is known. The upsert itself comes next; only
                     // then do we retarget children to the new id, since
                     // child tables FK→track(server_id, id) and would refuse
                     // an UPDATE pointing at an id that doesn't exist yet.
-                    let detected_old: Option<String> =
-                        if let Some((ref mut by_hash, ref mut by_path)) = remap_lookup {
-                            detect_remap_target_cached(by_hash, by_path, r)?
-                        } else {
-                            None
-                        };
-
                     upsert.execute(params![
                         r.server_id,
                         r.id,
@@ -1054,7 +1152,10 @@ impl<'a> TrackRepository<'a> {
                 crate::browse_projection::refresh_album_scopes(&tx, affected_album_scopes)?;
 
                 tx.commit()?;
-                Ok(RemapStats { remapped })
+                Ok(RemapStats {
+                    remapped,
+                    identity_transition: None,
+                })
             })
     }
 }
@@ -1129,6 +1230,84 @@ fn detect_remap_target_cached(
     }
 
     Ok(None)
+}
+
+fn detect_deterministic_track_transition(
+    tx: &Transaction<'_>,
+    guards: &HashMap<String, crate::navidrome_identity::DeterministicWriteGuard>,
+    rows: &[TrackRow],
+) -> rusqlite::Result<Option<RemapEntry>> {
+    if rows.is_empty() {
+        return Ok(None);
+    }
+    for incoming in rows {
+        let Some(guard) = guards.get(&incoming.server_id) else {
+            continue;
+        };
+        let Some(old_id) = crate::navidrome_identity::find_deterministic_legacy_id_with_guard(
+            tx,
+            &incoming.server_id,
+            guard,
+            crate::navidrome_identity::EntityKind::Track,
+            &incoming.id,
+        )? else {
+            continue;
+        };
+        return Ok(Some(RemapEntry {
+            server_id: incoming.server_id.clone(),
+            old_id,
+            new_id: incoming.id.clone(),
+        }));
+    }
+    Ok(None)
+}
+
+fn load_deterministic_write_guards(
+    tx: &Transaction<'_>,
+    rows: &[TrackRow],
+) -> rusqlite::Result<HashMap<String, crate::navidrome_identity::DeterministicWriteGuard>> {
+    let mut guards = HashMap::new();
+    for server_id in rows.iter().map(|row| row.server_id.as_str()).collect::<HashSet<_>>() {
+        guards.insert(
+            server_id.to_string(),
+            crate::navidrome_identity::load_deterministic_write_guard(tx, server_id)?,
+        );
+    }
+    Ok(guards)
+}
+
+fn register_track_row_aliases(
+    tx: &Transaction<'_>,
+    rows: &[TrackRow],
+    guards: &HashMap<String, crate::navidrome_identity::DeterministicWriteGuard>,
+) -> rusqlite::Result<()> {
+    for (server_id, guard) in guards {
+        crate::navidrome_identity::register_inactive_legacy_aliases(
+            tx,
+            server_id,
+            guard,
+            rows.iter()
+                .filter(|row| row.server_id == *server_id)
+                .flat_map(|row| {
+                    std::iter::once((
+                        crate::navidrome_identity::EntityKind::Track,
+                        row.id.as_str(),
+                    ))
+                    .chain(row.album_id.as_deref().map(|id| {
+                        (crate::navidrome_identity::EntityKind::Album, id)
+                    }))
+                    .chain(row.artist_id.as_deref().map(|id| {
+                        (crate::navidrome_identity::EntityKind::Artist, id)
+                    }))
+                }),
+            rows.iter()
+                .filter(|row| row.server_id == *server_id)
+                .map(|row| row.synced_at)
+                .max()
+                .unwrap_or(0),
+        )?;
+    }
+    Ok(())
 }
 
 /// Run the §6.9 retarget half — UPDATE every FK-bound child to the
@@ -2300,6 +2479,74 @@ mod tests {
             elapsed < std::time::Duration::from_millis(1000),
             "initial ingest batch(500) took {elapsed:?}; includes per-row track_genre \
              maintenance and large raw_json payloads"
+        );
+    }
+
+    #[test]
+    fn guarded_ingest_deduplicates_shared_alias_references_per_batch() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn("test.seed_guarded_alias_state", |conn| {
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, detected_at) \
+                     VALUES ('s1',?1,'no_legacy_ids',1)",
+                    params![crate::navidrome_identity::CANONICAL_ID_VERSION],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        let shared_album = "AAAAAAAAAAAAAAAAAAAAAA";
+        let shared_artist = "ZZZZZZZZZZZZZZZZZZZZZZ";
+        let rows: Vec<TrackRow> = (0..500)
+            .map(|index| {
+                let mut row = row(
+                    "s1",
+                    &format!("{index:032x}"),
+                    &format!("Track {index}"),
+                );
+                row.album_id = Some(shared_album.into());
+                row.artist_id = Some(shared_artist.into());
+                row
+            })
+            .collect();
+
+        let start = std::time::Instant::now();
+        TrackRepository::new(&store)
+            .upsert_batch_initial_ingest_guarded_timed(&rows, None)
+            .unwrap();
+        let elapsed = start.elapsed();
+
+        let (track_aliases, album_aliases, artist_aliases): (i64, i64, i64) = store
+            .with_read_conn(|conn| {
+                Ok((
+                    conn.query_row(
+                        "SELECT COUNT(*) FROM entity_id_remap \
+                         WHERE server_id = 's1' AND entity_kind = 'track'",
+                        [],
+                        |row| row.get(0),
+                    )?,
+                    conn.query_row(
+                        "SELECT COUNT(*) FROM entity_id_remap \
+                         WHERE server_id = 's1' AND entity_kind = 'album'",
+                        [],
+                        |row| row.get(0),
+                    )?,
+                    conn.query_row(
+                        "SELECT COUNT(*) FROM entity_id_remap \
+                         WHERE server_id = 's1' AND entity_kind = 'artist'",
+                        [],
+                        |row| row.get(0),
+                    )?,
+                ))
+            })
+            .unwrap();
+        assert_eq!(track_aliases, 500);
+        assert_eq!(album_aliases, 1);
+        assert_eq!(artist_aliases, 1);
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "guarded ingest with 500 rows and shared references took {elapsed:?}"
         );
     }
 

--- a/src-tauri/crates/psysonic-library/src/runtime.rs
+++ b/src-tauri/crates/psysonic-library/src/runtime.rs
@@ -93,6 +93,10 @@ pub struct LibraryRuntime {
     /// Scheduler ticks take shared access; destructive operations take exclusive
     /// access after draining the relevant foreground job.
     sync_activity: Arc<RwLock<()>>,
+    /// Non-sync writers that prepare ID-bearing rows before taking SQLite's writer
+    /// lock hold shared access. Canonical-ID migration takes exclusive access so a
+    /// prepared legacy row cannot be committed after the remap transaction.
+    identity_mutation: Arc<RwLock<()>>,
     /// Top-crate scheduler tick task watches this flag; set true on
     /// app shutdown / library index disabled.
     pub scheduler_cancel: Arc<AtomicBool>,
@@ -112,6 +116,7 @@ impl LibraryRuntime {
             current_job: Mutex::new(None),
             sync_lifecycle: Arc::new(AsyncMutex::new(())),
             sync_activity: Arc::new(RwLock::new(())),
+            identity_mutation: Arc::new(RwLock::new(())),
             scheduler_cancel: Arc::new(AtomicBool::new(false)),
             live_search_epoch: AtomicU64::new(0),
             analysis_progress_cache: Mutex::new(HashMap::new()),
@@ -249,6 +254,14 @@ impl LibraryRuntime {
     /// Shared scheduler access held for the full write-capable tick.
     pub async fn sync_activity_guard(&self) -> OwnedRwLockReadGuard<()> {
         Arc::clone(&self.sync_activity).read_owned().await
+    }
+
+    pub async fn identity_mutation_guard(&self) -> OwnedRwLockReadGuard<()> {
+        Arc::clone(&self.identity_mutation).read_owned().await
+    }
+
+    pub async fn identity_migration_guard(&self) -> OwnedRwLockWriteGuard<()> {
+        Arc::clone(&self.identity_mutation).write_owned().await
     }
 
     /// Snapshot all bound sessions — used by the scheduler tick task
@@ -582,6 +595,31 @@ mod tests {
             .unwrap();
         assert!(acquired.load(Ordering::SeqCst));
         drop(barrier);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn identity_migration_waits_for_prepared_non_sync_writer() {
+        let runtime = Arc::new(LibraryRuntime::new(Arc::new(LibraryStore::open_in_memory())));
+        let writer = runtime.identity_mutation_guard().await;
+        let acquired = Arc::new(AtomicBool::new(false));
+        let acquired_for_task = Arc::clone(&acquired);
+        let runtime_for_task = Arc::clone(&runtime);
+        let task = tokio::spawn(async move {
+            let guard = runtime_for_task.identity_migration_guard().await;
+            acquired_for_task.store(true, Ordering::SeqCst);
+            guard
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!acquired.load(Ordering::SeqCst));
+        drop(writer);
+
+        let migration = tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("identity migration stayed blocked")
+            .unwrap();
+        assert!(acquired.load(Ordering::SeqCst));
+        drop(migration);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src-tauri/crates/psysonic-library/src/store.rs
+++ b/src-tauri/crates/psysonic-library/src/store.rs
@@ -12,7 +12,7 @@ use tauri::Manager;
 ///
 /// Migration checklist (wiring, data backfill, open/swap path):
 /// psysonic-workdocs `ai/agent-rules/08-library-db-migrations.md`.
-pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 27;
+pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 29;
 
 /// One-time data repair after migration 014 (`artist.name_sort`).
 pub(crate) const ARTIST_NAME_SORT_RECONCILE_ID: &str = "artist_name_sort_reconcile_v1";
@@ -92,6 +92,12 @@ pub(crate) const MIGRATION_026_LIBRARY_TAG_CURSOR: &str =
 /// Version 27: durable Navidrome canonical-ID transition state and entity remap journal.
 pub(crate) const MIGRATION_027_NAVIDROME_CANONICAL_IDS: &str =
     include_str!("../migrations/027_navidrome_canonical_ids.sql");
+/// Version 28: durable cursor for bounded canonical-ID candidate probing.
+pub(crate) const MIGRATION_028_IDENTITY_PROBE_CURSOR: &str =
+    include_str!("../migrations/028_identity_probe_cursor.sql");
+/// Version 29: indexed text cursor for bounded inactive-alias baseline scans.
+pub(crate) const MIGRATION_029_IDENTITY_ALIAS_CURSOR: &str =
+    include_str!("../migrations/029_identity_alias_cursor.sql");
 
 /// Embedded migrations. Ordered ascending by `version`; the runner sorts
 /// defensively before applying so the source order can stay readable.
@@ -113,6 +119,8 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (25, MIGRATION_025_IDENTITY_INVALIDATION),
     (26, MIGRATION_026_LIBRARY_TAG_CURSOR),
     (27, MIGRATION_027_NAVIDROME_CANONICAL_IDS),
+    (28, MIGRATION_028_IDENTITY_PROBE_CURSOR),
+    (29, MIGRATION_029_IDENTITY_ALIAS_CURSOR),
 ];
 
 /// Idempotent repair — also runs after the migration runner on every open so
@@ -1114,6 +1122,7 @@ fn open_database_connections(
 
 fn prepare_write_connection_for_open(conn: &Connection) -> rusqlite::Result<()> {
     run_migrations(conn)?;
+    ensure_navidrome_identity_schema(conn)?;
     maybe_reconcile_artist_name_sort(conn)?;
     maybe_reconcile_artist_name_fold(conn)?;
     maybe_reconcile_replay_gain_peak(conn)?;
@@ -1221,6 +1230,30 @@ fn sync_state_ignored_articles_column_exists(conn: &Connection) -> rusqlite::Res
     Ok(column_exists > 0)
 }
 
+fn identity_probe_cursor_column_exists(conn: &Connection) -> rusqlite::Result<bool> {
+    let column_exists: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('server_identity_transition') \
+             WHERE name = 'probe_cursor'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+    Ok(column_exists > 0)
+}
+
+fn identity_alias_cursor_column_exists(conn: &Connection) -> rusqlite::Result<bool> {
+    let column_exists: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('library_data_migration') \
+             WHERE name = 'cursor_text'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+    Ok(column_exists > 0)
+}
+
 /// Apply schema 014 idempotently — mirrors `migrations/014_artist_name_sort.sql`
 /// but tolerates a partial prior apply (missing one column / re-run).
 fn apply_migration_14(conn: &Connection) -> rusqlite::Result<()> {
@@ -1247,6 +1280,33 @@ fn apply_migration_22(conn: &Connection) -> rusqlite::Result<()> {
     )?;
     maybe_reconcile_artist_name_fold(conn)?;
     Ok(())
+}
+
+/// Apply schema 028 idempotently so a crash after its single `ADD COLUMN`
+/// but before the migration marker is recorded recovers on the next open.
+fn apply_migration_28(conn: &Connection) -> rusqlite::Result<()> {
+    if !identity_probe_cursor_column_exists(conn)? {
+        conn.execute_batch(MIGRATION_028_IDENTITY_PROBE_CURSOR)?;
+    }
+    Ok(())
+}
+
+fn apply_migration_29(conn: &Connection) -> rusqlite::Result<()> {
+    if !identity_alias_cursor_column_exists(conn)? {
+        conn.execute_batch("ALTER TABLE library_data_migration ADD COLUMN cursor_text TEXT;")?;
+    }
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_album_artist_ref \
+         ON album(server_id, artist_id) \
+         WHERE artist_id IS NOT NULL AND artist_id != '';",
+    )?;
+    Ok(())
+}
+
+fn ensure_navidrome_identity_schema(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(MIGRATION_027_NAVIDROME_CANONICAL_IDS)?;
+    apply_migration_28(conn)?;
+    apply_migration_29(conn)
 }
 
 fn record_schema_migration(conn: &Connection, version: i64) -> rusqlite::Result<()> {
@@ -1692,6 +1752,16 @@ pub(crate) fn run_migrations_with(
             record_schema_migration(conn, version)?;
             continue;
         }
+        if version == 28 {
+            apply_migration_28(conn)?;
+            record_schema_migration(conn, version)?;
+            continue;
+        }
+        if version == 29 {
+            apply_migration_29(conn)?;
+            record_schema_migration(conn, version)?;
+            continue;
+        }
         conn.execute_batch(sql)?;
         match version {
             20 => mark_projection_migration_complete_if_empty(
@@ -1905,11 +1975,146 @@ mod tests {
     }
 
     #[test]
-    fn migration_026_adds_tag_cursor_without_rewriting_completion_state() {
+    fn migration_028_adds_identity_probe_cursor_without_changing_transition_state() {
         let conn = Connection::open_in_memory().unwrap();
+        let migrations_through_27: Vec<(i64, &str)> = MIGRATIONS
+            .iter()
+            .copied()
+            .filter(|(version, _)| *version <= 27)
+            .collect();
         run_migrations_with(
             &conn,
-            &MIGRATIONS[..MIGRATIONS.len() - 1],
+            &migrations_through_27,
+            LIBRARY_DB_MIN_COMPATIBLE_VERSION,
+            handle_breaking_schema_bump,
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO server_identity_transition \
+             (server_id, canonical_version, state, probe_old_id, probe_new_id, detected_at) \
+             VALUES ('s1', 2, 'retryable', 'old', 'new', 123)",
+            [],
+        )
+        .unwrap();
+
+        run_migrations(&conn).unwrap();
+
+        let state: (String, Option<String>, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT state, probe_old_id, probe_new_id, probe_cursor \
+                 FROM server_identity_transition WHERE server_id = 's1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            state,
+            (
+                "retryable".into(),
+                Some("old".into()),
+                Some("new".into()),
+                None
+            )
+        );
+    }
+
+    #[test]
+    fn migration_028_recovers_after_column_landed_without_marker() {
+        let conn = Connection::open_in_memory().unwrap();
+        let migrations_through_27: Vec<(i64, &str)> = MIGRATIONS
+            .iter()
+            .copied()
+            .filter(|(version, _)| *version <= 27)
+            .collect();
+        run_migrations_with(
+            &conn,
+            &migrations_through_27,
+            LIBRARY_DB_MIN_COMPATIBLE_VERSION,
+            handle_breaking_schema_bump,
+        )
+        .unwrap();
+        conn.execute_batch(MIGRATION_028_IDENTITY_PROBE_CURSOR)
+            .expect("apply partial migration ddl");
+
+        run_migrations(&conn).expect("recover partial migration");
+
+        assert!(identity_probe_cursor_column_exists(&conn).unwrap());
+        let recorded: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = 28)",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(recorded);
+    }
+
+    #[test]
+    fn migration_029_adds_text_cursor_and_album_artist_index() {
+        let conn = Connection::open_in_memory().unwrap();
+        let migrations_through_28: Vec<(i64, &str)> = MIGRATIONS
+            .iter()
+            .copied()
+            .filter(|(version, _)| *version <= 28)
+            .collect();
+        run_migrations_with(
+            &conn,
+            &migrations_through_28,
+            LIBRARY_DB_MIN_COMPATIBLE_VERSION,
+            handle_breaking_schema_bump,
+        )
+        .unwrap();
+
+        run_migrations(&conn).unwrap();
+
+        assert!(identity_alias_cursor_column_exists(&conn).unwrap());
+        let index_exists: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master \
+                 WHERE type = 'index' AND name = 'idx_album_artist_ref')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(index_exists);
+    }
+
+    #[test]
+    fn open_repairs_identity_schema_when_markers_exist_but_objects_are_missing() {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+        conn.execute_batch(
+            "DROP TABLE entity_id_remap;
+             DROP TABLE server_identity_transition;",
+        )
+        .unwrap();
+
+        prepare_write_connection_for_open(&conn).unwrap();
+
+        let identity_tables: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type = 'table' AND name IN ('entity_id_remap', 'server_identity_transition')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(identity_tables, 2);
+        assert!(identity_probe_cursor_column_exists(&conn).unwrap());
+        assert!(identity_alias_cursor_column_exists(&conn).unwrap());
+    }
+
+    #[test]
+    fn migration_026_adds_tag_cursor_without_rewriting_completion_state() {
+        let conn = Connection::open_in_memory().unwrap();
+        let migrations_through_25: Vec<(i64, &str)> = MIGRATIONS
+            .iter()
+            .copied()
+            .filter(|(version, _)| *version <= 25)
+            .collect();
+        run_migrations_with(
+            &conn,
+            &migrations_through_25,
             LIBRARY_DB_MIN_COMPATIBLE_VERSION,
             handle_breaking_schema_bump,
         )

--- a/src-tauri/crates/psysonic-library/src/store.rs
+++ b/src-tauri/crates/psysonic-library/src/store.rs
@@ -12,7 +12,7 @@ use tauri::Manager;
 ///
 /// Migration checklist (wiring, data backfill, open/swap path):
 /// psysonic-workdocs `ai/agent-rules/08-library-db-migrations.md`.
-pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 26;
+pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 27;
 
 /// One-time data repair after migration 014 (`artist.name_sort`).
 pub(crate) const ARTIST_NAME_SORT_RECONCILE_ID: &str = "artist_name_sort_reconcile_v1";
@@ -89,6 +89,9 @@ pub(crate) const MIGRATION_025_IDENTITY_INVALIDATION: &str =
 /// Version 26: resumable cursor for bounded post-sync library tagging.
 pub(crate) const MIGRATION_026_LIBRARY_TAG_CURSOR: &str =
     include_str!("../migrations/026_library_tag_cursor.sql");
+/// Version 27: durable Navidrome canonical-ID transition state and entity remap journal.
+pub(crate) const MIGRATION_027_NAVIDROME_CANONICAL_IDS: &str =
+    include_str!("../migrations/027_navidrome_canonical_ids.sql");
 
 /// Embedded migrations. Ordered ascending by `version`; the runner sorts
 /// defensively before applying so the source order can stay readable.
@@ -109,6 +112,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (24, MIGRATION_024_COMPOSER_BROWSE_PROJECTION),
     (25, MIGRATION_025_IDENTITY_INVALIDATION),
     (26, MIGRATION_026_LIBRARY_TAG_CURSOR),
+    (27, MIGRATION_027_NAVIDROME_CANONICAL_IDS),
 ];
 
 /// Idempotent repair — also runs after the migration runner on every open so
@@ -1150,13 +1154,14 @@ fn reconcile_ready_rows_with_ingest_cursors(conn: &Connection) -> rusqlite::Resu
 
     let tx = conn.unchecked_transaction()?;
     for (server_id, library_scope, raw_cursor) in candidates {
-        let has_ingest_cursor = raw_cursor.as_deref().is_some_and(|raw| {
-            match serde_json::from_str::<serde_json::Value>(raw) {
-                Ok(serde_json::Value::Object(cursor)) => !cursor.is_empty(),
-                Ok(serde_json::Value::Null) => false,
-                Ok(_) | Err(_) => true,
-            }
-        });
+        let has_ingest_cursor =
+            raw_cursor.as_deref().is_some_and(|raw| {
+                match serde_json::from_str::<serde_json::Value>(raw) {
+                    Ok(serde_json::Value::Object(cursor)) => !cursor.is_empty(),
+                    Ok(serde_json::Value::Null) => false,
+                    Ok(_) | Err(_) => true,
+                }
+            });
         if !has_ingest_cursor {
             continue;
         }
@@ -2126,7 +2131,10 @@ mod tests {
         assert_eq!(trigger_count, 3);
         assert_eq!(fts_matches, 1, "open repair rebuilds missed FTS rows");
         assert_eq!(cursor, "{}", "ready rows cannot retain ingest cursors");
-        assert_eq!(local_count, 2, "repair refreshes the persisted count snapshot");
+        assert_eq!(
+            local_count, 2,
+            "repair refreshes the persisted count snapshot"
+        );
         reopened
             .verify_operational_schema()
             .expect("reopened database satisfies backup-import health checks");

--- a/src-tauri/crates/psysonic-library/src/sync/album_metadata.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/album_metadata.rs
@@ -37,9 +37,44 @@ pub(crate) fn upsert_album_from_get_album(
     let song_count = album
         .song_count
         .or(Some(album.song.len() as i64));
-    store
+    let transition = store
         .with_conn_mut("sync.upsert_album_metadata", |conn| {
-            conn.execute(
+            let tx = conn.transaction()?;
+            let identity_guard =
+                crate::navidrome_identity::load_deterministic_write_guard(&tx, server_id)?;
+            if let Some(old_id) =
+                crate::navidrome_identity::find_deterministic_legacy_id_with_guard(
+                    &tx,
+                    server_id,
+                    &identity_guard,
+                    crate::navidrome_identity::EntityKind::Album,
+                    &album.id,
+                )?
+            {
+                crate::navidrome_identity::record_deterministic_transition_if_legacy_state(
+                    &tx,
+                    server_id,
+                    "album",
+                    &old_id,
+                    &album.id,
+                )?;
+                tx.commit()?;
+                return Ok(Some(old_id));
+            }
+            crate::navidrome_identity::register_inactive_legacy_aliases(
+                &tx,
+                server_id,
+                &identity_guard,
+                std::iter::once((
+                    crate::navidrome_identity::EntityKind::Album,
+                    album.id.as_str(),
+                ))
+                .chain(album.artist_id.as_deref().map(|id| {
+                    (crate::navidrome_identity::EntityKind::Artist, id)
+                })),
+                synced_at,
+            )?;
+            tx.execute(
                 "INSERT INTO album (
                    server_id, id, name, artist, artist_id, song_count, duration_sec,
                    year, genre, cover_art_id, starred_at, synced_at, raw_json
@@ -73,9 +108,17 @@ pub(crate) fn upsert_album_from_get_album(
                     starred_flag,
                 ],
             )?;
-            Ok(())
+            tx.commit()?;
+            Ok(None)
         })
-        .map_err(SyncError::Storage)
+        .map_err(SyncError::Storage)?;
+    if let Some(old_id) = transition {
+        return Err(SyncError::IdentityTransition(format!(
+            "server `{server_id}` changed album id `{old_id}` to canonical id `{}`; migration required",
+            album.id
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -198,5 +241,118 @@ mod tests {
             artist_id.is_none(),
             "stale artist_id must not persist when getAlbum omits it"
         );
+    }
+
+    #[test]
+    fn canonical_album_transition_is_recorded_before_insert() {
+        let store = LibraryStore::open_in_memory();
+        let old = "11112222333344445555666677778888";
+        let new = crate::navidrome_identity::canonical_id(old);
+        store
+            .with_conn_mut("test.seed_legacy_album_state", |conn| {
+                conn.execute(
+                    "INSERT INTO album(server_id,id,name,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Legacy',1,'{}')",
+                    params![old],
+                )?;
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, detected_at) \
+                     VALUES ('s1',?1,'legacy',1)",
+                    params![crate::navidrome_identity::CANONICAL_ID_VERSION],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        let album = Album {
+            id: new.clone(),
+            name: "Canonical".into(),
+            artist: None,
+            artist_id: None,
+            song_count: Some(0),
+            duration: None,
+            year: None,
+            genre: None,
+            cover_art: None,
+            song: vec![],
+        };
+
+        let error = upsert_album_from_get_album(
+            &store,
+            "s1",
+            &album,
+            &serde_json::json!({ "id": new, "name": "Canonical" }),
+            2,
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, SyncError::IdentityTransition(_)));
+        store
+            .with_read_conn(|conn| {
+                let canonical_exists: bool = conn.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM album WHERE server_id = 's1' AND id = ?1)",
+                    params![new],
+                    |row| row.get(0),
+                )?;
+                assert!(!canonical_exists);
+                let remap: (String, i64) = conn.query_row(
+                    "SELECT new_id, active FROM entity_id_remap \
+                     WHERE server_id = 's1' AND entity_kind = 'album' AND old_id = ?1",
+                    params![old],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )?;
+                assert_eq!(remap, (new.clone(), 0));
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn unrelated_album_id_change_is_not_treated_as_canonical_transition() {
+        let store = LibraryStore::open_in_memory();
+        seed_album_with_artist(&store, "Artist", "ar_old");
+        store
+            .with_conn_mut("test.seed_legacy_state", |conn| {
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, detected_at) \
+                     VALUES ('s1',?1,'legacy',1)",
+                    params![crate::navidrome_identity::CANONICAL_ID_VERSION],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        let album = Album {
+            id: "al-unrelated".into(),
+            name: "Unrelated".into(),
+            artist: None,
+            artist_id: None,
+            song_count: Some(0),
+            duration: None,
+            year: None,
+            genre: None,
+            cover_art: None,
+            song: vec![],
+        };
+
+        upsert_album_from_get_album(
+            &store,
+            "s1",
+            &album,
+            &serde_json::json!({ "id": "al-unrelated", "name": "Unrelated" }),
+            2,
+        )
+        .unwrap();
+
+        let exists = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM album WHERE server_id = 's1' AND id = 'al-unrelated')",
+                    [],
+                    |row| row.get::<_, bool>(0),
+                )
+            })
+            .unwrap();
+        assert!(exists);
     }
 }

--- a/src-tauri/crates/psysonic-library/src/sync/artist_index.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/artist_index.rs
@@ -26,9 +26,15 @@ pub fn apply_artist_index(
         .set_ignored_articles(server_id, library_scope, ignored)
         .map_err(SyncError::Storage)?;
     let repo = ArtistRepository::new(store);
-    let confirmed = repo
+    let (confirmed, transition) = repo
         .upsert_index(server_id, index, synced_at)
         .map_err(SyncError::Storage)?;
+    if let Some(transition) = transition {
+        return Err(SyncError::IdentityTransition(format!(
+            "server `{}` changed artist id `{}` to canonical id `{}`; migration required",
+            transition.server_id, transition.old_id, transition.new_id
+        )));
+    }
     repo.backfill_from_tracks(server_id, ignored, synced_at).map_err(SyncError::Storage)?;
     if let Some(ms) = index.last_modified_ms {
         sync_state

--- a/src-tauri/crates/psysonic-library/src/sync/census.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/census.rs
@@ -650,12 +650,18 @@ impl<'a> AlbumCensusRunner<'a> {
         // Servers that rebuild their id space on rescan hand back the same
         // music under new ids. Without the remap the census would insert a
         // second copy of the catalogue and leave the first one live.
-        repo.upsert_batch_with_remap(
+        let stats = repo.upsert_delta_batch_with_remap(
             &rows,
             self.capability_flags
                 .contains(CapabilityFlags::UNSTABLE_TRACK_IDS),
         )
         .map_err(SyncError::Storage)?;
+        if let Some(transition) = stats.identity_transition {
+            return Err(SyncError::IdentityTransition(format!(
+                "server `{}` changed track id `{}` to canonical id `{}` during census ingest; migration required",
+                transition.server_id, transition.old_id, transition.new_id
+            )));
+        }
 
         // Deliberately no track-level sweep here. A `getAlbum` response is
         // authoritative only for what this request can see: on a server with
@@ -1403,6 +1409,60 @@ mod tests {
             2,
             "the delta cannot reach below its watermark; the census can"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn gap_fill_blocks_child_track_canonical_transition_with_unchanged_album_id() {
+        let server = MockServer::start().await;
+        let store = LibraryStore::open_in_memory();
+        mark_ready(&store);
+        let old_track = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new_track = canonical_id(old_track);
+        store
+            .with_conn("test.seed_legacy_identity_state", |conn| {
+                conn.execute(
+                    "INSERT INTO track (server_id, id, title, album, album_id, duration_sec, \
+                     deleted, synced_at, raw_json) \
+                     VALUES ('s1', ?1, 'Title', 'Album', 'al-gap', 100, 0, 1, '{}')",
+                    rusqlite::params![old_track],
+                )?;
+                conn.execute(
+                    "INSERT INTO album(server_id,id,name,synced_at,raw_json) \
+                     VALUES ('s1','al-gap','Album',1,'{}')",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, probe_old_id, probe_new_id, detected_at) \
+                     VALUES ('s1',?1,'legacy',?2,?3,1)",
+                    rusqlite::params![
+                        crate::navidrome_identity::CANONICAL_ID_VERSION,
+                        old_track,
+                        new_track
+                    ],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        mount_album_list(&server, vec![album_summary("al-gap", 1, 100)]).await;
+        mount_album_present(&server, "al-gap", &[&new_track]).await;
+
+        let error = AlbumCensusRunner::new(&store, &test_subsonic(&server.uri()), "s1")
+            .with_sleep_disabled()
+            .run()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, SyncError::IdentityTransition(_)));
+        assert_eq!(transition_status(&store, "s1").unwrap().state, "transition_detected");
+        let ids: Vec<String> = store
+            .with_read_conn(|conn| {
+                conn.prepare("SELECT id FROM track WHERE server_id = 's1' ORDER BY id")?
+                    .query_map([], |row| row.get(0))?
+                    .collect()
+            })
+            .unwrap();
+        assert_eq!(ids, vec![old_track.to_string()]);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src-tauri/crates/psysonic-library/src/sync/census.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/census.rs
@@ -39,6 +39,9 @@ use super::ingest_parallel::{
 };
 use super::mapping::album_track_rows;
 use super::now_unix_ms;
+use crate::navidrome_identity::{
+    resolve_unexpected_not_found, EntityKind, TargetedNotFoundOutcome,
+};
 use crate::repos::TrackRepository;
 use crate::store::LibraryStore;
 
@@ -321,7 +324,8 @@ impl<'a> AlbumCensusRunner<'a> {
         if phase.as_deref() != Some("ready") {
             return Ok(CensusReport::default());
         }
-        let local = local_album_inventory(self.store, &self.server_id).map_err(SyncError::Storage)?;
+        let local =
+            local_album_inventory(self.store, &self.server_id).map_err(SyncError::Storage)?;
         let mut report = CensusReport {
             local_albums: local.len(),
             ..CensusReport::default()
@@ -397,9 +401,7 @@ impl<'a> AlbumCensusRunner<'a> {
             .min(self.probe_cap.saturating_sub(to_remove_len));
         let mut spare = self.probe_cap.saturating_sub(to_remove_len + to_fill_len);
         let to_remove_len = to_remove_len + spare.min(removable.len() - to_remove_len);
-        spare = self
-            .probe_cap
-            .saturating_sub(to_remove_len + to_fill_len);
+        spare = self.probe_cap.saturating_sub(to_remove_len + to_fill_len);
         let to_fill_len = to_fill_len + spare.min(diff.missing_locally.len() - to_fill_len);
 
         let to_remove: Vec<String> = removable[..to_remove_len].to_vec();
@@ -418,8 +420,10 @@ impl<'a> AlbumCensusRunner<'a> {
                 break;
             }
             self.check_cancellation()?;
-            wait_while_bulk_paused(&self.budget, self.sleep_enabled, || self.check_cancellation())
-                .await?;
+            wait_while_bulk_paused(&self.budget, self.sleep_enabled, || {
+                self.check_cancellation()
+            })
+            .await?;
             sleep_request_gap(&self.budget, self.sleep_enabled).await;
             if self.deadline_reached() {
                 report.budget_exhausted = true;
@@ -435,13 +439,41 @@ impl<'a> AlbumCensusRunner<'a> {
                 break;
             };
             match result {
-                Err(SubsonicError::NotFound) => confirmed_gone.push(album_id.clone()),
+                Err(SubsonicError::NotFound) => {
+                    let Some(outcome) = self
+                        .await_before_deadline(resolve_unexpected_not_found(
+                            self.store,
+                            self.subsonic,
+                            &self.server_id,
+                            EntityKind::Album,
+                            album_id,
+                        ))
+                        .await
+                    else {
+                        report.budget_exhausted = true;
+                        report.deferred += to_remove.len() - index;
+                        break;
+                    };
+                    match outcome.map_err(SyncError::IdentityTransition)? {
+                        TargetedNotFoundOutcome::ConfirmedMissing => {
+                            confirmed_gone.push(album_id.clone());
+                        }
+                        TargetedNotFoundOutcome::TransitionDetected => {
+                            return Err(SyncError::IdentityTransition(
+                                "canonical-ID transition detected while verifying an album"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                }
                 Ok(_) => {}
                 // One album that could not be asked is one album left for the
                 // next pass, not a reason to throw away the removals already
                 // applied and the gap work still to come.
                 Err(other) => {
-                    crate::app_eprintln!("[library-sync] census could not confirm an album: {other}");
+                    crate::app_eprintln!(
+                        "[library-sync] census could not confirm an album: {other}"
+                    );
                     report.deferred += 1;
                 }
             }
@@ -471,8 +503,10 @@ impl<'a> AlbumCensusRunner<'a> {
                 break;
             }
             self.check_cancellation()?;
-            wait_while_bulk_paused(&self.budget, self.sleep_enabled, || self.check_cancellation())
-                .await?;
+            wait_while_bulk_paused(&self.budget, self.sleep_enabled, || {
+                self.check_cancellation()
+            })
+            .await?;
             sleep_request_gap(&self.budget, self.sleep_enabled).await;
             if self.deadline_reached() {
                 report.budget_exhausted = true;
@@ -518,8 +552,10 @@ impl<'a> AlbumCensusRunner<'a> {
                 return Ok(AlbumEnumeration::BudgetExhausted);
             }
             self.check_cancellation()?;
-            wait_while_bulk_paused(&self.budget, self.sleep_enabled, || self.check_cancellation())
-                .await?;
+            wait_while_bulk_paused(&self.budget, self.sleep_enabled, || {
+                self.check_cancellation()
+            })
+            .await?;
             sleep_request_gap(&self.budget, self.sleep_enabled).await;
             if self.deadline_reached() {
                 return Ok(AlbumEnumeration::BudgetExhausted);
@@ -644,7 +680,8 @@ impl<'a> AlbumCensusRunner<'a> {
     }
 
     fn deadline_reached(&self) -> bool {
-        self.deadline.is_some_and(|deadline| Instant::now() >= deadline)
+        self.deadline
+            .is_some_and(|deadline| Instant::now() >= deadline)
     }
 
     /// Bound the in-flight future as well as the gaps between requests. Without
@@ -675,6 +712,7 @@ enum AlbumEnumeration {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::navidrome_identity::{canonical_id, transition_status};
 
     fn entry(id: &str, songs: i64, duration: i64) -> AlbumInventoryEntry {
         AlbumInventoryEntry {
@@ -754,12 +792,20 @@ mod tests {
     fn the_cap_refuses_a_run_that_would_gut_the_library() {
         // 3000 of 12,746 albums is not a user deleting music between two
         // passes; it is an enumeration that went wrong.
-        assert!(!removal_is_within_cap(3_000, 12_746, CENSUS_REMOVAL_CAP_PERCENT));
+        assert!(!removal_is_within_cap(
+            3_000,
+            12_746,
+            CENSUS_REMOVAL_CAP_PERCENT
+        ));
     }
 
     #[test]
     fn the_cap_lets_an_ordinary_cleanup_through() {
-        assert!(removal_is_within_cap(30, 12_746, CENSUS_REMOVAL_CAP_PERCENT));
+        assert!(removal_is_within_cap(
+            30,
+            12_746,
+            CENSUS_REMOVAL_CAP_PERCENT
+        ));
         assert!(removal_is_within_cap(0, 0, CENSUS_REMOVAL_CAP_PERCENT));
     }
 
@@ -930,7 +976,10 @@ mod tests {
 
         assert!(report.budget_exhausted);
         assert!(report.enumeration_incomplete);
-        assert_eq!(report.deferred, 0, "the runner does not know a resumable backlog yet");
+        assert_eq!(
+            report.deferred, 0,
+            "the runner does not know a resumable backlog yet"
+        );
         assert_eq!(live_rows(&store, "al-1"), 1);
     }
 
@@ -1017,10 +1066,17 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         mark_ready(&store);
         for index in 0..10 {
-            seed_album(&store, &format!("al-{index}"), &[&format!("t-{index}")], 100);
+            seed_album(
+                &store,
+                &format!("al-{index}"),
+                &[&format!("t-{index}")],
+                100,
+            );
         }
         // The server still lists nine of the ten.
-        let listed: Vec<_> = (0..9).map(|i| album_summary(&format!("al-{i}"), 1, 100)).collect();
+        let listed: Vec<_> = (0..9)
+            .map(|i| album_summary(&format!("al-{i}"), 1, 100))
+            .collect();
         mount_album_list(&server, listed).await;
         mount_album_gone(&server, "al-9").await;
 
@@ -1036,14 +1092,58 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn canonical_fallback_aborts_before_tombstoning_a_legacy_album() {
+        let server = MockServer::start().await;
+        let store = LibraryStore::open_in_memory();
+        mark_ready(&store);
+        let old = "00112233445566778899aabbccddeeff";
+        let new = canonical_id(old);
+        seed_album(&store, old, &["t-old"], 100);
+        for index in 0..9 {
+            seed_album(
+                &store,
+                &format!("al-{index}"),
+                &[&format!("t-{index}")],
+                100,
+            );
+        }
+        let listed: Vec<_> = (0..9)
+            .map(|index| album_summary(&format!("al-{index}"), 1, 100))
+            .collect();
+        mount_album_list(&server, listed).await;
+        mount_album_gone(&server, old).await;
+        mount_album_present(&server, &new, &["t-old"]).await;
+
+        let error = AlbumCensusRunner::new(&store, &test_subsonic(&server.uri()), "s1")
+            .with_sleep_disabled()
+            .run()
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, SyncError::IdentityTransition(_)));
+        assert_eq!(live_rows(&store, old), 1);
+        assert_eq!(
+            transition_status(&store, "s1").unwrap().state,
+            "transition_detected"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn an_album_missing_from_the_page_run_but_still_there_is_not_touched() {
         let server = MockServer::start().await;
         let store = LibraryStore::open_in_memory();
         mark_ready(&store);
         for index in 0..10 {
-            seed_album(&store, &format!("al-{index}"), &[&format!("t-{index}")], 100);
+            seed_album(
+                &store,
+                &format!("al-{index}"),
+                &[&format!("t-{index}")],
+                100,
+            );
         }
-        let listed: Vec<_> = (0..9).map(|i| album_summary(&format!("al-{i}"), 1, 100)).collect();
+        let listed: Vec<_> = (0..9)
+            .map(|i| album_summary(&format!("al-{i}"), 1, 100))
+            .collect();
         mount_album_list(&server, listed).await;
         // The enumeration skipped it, but the album is alive and well.
         mount_album_present(&server, "al-9", &["t-9"]).await;
@@ -1087,7 +1187,12 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         mark_ready(&store);
         for index in 0..20 {
-            seed_album(&store, &format!("al-{index}"), &[&format!("t-{index}")], 100);
+            seed_album(
+                &store,
+                &format!("al-{index}"),
+                &[&format!("t-{index}")],
+                100,
+            );
         }
         // Only one album survives the enumeration — nineteen of twenty exceeds
         // both the percentage cap and the small-library floor.
@@ -1113,7 +1218,12 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         mark_ready(&store);
         for index in 0..20 {
-            seed_album(&store, &format!("al-{index:03}"), &[&format!("t-{index}")], 100);
+            seed_album(
+                &store,
+                &format!("al-{index:03}"),
+                &[&format!("t-{index}")],
+                100,
+            );
         }
         // Two removals and two gaps, against a cap of three.
         let mut listed: Vec<_> = (2..20)
@@ -1140,7 +1250,10 @@ mod tests {
             3,
             "a cap of three means three probes, not four"
         );
-        assert_eq!(report.deferred, 1, "the fourth candidate is named, not spent");
+        assert_eq!(
+            report.deferred, 1,
+            "the fourth candidate is named, not spent"
+        );
     }
 
     /// An album the server itself reports as empty can never produce a track
@@ -1182,7 +1295,12 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         mark_ready(&store);
         for index in 0..100 {
-            seed_album(&store, &format!("al-{index:03}"), &[&format!("t-{index}")], 100);
+            seed_album(
+                &store,
+                &format!("al-{index:03}"),
+                &[&format!("t-{index}")],
+                100,
+            );
         }
         // Ten of a hundred are gone: well inside the removal cap, well above
         // the probe cap this run is given.
@@ -1201,9 +1319,15 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(!report.removal_refused, "ten of a hundred is an ordinary cleanup");
+        assert!(
+            !report.removal_refused,
+            "ten of a hundred is an ordinary cleanup"
+        );
         assert_eq!(report.albums_removed, 3, "one run spends its cap and stops");
-        assert_eq!(report.deferred, 7, "the rest is named, not silently dropped");
+        assert_eq!(
+            report.deferred, 7,
+            "the rest is named, not silently dropped"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1212,11 +1336,18 @@ mod tests {
         let store = LibraryStore::open_in_memory();
         mark_ready(&store);
         for index in 0..9 {
-            seed_album(&store, &format!("al-{index}"), &[&format!("t-{index}")], 100);
+            seed_album(
+                &store,
+                &format!("al-{index}"),
+                &[&format!("t-{index}")],
+                100,
+            );
         }
         // An album row with no live tracks behind it: nothing to tombstone.
         seed_album(&store, "al-stale", &[], 0);
-        let listed: Vec<_> = (0..9).map(|i| album_summary(&format!("al-{i}"), 1, 100)).collect();
+        let listed: Vec<_> = (0..9)
+            .map(|i| album_summary(&format!("al-{i}"), 1, 100))
+            .collect();
         mount_album_list(&server, listed).await;
         mount_album_gone(&server, "al-stale").await;
 
@@ -1407,9 +1538,11 @@ mod tests {
                     conn.query_row("SELECT raw_json FROM album WHERE id = 'al-2'", [], |row| {
                         row.get(0)
                     })?,
-                    conn.query_row("SELECT starred_at FROM album WHERE id = 'al-2'", [], |row| {
-                        row.get(0)
-                    })?,
+                    conn.query_row(
+                        "SELECT starred_at FROM album WHERE id = 'al-2'",
+                        [],
+                        |row| row.get(0),
+                    )?,
                     conn.query_row("SELECT title_sort FROM track WHERE id = 't-2'", [], |row| {
                         row.get(0)
                     })?,

--- a/src-tauri/crates/psysonic-library/src/sync/delta.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/delta.rs
@@ -164,6 +164,15 @@ impl<'a> DeltaSyncRunner<'a> {
         sync_state
             .ensure(&self.server_id, &self.library_scope)
             .map_err(SyncError::Storage)?;
+        crate::navidrome_identity::revalidate_before_ingest(
+            self.store,
+            self.subsonic,
+            &self.server_id,
+        )
+        .await
+        .map_err(SyncError::IdentityTransition)?;
+        crate::navidrome_identity::assert_sync_ready(self.store, &self.server_id)
+            .map_err(SyncError::IdentityTransition)?;
 
         let mut report = DeltaSyncReport::default();
 
@@ -204,6 +213,16 @@ impl<'a> DeltaSyncRunner<'a> {
             self.stamp_last_delta(&sync_state)?;
             return Ok(report);
         }
+
+        crate::navidrome_identity::revalidate_before_ingest(
+            self.store,
+            self.subsonic,
+            &self.server_id,
+        )
+        .await
+        .map_err(SyncError::IdentityTransition)?;
+        crate::navidrome_identity::assert_sync_ready(self.store, &self.server_id)
+            .map_err(SyncError::IdentityTransition)?;
 
         // DS-4 — targeted ingest. Strategy choice matches initial sync
         // but S1 is skipped: `search3` doesn't carry a delta semantic.
@@ -319,8 +338,14 @@ impl<'a> DeltaSyncRunner<'a> {
 
     fn write_batch(&self, rows: &[TrackRow]) -> Result<(u32, u32), SyncError> {
         let stats = TrackRepository::new(self.store)
-            .upsert_batch_with_remap(rows, self.unstable_track_ids())
+            .upsert_delta_batch_with_remap(rows, self.unstable_track_ids())
             .map_err(SyncError::Storage)?;
+        if let Some(transition) = stats.identity_transition {
+            return Err(SyncError::IdentityTransition(format!(
+                "server `{}` changed track id `{}` to canonical id `{}`; migration required",
+                transition.server_id, transition.old_id, transition.new_id
+            )));
+        }
         Ok((rows.len() as u32, stats.remapped.len() as u32))
     }
 
@@ -691,6 +716,211 @@ mod tests {
             .unwrap();
     }
 
+    #[test]
+    fn delta_canonical_transition_aborts_before_unstable_id_remap() {
+        let store = LibraryStore::open_in_memory();
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = crate::navidrome_identity::canonical_id(old);
+        let mut existing = TrackRow {
+            server_id: "s1".into(),
+            id: old.into(),
+            title: "old".into(),
+            title_sort: None,
+            artist: None,
+            artist_id: None,
+            album: "A".into(),
+            album_id: Some("album".into()),
+            album_artist: None,
+            duration_sec: 240,
+            track_number: None,
+            disc_number: None,
+            year: None,
+            genre: None,
+            suffix: None,
+            bit_rate: None,
+            size_bytes: None,
+            cover_art_id: None,
+            starred_at: None,
+            user_rating: None,
+            play_count: None,
+            played_at: None,
+            server_path: Some("/music/track.flac".into()),
+            library_id: None,
+            isrc: None,
+            mbid_recording: None,
+            bpm: None,
+            replay_gain_track_db: None,
+            replay_gain_album_db: None,
+            replay_gain_peak: None,
+            content_hash: Some("same-content".into()),
+            server_updated_at: Some(1),
+            server_created_at: None,
+            deleted: false,
+            synced_at: 1,
+            raw_json: "{}".into(),
+        };
+        TrackRepository::new(&store)
+            .upsert_batch(std::slice::from_ref(&existing))
+            .unwrap();
+        store
+            .with_conn("test.seed_identity_state", |conn| {
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, detected_at) \
+                     VALUES ('s1', 1, 'no_legacy_ids', 1)",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT INTO track_offline(server_id,track_id,local_path,cached_at) \
+                     VALUES ('s1',?1,'/offline/track.flac',1)",
+                    rusqlite::params![old],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        existing.id = new.clone();
+        existing.title = "canonical".into();
+        existing.synced_at = 2;
+
+        let subsonic = test_subsonic("http://127.0.0.1:1");
+        let runner = DeltaSyncRunner::new(
+            &store,
+            &subsonic,
+            "s1",
+            "",
+            flags(CapabilityFlags::UNSTABLE_TRACK_IDS),
+        );
+        let error = runner.write_batch(&[existing]).unwrap_err();
+
+        assert!(matches!(error, SyncError::IdentityTransition(_)));
+        store
+            .with_read_conn(|conn| {
+                let ids: Vec<String> = conn
+                    .prepare("SELECT id FROM track WHERE server_id = 's1' ORDER BY id")?
+                    .query_map([], |row| row.get(0))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                assert_eq!(ids, vec![old.to_string()]);
+                let offline_id: String = conn.query_row(
+                    "SELECT track_id FROM track_offline WHERE server_id = 's1'",
+                    [],
+                    |row| row.get(0),
+                )?;
+                assert_eq!(offline_id, old);
+                let history_count: i64 =
+                    conn.query_row("SELECT COUNT(*) FROM track_id_history", [], |row| row.get(0))?;
+                assert_eq!(history_count, 0);
+                let remap: (String, i64) = conn.query_row(
+                    "SELECT new_id, active FROM entity_id_remap \
+                     WHERE server_id = 's1' AND entity_kind = 'track' AND old_id = ?1",
+                    rusqlite::params![old],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )?;
+                assert_eq!(remap, (new.clone(), 0));
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(
+            crate::navidrome_identity::transition_status(&store, "s1")
+                .unwrap()
+                .state,
+            "transition_detected"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn delta_revalidates_namespace_before_ingest_without_remap_keys() {
+        let server = MockServer::start().await;
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = crate::navidrome_identity::canonical_id(old);
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getArtists.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "artists": {
+                        "lastModified": 1_716_840_000_000_i64,
+                        "ignoredArticles": "",
+                        "index": []
+                    }
+                }
+            })))
+            .expect(0)
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getSong.view"))
+            .and(query_param("id", old))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "failed",
+                    "error": { "code": 70, "message": "Song not found" }
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getSong.view"))
+            .and(query_param("id", new.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "song": { "id": new, "title": "Canonical" }
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/api/song"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "id": new,
+                "title": "Canonical",
+                "updatedAt": "2024-06-03T00:00:00Z"
+            }])))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, old, "album", 1_000);
+        let subsonic = test_subsonic(&server.uri());
+        let error = DeltaSyncRunner::new(
+            &store,
+            &subsonic,
+            "s1",
+            "",
+            flags(
+                CapabilityFlags::NAVIDROME_NATIVE_BULK
+                    | CapabilityFlags::UNSTABLE_TRACK_IDS,
+            ),
+        )
+        .with_navidrome_credentials(NavidromeProbeCredentials {
+            server_url: server.uri(),
+            bearer_token: "nd-tok".into(),
+        })
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, SyncError::IdentityTransition(_)));
+        let ids = store
+            .with_read_conn(|conn| {
+                conn.prepare("SELECT id FROM track WHERE server_id = 's1' ORDER BY id")?
+                    .query_map([], |row| row.get::<_, String>(0))?
+                    .collect::<rusqlite::Result<Vec<_>>>()
+            })
+            .unwrap();
+        assert_eq!(ids, vec![old.to_string()]);
+        assert_eq!(
+            crate::navidrome_identity::transition_status(&store, "s1")
+                .unwrap()
+                .state,
+            "transition_detected"
+        );
+    }
+
     // ── DS-2: getArtists watermark match → short-circuit ─────────────
 
     #[tokio::test(flavor = "multi_thread")]
@@ -966,6 +1196,144 @@ mod tests {
             })
             .unwrap();
         assert_eq!(title, "Known changed");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn s2_album_write_guard_catches_transition_after_preflight() {
+        let server = MockServer::start().await;
+        let old_album = "11112222333344445555666677778888";
+        let new_album = crate::navidrome_identity::canonical_id(old_album);
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getArtists.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "artists": {
+                        "lastModified": 1_716_840_000_000_i64,
+                        "ignoredArticles": "",
+                        "index": []
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getAlbumList2.view"))
+            .and(query_param("type", "newest"))
+            .and(query_param("offset", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "albumList2": { "album": [{ "id": new_album, "name": "Canonical" }] }
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getAlbumList2.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok", "albumList2": { "album": [] } }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getAlbum.view"))
+            .and(query_param("id", new_album.as_str()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(std::time::Duration::from_millis(250))
+                    .set_body_json(json!({
+                        "subsonic-response": {
+                            "status": "ok",
+                            "album": {
+                                "id": new_album,
+                                "name": "Canonical",
+                                "song": []
+                            }
+                        }
+                    })),
+            )
+            .mount(&server)
+            .await;
+
+        let store = Arc::new(LibraryStore::open_in_memory());
+        store
+            .with_conn_mut("test.seed_old_album", |conn| {
+                conn.execute(
+                    "INSERT INTO album(server_id,id,name,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Legacy',1,'{}')",
+                    rusqlite::params![old_album],
+                )?;
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, detected_at) \
+                     VALUES ('s1',?1,'no_legacy_ids',2)",
+                    rusqlite::params![crate::navidrome_identity::CANONICAL_ID_VERSION],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        let runner_store = Arc::clone(&store);
+        let client = test_subsonic(&server.uri());
+        let runner = tokio::spawn(async move {
+            DeltaSyncRunner::new(
+                &runner_store,
+                &client,
+                "s1",
+                "",
+                flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK),
+            )
+            .with_sleep_disabled()
+            .run()
+            .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let started = server
+                    .received_requests()
+                    .await
+                    .unwrap()
+                    .iter()
+                    .any(|request| request.url.path() == "/rest/getAlbum.view");
+                if started {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .unwrap();
+        store
+            .with_conn_mut("test.flip_identity_state", |conn| {
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, detected_at) \
+                     VALUES ('s1',?1,'legacy',1) \
+                     ON CONFLICT(server_id) DO UPDATE SET state = 'legacy'",
+                    rusqlite::params![crate::navidrome_identity::CANONICAL_ID_VERSION],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        let error = runner.await.unwrap().unwrap_err();
+
+        assert!(matches!(error, SyncError::IdentityTransition(_)));
+        let canonical_exists = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM album WHERE server_id = 's1' AND id = ?1)",
+                    rusqlite::params![new_album],
+                    |row| row.get::<_, bool>(0),
+                )
+            })
+            .unwrap();
+        assert!(!canonical_exists);
+        assert_eq!(
+            crate::navidrome_identity::transition_status(&store, "s1")
+                .unwrap()
+                .state,
+            "transition_detected"
+        );
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/sync/error.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/error.rs
@@ -30,11 +30,13 @@ pub enum SyncError {
     /// Persistence layer (SQLite) failure.
     Storage(String),
 
+    /// Canonical-ID evidence changed while sync was validating a locally live
+    /// entity. The caller must stop destructive work until reconciliation runs.
+    IdentityTransition(String),
+
     /// Strategy is enumerated but not implemented for v1
     /// (currently only `S3`).
-    StrategyUnsupported {
-        strategy: &'static str,
-    },
+    StrategyUnsupported { strategy: &'static str },
 
     /// Cancellation token tripped — caller asked us to abort.
     /// Cursor stays where it was so the next run resumes the batch.
@@ -57,6 +59,7 @@ impl fmt::Display for SyncError {
             Self::NotFound => write!(f, "subsonic: not found (code 70)"),
             Self::Navidrome(m) => write!(f, "navidrome: {m}"),
             Self::Storage(m) => write!(f, "storage: {m}"),
+            Self::IdentityTransition(m) => write!(f, "identity transition: {m}"),
             Self::StrategyUnsupported { strategy } => {
                 write!(f, "ingest strategy not supported: {strategy}")
             }
@@ -107,7 +110,11 @@ mod tests {
 
     #[test]
     fn subsonic_api_error_carries_code_through() {
-        let e: SyncError = SubsonicError::Api { code: 40, message: "bad creds".into() }.into();
+        let e: SyncError = SubsonicError::Api {
+            code: 40,
+            message: "bad creds".into(),
+        }
+        .into();
         match e {
             SyncError::Subsonic { code, message } => {
                 assert_eq!(code, 40);
@@ -119,7 +126,8 @@ mod tests {
 
     #[test]
     fn http_status_collapses_into_transport() {
-        let e: SyncError = SubsonicError::HttpStatus(reqwest::StatusCode::SERVICE_UNAVAILABLE).into();
+        let e: SyncError =
+            SubsonicError::HttpStatus(reqwest::StatusCode::SERVICE_UNAVAILABLE).into();
         assert!(matches!(e, SyncError::Transport(ref m) if m.contains("503")));
     }
 

--- a/src-tauri/crates/psysonic-library/src/sync/initial.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/initial.rs
@@ -321,6 +321,16 @@ impl<'a> InitialSyncRunner<'a> {
             .ensure(&self.server_id, &self.library_scope)
             .map_err(SyncError::Storage)?;
 
+        crate::navidrome_identity::revalidate_before_ingest(
+            self.store,
+            self.subsonic,
+            &self.server_id,
+        )
+        .await
+        .map_err(SyncError::IdentityTransition)?;
+        crate::navidrome_identity::assert_sync_ready(self.store, &self.server_id)
+            .map_err(SyncError::IdentityTransition)?;
+
         // IS-1 — phase=initial_sync.
         sync_state
             .set_sync_phase(&self.server_id, &self.library_scope, "initial_sync")
@@ -674,15 +684,22 @@ impl<'a> InitialSyncRunner<'a> {
         sparse_payload: bool,
     ) -> Result<WriteOpTiming, SyncError> {
         let tracks = TrackRepository::new(self.store);
-        if sparse_payload {
+        let (timing, transition) = if sparse_payload {
             tracks
-                .upsert_sparse_batch_initial_ingest_timed(rows, resync_gen)
+                .upsert_sparse_batch_initial_ingest_guarded_timed(rows, resync_gen)
                 .map_err(SyncError::Storage)
         } else {
             tracks
-                .upsert_batch_initial_ingest_timed(rows, resync_gen)
+                .upsert_batch_initial_ingest_guarded_timed(rows, resync_gen)
                 .map_err(SyncError::Storage)
+        }?;
+        if let Some(transition) = transition {
+            return Err(SyncError::IdentityTransition(format!(
+                "server `{}` changed track id `{}` to canonical id `{}`; migration required",
+                transition.server_id, transition.old_id, transition.new_id
+            )));
         }
+        Ok(timing)
     }
 
     fn write_batch_logged(
@@ -1976,6 +1993,208 @@ mod tests {
         assert_eq!(after.synchronous, before.synchronous);
         assert_eq!(after.wal_autocheckpoint, before.wal_autocheckpoint);
         assert_eq!(after.cache_size, before.cache_size);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn full_sync_revalidates_legacy_namespace_before_any_ingest() {
+        let server = MockServer::start().await;
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = crate::navidrome_identity::canonical_id(old);
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getSong.view"))
+            .and(query_param("id", old))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "failed",
+                    "error": { "code": 70, "message": "Song not found" }
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getSong.view"))
+            .and(query_param("id", new.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "song": { "id": new, "title": "Canonical" }
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/search3.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "searchResult3": { "song": [{ "id": new, "title": "Canonical" }] }
+                }
+            })))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let store = LibraryStore::open_in_memory();
+        let mut legacy = test_track_row(old, "Legacy");
+        legacy.synced_at = 1;
+        TrackRepository::new(&store).upsert_batch(&[legacy]).unwrap();
+        store
+            .with_conn_mut("test.seed_legacy_identity", |conn| {
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, probe_old_id, probe_new_id, detected_at) \
+                     VALUES ('s1',?1,'legacy',?2,?3,1)",
+                    rusqlite::params![
+                        crate::navidrome_identity::CANONICAL_ID_VERSION,
+                        old,
+                        new
+                    ],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        let error = InitialSyncRunner::new(
+            &store,
+            &test_subsonic(&server.uri()),
+            "s1",
+            "",
+            flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK),
+        )
+        .with_sleep_disabled()
+        .run()
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, SyncError::IdentityTransition(_)));
+        let ids = store
+            .with_read_conn(|conn| {
+                conn.prepare("SELECT id FROM track WHERE server_id = 's1' ORDER BY id")?
+                    .query_map([], |row| row.get::<_, String>(0))?
+                    .collect::<rusqlite::Result<Vec<_>>>()
+            })
+            .unwrap();
+        assert_eq!(ids, vec![old.to_string()]);
+        assert_eq!(
+            SyncStateRepository::new(&store)
+                .get_initial_sync_cursor("s1", "")
+                .unwrap(),
+            Some(json!({}))
+        );
+    }
+
+    #[test]
+    fn n1_page_guard_blocks_a_mid_crawl_canonical_transition_without_mixed_rows() {
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = crate::navidrome_identity::canonical_id(old);
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn_mut("test.seed_n1_race", |conn| {
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Legacy','Album',1,'{}')",
+                    rusqlite::params![old],
+                )?;
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, detected_at) \
+                     VALUES ('s1',?1,'no_legacy_ids',2)",
+                    rusqlite::params![crate::navidrome_identity::CANONICAL_ID_VERSION],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        let client = test_subsonic("http://127.0.0.1:9");
+        let runner = InitialSyncRunner::new(
+            &store,
+            &client,
+            "s1",
+            "",
+            flags(CapabilityFlags::NAVIDROME_NATIVE_BULK),
+        );
+        runner
+            .write_batch_timed(&[test_track_row("stable-first", "First")], None, false)
+            .unwrap();
+        store
+            .with_conn_mut("test.flip_n1_identity", |conn| {
+                conn.execute(
+                    "UPDATE server_identity_transition SET state = 'legacy' WHERE server_id = 's1'",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        let error = runner
+            .write_batch_timed(&[test_track_row(&new, "Canonical")], None, false)
+            .unwrap_err();
+        assert!(matches!(error, SyncError::IdentityTransition(_)));
+        let ids = store
+            .with_read_conn(|conn| {
+                conn.prepare("SELECT id FROM track WHERE server_id = 's1' ORDER BY id")?
+                    .query_map([], |row| row.get::<_, String>(0))?
+                    .collect::<rusqlite::Result<Vec<_>>>()
+            })
+            .unwrap();
+        assert_eq!(ids, vec![old.to_string(), "stable-first".to_string()]);
+    }
+
+    #[test]
+    fn s1_page_guard_blocks_a_mid_crawl_canonical_transition_without_mixed_rows() {
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = crate::navidrome_identity::canonical_id(old);
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn_mut("test.seed_s1_race", |conn| {
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Legacy','Album',1,'{}')",
+                    rusqlite::params![old],
+                )?;
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, detected_at) \
+                     VALUES ('s1',?1,'no_legacy_ids',2)",
+                    rusqlite::params![crate::navidrome_identity::CANONICAL_ID_VERSION],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        let client = test_subsonic("http://127.0.0.1:9");
+        let runner = InitialSyncRunner::new(
+            &store,
+            &client,
+            "s1",
+            "",
+            flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK),
+        );
+        runner
+            .write_batch_timed(&[test_track_row("stable-first", "First")], None, true)
+            .unwrap();
+        store
+            .with_conn_mut("test.flip_s1_identity", |conn| {
+                conn.execute(
+                    "UPDATE server_identity_transition SET state = 'legacy' WHERE server_id = 's1'",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        let error = runner
+            .write_batch_timed(&[test_track_row(&new, "Canonical")], None, true)
+            .unwrap_err();
+        assert!(matches!(error, SyncError::IdentityTransition(_)));
+        let ids = store
+            .with_read_conn(|conn| {
+                conn.prepare("SELECT id FROM track WHERE server_id = 's1' ORDER BY id")?
+                    .query_map([], |row| row.get::<_, String>(0))?
+                    .collect::<rusqlite::Result<Vec<_>>>()
+            })
+            .unwrap();
+        assert_eq!(ids, vec![old.to_string(), "stable-first".to_string()]);
     }
 
     // ── S1 happy path ──────────────────────────────────────────────────

--- a/src-tauri/crates/psysonic-library/src/sync/scheduler.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/scheduler.rs
@@ -419,6 +419,7 @@ impl<'a> BackgroundScheduler<'a> {
                 // sync_state for a torn-down session is exactly what that
                 // convention prevents.
                 Err(SyncError::Cancelled) => return Err(SyncError::Cancelled),
+                Err(error @ SyncError::IdentityTransition(_)) => return Err(error),
                 Err(error) => {
                     // Any other failure is simply no answer this round; the
                     // delta pass it rode along with has already done its work,
@@ -776,6 +777,108 @@ mod tests {
             stats.next_census_at_ms,
             Some(1_000_000 + CENSUS_INTERVAL_MS),
             "a clean run waits a full interval"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn census_identity_transition_escapes_the_scheduler_tick() {
+        let server = MockServer::start().await;
+        let watermark = 1_716_840_000_000_i64;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getArtists.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "artists": { "lastModified": watermark, "ignoredArticles": "", "index": [] }
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getAlbumList2.view"))
+            .and(wiremock::matchers::query_param("offset", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "albumList2": { "album": [{ "id": "al-gap", "name": "Album", "songCount": 1 }] }
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getAlbumList2.view"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": { "status": "ok", "albumList2": { "album": [] } }
+            })))
+            .mount(&server)
+            .await;
+
+        let old_track = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new_track = crate::navidrome_identity::canonical_id(old_track);
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getAlbum.view"))
+            .and(wiremock::matchers::query_param("id", "al-gap"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "album": {
+                        "id": "al-gap",
+                        "name": "Album",
+                        "songCount": 1,
+                        "song": [{ "id": new_track, "title": "Track", "album": "Album", "albumId": "al-gap" }]
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn("test.seed_scheduler_census_transition", |conn| {
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,album,album_id,synced_at,raw_json) \
+                     VALUES ('s1',?1,'Track','Album','al-gap',1,'{}')",
+                    rusqlite::params![old_track],
+                )?;
+                conn.execute(
+                    "INSERT INTO album(server_id,id,name,synced_at,raw_json) \
+                     VALUES ('s1','al-gap','Album',1,'{}')",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT INTO server_identity_transition \
+                     (server_id, canonical_version, state, detected_at) \
+                     VALUES ('s1',?1,'no_legacy_ids',1)",
+                    rusqlite::params![crate::navidrome_identity::CANONICAL_ID_VERSION],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        let sync_state = SyncStateRepository::new(&store);
+        sync_state.ensure("s1", "").unwrap();
+        sync_state.set_sync_phase("s1", "", "ready").unwrap();
+        sync_state
+            .set_artists_last_modified_ms("s1", "", watermark)
+            .unwrap();
+
+        let error = BackgroundScheduler::new(
+            &store,
+            &test_subsonic(&server.uri()),
+            "s1",
+            "",
+            flags(CapabilityFlags::SUBSONIC_SEARCH3_BULK),
+        )
+        .with_sleep_disabled()
+        .tick(1_000_000)
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, SyncError::IdentityTransition(_)));
+        assert_eq!(
+            crate::navidrome_identity::transition_status(&store, "s1")
+                .unwrap()
+                .state,
+            "transition_detected"
         );
     }
 

--- a/src-tauri/crates/psysonic-library/src/sync/tombstone.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/tombstone.rs
@@ -24,6 +24,9 @@ use psysonic_integration::subsonic::{SubsonicClient, SubsonicError};
 
 use super::backoff::{jitter_salt, with_jitter, Backoff};
 use super::error::SyncError;
+use crate::navidrome_identity::{
+    resolve_unexpected_not_found, EntityKind, TargetedNotFoundOutcome,
+};
 use crate::repos::TrackRepository;
 use crate::store::LibraryStore;
 
@@ -131,8 +134,27 @@ impl<'a> TombstoneReconciler<'a> {
                     alive_ids.push(id);
                 }
                 Err(SyncError::NotFound) => {
-                    deleted_ids.push(id);
-                    report.deleted = report.deleted.saturating_add(1);
+                    match resolve_unexpected_not_found(
+                        self.store,
+                        self.subsonic,
+                        &self.server_id,
+                        EntityKind::Track,
+                        &id,
+                    )
+                    .await
+                    .map_err(SyncError::IdentityTransition)?
+                    {
+                        TargetedNotFoundOutcome::ConfirmedMissing => {
+                            deleted_ids.push(id);
+                            report.deleted = report.deleted.saturating_add(1);
+                        }
+                        TargetedNotFoundOutcome::TransitionDetected => {
+                            return Err(SyncError::IdentityTransition(
+                                "canonical-ID transition detected while verifying a track"
+                                    .to_string(),
+                            ));
+                        }
+                    }
                 }
                 Err(other) => return Err(other),
             }
@@ -325,6 +347,7 @@ fn is_retryable(e: &SyncError) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::navidrome_identity::{canonical_id, transition_status};
     use crate::repos::{TrackRepository, TrackRow};
     use psysonic_integration::subsonic::{SubsonicClient, SubsonicCredentials};
     use serde_json::json;
@@ -481,6 +504,102 @@ mod tests {
             .unwrap();
         assert_eq!(a_deleted, 0);
         assert_eq!(b_deleted, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn canonical_fallback_aborts_before_tombstoning_a_legacy_track() {
+        let server = MockServer::start().await;
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = canonical_id(old);
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getSong.view"))
+            .and(query_param("id", old))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "failed",
+                    "error": { "code": 70, "message": "Song not found" }
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/rest/getSong.view"))
+            .and(query_param("id", new.as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "subsonic-response": {
+                    "status": "ok",
+                    "song": { "id": new, "title": "Still here" }
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, old, 1);
+
+        let error = TombstoneReconciler::new(&store, &test_subsonic(&server.uri()), "s1")
+            .with_sleep_disabled()
+            .reconcile_chunk(10)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, SyncError::IdentityTransition(_)));
+        let deleted: i64 = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT deleted FROM track WHERE server_id = 's1' AND id = ?1",
+                    rusqlite::params![old],
+                    |row| row.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(deleted, 0);
+        assert_eq!(
+            transition_status(&store, "s1").unwrap().state,
+            "transition_detected"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn legacy_track_is_tombstoned_when_both_old_and_canonical_ids_are_missing() {
+        let server = MockServer::start().await;
+        let old = "00112233445566778899aabbccddeeff";
+        let new = canonical_id(old);
+        for id in [old, new.as_str()] {
+            Mock::given(wm_method("GET"))
+                .and(wm_path("/rest/getSong.view"))
+                .and(query_param("id", id))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "subsonic-response": {
+                        "status": "failed",
+                        "error": { "code": 70, "message": "Song not found" }
+                    }
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+        }
+        let store = LibraryStore::open_in_memory();
+        seed_track(&store, old, 1);
+
+        let report = TombstoneReconciler::new(&store, &test_subsonic(&server.uri()), "s1")
+            .with_sleep_disabled()
+            .reconcile_chunk(10)
+            .await
+            .unwrap();
+
+        assert_eq!(report.deleted, 1);
+        let deleted: i64 = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT deleted FROM track WHERE server_id = 's1' AND id = ?1",
+                    rusqlite::params![old],
+                    |row| row.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(deleted, 1);
     }
 
     // ── reconcile_chunk respects budget and ordering ─────────────────

--- a/src-tauri/crates/psysonic-syncfs/src/cache/local.rs
+++ b/src-tauri/crates/psysonic-syncfs/src/cache/local.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant, SystemTime};
 
 use psysonic_analysis::analysis_runtime::enqueue_offline_library_analysis_from_file;
 use psysonic_audio as audio;
@@ -148,6 +149,76 @@ fn track_download_locks(
     LOCKS.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()))
 }
 
+fn library_tier_mutation_locks(
+) -> &'static tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::RwLock<()>>>> {
+    static LOCKS: OnceLock<tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::RwLock<()>>>>> =
+        OnceLock::new();
+    LOCKS.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()))
+}
+
+fn persistent_tier_mutation_locks(
+) -> &'static tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::RwLock<()>>>> {
+    static LOCKS: OnceLock<tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::RwLock<()>>>>> =
+        OnceLock::new();
+    LOCKS.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()))
+}
+
+async fn persistent_tier_mutation_lock(tier: LocalTier) -> Arc<tokio::sync::RwLock<()>> {
+    let mut locks = persistent_tier_mutation_locks().lock().await;
+    locks
+        .entry(tier.subdir().to_string())
+        .or_insert_with(|| Arc::new(tokio::sync::RwLock::new(())))
+        .clone()
+}
+
+fn recent_library_paths() -> &'static std::sync::Mutex<HashMap<String, Instant>> {
+    static PATHS: OnceLock<std::sync::Mutex<HashMap<String, Instant>>> = OnceLock::new();
+    PATHS.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+fn mark_recent_library_path(path: &Path) {
+    if let Ok(mut paths) = recent_library_paths().lock() {
+        paths.insert(normalize_path_key(path), Instant::now());
+    }
+}
+
+fn recent_library_path_keys() -> HashSet<String> {
+    const HANDOFF_GRACE: Duration = Duration::from_secs(30);
+    let Ok(mut paths) = recent_library_paths().lock() else {
+        return HashSet::new();
+    };
+    paths.retain(|_, marked_at| marked_at.elapsed() <= HANDOFF_GRACE);
+    paths.keys().cloned().collect()
+}
+
+fn is_recent_library_path(path: &Path) -> bool {
+    recent_library_path_keys().contains(&normalize_path_key(path))
+}
+
+async fn library_tier_mutation_lock(server_index_key: &str) -> Arc<tokio::sync::RwLock<()>> {
+    let mut locks = library_tier_mutation_locks().lock().await;
+    locks
+        .entry(sanitize_path_segment(server_index_key))
+        .or_insert_with(|| Arc::new(tokio::sync::RwLock::new(())))
+        .clone()
+}
+
+fn library_server_segment_for_path(
+    file_path: &Path,
+    media_dir: Option<&str>,
+    app: &AppHandle,
+) -> Option<String> {
+    let library_root = resolve_media_dir(media_dir, app).ok()?.join(LocalTier::Library.subdir());
+    file_path
+        .strip_prefix(library_root)
+        .ok()?
+        .components()
+        .next()?
+        .as_os_str()
+        .to_str()
+        .map(str::to_string)
+}
+
 async fn acquire_per_track_download_lock(key: &str) -> tokio::sync::OwnedMutexGuard<()> {
     let lock_arc = {
         let mut map = track_download_locks().lock().await;
@@ -273,6 +344,16 @@ pub async fn download_track_local(
     app: AppHandle,
 ) -> Result<LocalTrackDownloadResult, String> {
     let local_tier = LocalTier::parse(&tier).ok_or_else(|| format!("unknown local tier: `{tier}`"))?;
+    let persistent_tier_lock = match local_tier {
+        LocalTier::Library | LocalTier::Favorites => {
+            Some(persistent_tier_mutation_lock(local_tier).await)
+        }
+        LocalTier::Ephemeral => None,
+    };
+    let _persistent_tier_guard = match persistent_tier_lock.as_ref() {
+        Some(lock) => Some(lock.read().await),
+        None => None,
+    };
 
     let resolved = if local_tier == LocalTier::Library || local_tier == LocalTier::Favorites {
         resolve_track_path_for_tier(ResolveTrackPathForTier {
@@ -337,10 +418,22 @@ pub async fn download_track_local(
         client: &client,
         registry: http_registry.as_deref(),
     };
+    let library_tier_lock = if local_tier == LocalTier::Library {
+        Some(library_tier_mutation_lock(&server_index_key).await)
+    } else {
+        None
+    };
+    let _library_tier_guard = match library_tier_lock.as_ref() {
+        Some(lock) => Some(lock.read().await),
+        None => None,
+    };
 
     if !verified_raw_request {
         if let Some(hit) = local_track_hit_if_exists(&local_track_hit_args, false).await?
         {
+            if local_tier == LocalTier::Library {
+                mark_recent_library_path(&file_path);
+            }
             return Ok(hit);
         }
     }
@@ -358,6 +451,9 @@ pub async fn download_track_local(
     )
     .await?
     {
+        if local_tier == LocalTier::Library {
+            mark_recent_library_path(&file_path);
+        }
         return Ok(hit);
     }
 
@@ -457,6 +553,9 @@ pub async fn download_track_local(
         .await
         .map(|m| m.len())
         .unwrap_or(0);
+    if local_tier == LocalTier::Library {
+        mark_recent_library_path(&file_path);
+    }
 
     Ok(LocalTrackDownloadResult {
         path: path_str,
@@ -615,7 +714,12 @@ pub async fn probe_library_track_local(
     })
 }
 
-async fn prune_orphan_files_under_root(root: &Path, keep_paths: &[String]) -> Vec<String> {
+async fn prune_orphan_files_under_root_before(
+    root: &Path,
+    keep_paths: &[String],
+    modified_before: Option<SystemTime>,
+    preserve_recent_library_paths: bool,
+) -> Vec<String> {
     if !root.is_dir() {
         return Vec::new();
     }
@@ -623,9 +727,20 @@ async fn prune_orphan_files_under_root(root: &Path, keep_paths: &[String]) -> Ve
         .iter()
         .map(|p| normalize_path_key(Path::new(p)))
         .collect();
+    let recent = preserve_recent_library_paths
+        .then(recent_library_path_keys)
+        .unwrap_or_default();
     let mut removed = Vec::new();
     for file in super::fs_utils::collect_regular_files_under(root) {
-        if keep.contains(&normalize_path_key(&file)) {
+        let normalized = normalize_path_key(&file);
+        if keep.contains(&normalized) || recent.contains(&normalized) {
+            continue;
+        }
+        if modified_before.is_some_and(|cutoff| {
+            std::fs::metadata(&file)
+                .and_then(|metadata| metadata.modified())
+                .is_ok_and(|modified| modified > cutoff)
+        }) {
             continue;
         }
         if tokio::fs::remove_file(&file).await.is_err() {
@@ -640,6 +755,10 @@ async fn prune_orphan_files_under_root(root: &Path, keep_paths: &[String]) -> Ve
     removed
 }
 
+async fn prune_orphan_files_under_root(root: &Path, keep_paths: &[String]) -> Vec<String> {
+    prune_orphan_files_under_root_before(root, keep_paths, None, false).await
+}
+
 /// Remove library-tier files under `{server_index_key}` that are not listed in `keep_paths`.
 #[tauri::command]
 #[specta::specta]
@@ -649,10 +768,15 @@ pub async fn prune_orphan_library_tier_files(
     media_dir: Option<String>,
     app: AppHandle,
 ) -> Result<Vec<String>, String> {
+    let mutation_lock = library_tier_mutation_lock(&server_index_key).await;
+    let _mutation_guard = mutation_lock.write().await;
     let media_root = resolve_media_dir(media_dir.as_deref(), &app)?;
     let segment = sanitize_path_segment(&server_index_key);
     let root = media_root.join(LocalTier::Library.subdir()).join(segment);
-    Ok(prune_orphan_files_under_root(&root, &keep_paths).await)
+    let cutoff = SystemTime::now()
+        .checked_sub(Duration::from_secs(30))
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    Ok(prune_orphan_files_under_root_before(&root, &keep_paths, Some(cutoff), true).await)
 }
 
 struct OrphanCacheFile {
@@ -786,6 +910,16 @@ pub async fn purge_media_tier(
     app: AppHandle,
 ) -> Result<(), String> {
     let local_tier = LocalTier::parse(&tier).ok_or_else(|| format!("unknown local tier: `{tier}`"))?;
+    let persistent_tier_lock = match local_tier {
+        LocalTier::Library | LocalTier::Favorites => {
+            Some(persistent_tier_mutation_lock(local_tier).await)
+        }
+        LocalTier::Ephemeral => None,
+    };
+    let _persistent_tier_guard = match persistent_tier_lock.as_ref() {
+        Some(lock) => Some(lock.write().await),
+        None => None,
+    };
     let root = resolve_media_tier_root(local_tier, media_dir.as_deref(), &app)?;
     if root.exists() {
         tokio::fs::remove_dir_all(&root)
@@ -824,6 +958,19 @@ pub async fn delete_media_file(
     app: AppHandle,
 ) -> Result<(), String> {
     let file_path = std::path::PathBuf::from(&local_path);
+    let library_lock = library_server_segment_for_path(&file_path, media_dir.as_deref(), &app)
+        .map(|segment| async move { library_tier_mutation_lock(&segment).await });
+    let library_lock = match library_lock {
+        Some(lock) => Some(lock.await),
+        None => None,
+    };
+    let _library_guard = match library_lock.as_ref() {
+        Some(lock) => Some(lock.write().await),
+        None => None,
+    };
+    if library_lock.is_some() && is_recent_library_path(&file_path) {
+        return Ok(());
+    }
     if file_path.is_file() {
         tokio::fs::remove_file(&file_path)
             .await
@@ -1361,6 +1508,8 @@ pub async fn migrate_legacy_offline_disk(
     runtime: State<'_, LibraryRuntime>,
     app: AppHandle,
 ) -> Result<Vec<LegacyOfflineMigrationResult>, String> {
+    let persistent_tier_lock = persistent_tier_mutation_lock(LocalTier::Library).await;
+    let _persistent_tier_guard = persistent_tier_lock.read().await;
     let media_root = resolve_media_dir(media_dir.as_deref(), &app)?;
     let library_boundary = media_root.join(LocalTier::Library.subdir());
     let repo = TrackRepository::new(&runtime.store);
@@ -1396,7 +1545,9 @@ pub async fn migrate_legacy_offline_disk(
             continue;
         }
 
-        out.push(
+        let mutation_lock = library_tier_mutation_lock(&server_index_key).await;
+        let _mutation_guard = mutation_lock.write().await;
+        let result =
             relocate_legacy_track_file(RelocateLegacyTrackFile {
                 track_id: &file.track_id,
                 server_index_key: &server_index_key,
@@ -1407,8 +1558,11 @@ pub async fn migrate_legacy_offline_disk(
                 library_boundary: &library_boundary,
                 app: &app,
             })
-            .await,
-        );
+            .await;
+        if result.relocated {
+            mark_recent_library_path(Path::new(&result.path));
+        }
+        out.push(result);
     }
 
     Ok(out)
@@ -1593,6 +1747,30 @@ mod migrate_tests {
         assert!(!orphan.exists());
         assert!(!orphan_part.exists());
         assert!(!base.join("cache/srv/Other").exists());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn library_orphan_prune_preserves_recent_download_handoffs() {
+        let base = std::env::temp_dir().join(format!(
+            "psysonic-library-prune-recent-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&base);
+        let recent = base.join("library/srv/Artist/Album/Recent.flac");
+        std::fs::create_dir_all(recent.parent().unwrap()).unwrap();
+        std::fs::write(&recent, b"recent").unwrap();
+
+        let removed = prune_orphan_files_under_root_before(
+            &base.join("library/srv"),
+            &[],
+            Some(SystemTime::now() - Duration::from_secs(30)),
+            true,
+        )
+        .await;
+
+        assert!(removed.is_empty());
+        assert!(recent.is_file());
         let _ = std::fs::remove_dir_all(&base);
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -95,6 +95,24 @@ fn scheduler_idle_payload(
         })
 }
 
+fn scheduler_error_idle_payload(
+    error: &psysonic_library::sync::SyncError,
+    server_id: &str,
+    library_scope: &str,
+) -> Option<psysonic_library::LibrarySyncIdlePayload> {
+    matches!(
+        error,
+        psysonic_library::sync::SyncError::IdentityTransition(_)
+    )
+    .then(|| psysonic_library::LibrarySyncIdlePayload::err(
+        server_id,
+        library_scope,
+        "delta_sync",
+        "background",
+        &error.to_string(),
+    ))
+}
+
 /// Shared handle to OS media controls (MPRIS2 on Linux, Now Playing on macOS, SMTC on Windows).
 /// `None` if souvlaki failed to initialize (e.g. no D-Bus session on Linux).
 type MprisControls = Mutex<Option<souvlaki::MediaControls>>;
@@ -828,14 +846,6 @@ pub fn run() {
                                 {
                                     return;
                                 }
-                                if psysonic_library::navidrome_identity::assert_sync_ready(
-                                    &runtime.store,
-                                    &session.server_id,
-                                )
-                                .is_err()
-                                {
-                                    return;
-                                }
                                 let subsonic = psysonic_integration::subsonic::subsonic_client_with_registry(
                                     Some(registry.as_ref()),
                                     &session.server_id,
@@ -938,11 +948,23 @@ pub fn run() {
                                             );
                                         }
                                     }
-                                    Err(err) => crate::app_deprintln!(
-                                        "[library-sync] scheduler recorded server failure server_id={}: {}",
-                                        session.server_id,
-                                        err
-                                    ),
+                                    Err(err) => {
+                                        crate::app_deprintln!(
+                                            "[library-sync] scheduler recorded server failure server_id={}: {}",
+                                            session.server_id,
+                                            err
+                                        );
+                                        if let Some(payload) = scheduler_error_idle_payload(
+                                            &err,
+                                            &session.server_id,
+                                            &scope,
+                                        ) {
+                                            let _ = app_for_session.emit(
+                                                psysonic_library::LibrarySyncProgressPayload::IDLE_EVENT_NAME,
+                                                &payload,
+                                            );
+                                        }
+                                    }
                                 }
                             }
                         })
@@ -1899,6 +1921,32 @@ mod scheduler_driver_tests {
             ..skipped
         };
         assert!(scheduler_idle_payload(&census_only, "s1", "").is_some());
+    }
+
+    #[test]
+    fn scheduler_identity_transition_maps_to_failed_background_idle_payload() {
+        let payload = scheduler_error_idle_payload(
+            &psysonic_library::sync::SyncError::IdentityTransition(
+                "canonical migration required".into(),
+            ),
+            "s1",
+            "scope",
+        )
+        .unwrap();
+
+        assert!(!payload.ok);
+        assert_eq!(payload.source, "background");
+        assert_eq!(payload.kind, "delta_sync");
+        assert!(payload
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("canonical migration required")));
+        assert!(scheduler_error_idle_payload(
+            &psysonic_library::sync::SyncError::Transport("offline".into()),
+            "s1",
+            "scope",
+        )
+        .is_none());
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,12 +1,12 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-pub mod cli;
 mod benchmark;
+pub mod cli;
 mod cover_cache;
 mod lib_commands;
-mod library_identity_maintenance;
 pub(crate) mod library_analysis_backfill;
+mod library_identity_maintenance;
 pub mod theme_animation;
 pub(crate) mod theme_import;
 
@@ -187,6 +187,10 @@ fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             psysonic_library::commands::library_resolve_entity_sources,
             psysonic_library::commands::library_resolve_album_overlay,
             psysonic_library::commands::library_sync_bind_session,
+            psysonic_library::commands::library_identity_transition_status,
+            psysonic_library::commands::library_identity_transition_ack,
+            psysonic_library::commands::library_identity_transition_probe,
+            psysonic_library::commands::library_identity_transition_run_native_migration,
             psysonic_library::commands::library_sync_clear_session,
             psysonic_library::commands::library_set_playback_hint,
             psysonic_library::commands::library_get_playback_hint,
@@ -810,6 +814,21 @@ pub fn run() {
                                 {
                                     return;
                                 }
+                                if psysonic_library::navidrome_identity::assert_sync_ready(
+                                    &runtime.store,
+                                    &session.server_id,
+                                )
+                                .is_err()
+                                {
+                                    return;
+                                }
+                                let subsonic = psysonic_integration::subsonic::subsonic_client_with_registry(
+                                    Some(registry.as_ref()),
+                                    &session.server_id,
+                                    session.base_url.clone(),
+                                    session.username.clone(),
+                                    session.password.clone(),
+                                );
                                 let foreground_active = foreground_blocks_scheduler_session(
                                     runtime.current_job().as_ref(),
                                     &session.server_id,
@@ -826,13 +845,6 @@ pub fn run() {
                                     psysonic_library::sync::capability::CapabilityFlags::new(
                                         flags_bits,
                                     );
-                                let subsonic = psysonic_integration::subsonic::subsonic_client_with_registry(
-                                    Some(registry.as_ref()),
-                                    &session.server_id,
-                                    session.base_url.clone(),
-                                    session.username.clone(),
-                                    session.password.clone(),
-                                );
                                 let mut sched =
                                     psysonic_library::sync::scheduler::BackgroundScheduler::new(
                                         &runtime.store,
@@ -1044,10 +1056,17 @@ pub fn run() {
                         else {
                             return TrackEnrichmentPlan::default();
                         };
+                        let track_id = psysonic_library::navidrome_identity::resolve_remapped_id(
+                            &runtime.store,
+                            server_id,
+                            "track",
+                            track_id,
+                        )
+                        .unwrap_or_else(|_| track_id.to_string());
                         match psysonic_library::enrichment::plan_track_enrichment(
                             &runtime.store,
                             server_id,
-                            track_id,
+                            &track_id,
                             content_hash,
                             enrichment_now_unix_ms(),
                         ) {
@@ -1074,10 +1093,16 @@ pub fn run() {
                         else {
                             return Err("library runtime unavailable".into());
                         };
+                        let track_id = psysonic_library::navidrome_identity::resolve_remapped_id(
+                            &runtime.store,
+                            server_id,
+                            "track",
+                            track_id,
+                        )?;
                         psysonic_library::enrichment::store_track_enrichment_facts(
                             &runtime.store,
                             server_id,
-                            track_id,
+                            &track_id,
                             content_hash,
                             facts,
                             enrichment_now_unix_ms(),
@@ -1471,6 +1496,10 @@ pub fn run() {
             psysonic_library::commands::library_analysis_progress,
             psysonic_library::commands::library_count_live_tracks,
             psysonic_library::commands::library_sync_bind_session,
+            psysonic_library::commands::library_identity_transition_status,
+            psysonic_library::commands::library_identity_transition_ack,
+            psysonic_library::commands::library_identity_transition_probe,
+            psysonic_library::commands::library_identity_transition_run_native_migration,
             psysonic_library::commands::library_sync_clear_session,
             psysonic_library::commands::library_set_playback_hint,
             psysonic_library::commands::library_get_playback_hint,

--- a/src-tauri/src/lib_commands/app_api/migration.rs
+++ b/src-tauri/src/lib_commands/app_api/migration.rs
@@ -13,31 +13,105 @@ struct ScopedTable {
 }
 
 const LIBRARY_TABLES: &[ScopedTable] = &[
-    ScopedTable { table: "track_extension", column: "server_id" },
-    ScopedTable { table: "track_fact", column: "server_id" },
-    ScopedTable { table: "track_artifact", column: "server_id" },
-    ScopedTable { table: "track_canonical_link", column: "server_id" },
-    ScopedTable { table: "track_id_history", column: "server_id" },
-    ScopedTable { table: "play_session", column: "server_id" },
-    ScopedTable { table: "track_offline", column: "server_id" },
-    ScopedTable { table: "track_genre", column: "server_id" },
-    ScopedTable { table: "artist_artwork_lookup", column: "server_id" },
-    ScopedTable { table: "library_tag_state", column: "server_id" },
-    ScopedTable { table: "library_tag_cursor", column: "server_id" },
-    ScopedTable { table: "entity_user_rating", column: "server_id" },
-    ScopedTable { table: "album_browse_projection", column: "server_id" },
-    ScopedTable { table: "composer_album_projection", column: "server_id" },
-    ScopedTable { table: "canonical_enrichment_link", column: "owner_server_id" },
-    ScopedTable { table: "track", column: "server_id" },
-    ScopedTable { table: "album", column: "server_id" },
-    ScopedTable { table: "artist", column: "server_id" },
-    ScopedTable { table: "sync_state", column: "server_id" },
+    ScopedTable {
+        table: "track_extension",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "track_fact",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "track_artifact",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "track_canonical_link",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "track_id_history",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "play_session",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "track_offline",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "track_genre",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "artist_artwork_lookup",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "library_tag_state",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "library_tag_cursor",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "server_identity_transition",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "entity_id_remap",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "entity_user_rating",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "album_browse_projection",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "composer_album_projection",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "canonical_enrichment_link",
+        column: "owner_server_id",
+    },
+    ScopedTable {
+        table: "track",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "album",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "artist",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "sync_state",
+        column: "server_id",
+    },
 ];
 
 const ANALYSIS_TABLES: &[ScopedTable] = &[
-    ScopedTable { table: "analysis_track", column: "server_id" },
-    ScopedTable { table: "waveform_cache", column: "server_id" },
-    ScopedTable { table: "loudness_cache", column: "server_id" },
+    ScopedTable {
+        table: "analysis_track",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "waveform_cache",
+        column: "server_id",
+    },
+    ScopedTable {
+        table: "loudness_cache",
+        column: "server_id",
+    },
 ];
 
 fn migration_lock() -> &'static Mutex<()> {
@@ -259,12 +333,13 @@ fn run_internal(
         }
     }
     if paths.analysis_v2.exists() {
-        let switch_result =
-            if let Some(cache) = app.try_state::<psysonic_analysis::analysis_cache::AnalysisCache>() {
-                cache.swap_database_file(&paths.analysis_active, &paths.analysis_v2)
-            } else {
-                switch_file(&paths.analysis_active, &paths.analysis_v2).map(Some)
-            };
+        let switch_result = if let Some(cache) =
+            app.try_state::<psysonic_analysis::analysis_cache::AnalysisCache>()
+        {
+            cache.swap_database_file(&paths.analysis_active, &paths.analysis_v2)
+        } else {
+            switch_file(&paths.analysis_active, &paths.analysis_v2).map(Some)
+        };
         match switch_result {
             Ok(backup) => analysis_backup = backup,
             Err(err) => {
@@ -562,7 +637,7 @@ fn purge_unknown_rows(
             &format!("DELETE FROM {} WHERE {} <> ''", table.table, table.column),
             [],
         )
-            .map_err(|e| e.to_string())?;
+        .map_err(|e| e.to_string())?;
         return Ok(());
     }
     let placeholders = std::iter::repeat_n("?", known.len())
@@ -590,9 +665,11 @@ fn sum_table_rows(conn: &Connection, tables: &[ScopedTable]) -> Result<u64, Stri
     let mut total = 0_u64;
     for table in tables {
         let rows: i64 = conn
-            .query_row(&format!("SELECT COUNT(*) FROM {}", table.table), [], |row| {
-                row.get(0)
-            })
+            .query_row(
+                &format!("SELECT COUNT(*) FROM {}", table.table),
+                [],
+                |row| row.get(0),
+            )
             .map_err(|e| e.to_string())?;
         total = total.saturating_add(rows.max(0) as u64);
     }
@@ -726,7 +803,11 @@ fn restore_backup(backup: &Path, active: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn health_check(app: &AppHandle, library_active: &Path, analysis_active: &Path) -> Result<(), String> {
+fn health_check(
+    app: &AppHandle,
+    library_active: &Path,
+    analysis_active: &Path,
+) -> Result<(), String> {
     if library_active.exists() {
         if let Some(runtime) = app.try_state::<psysonic_library::LibraryRuntime>() {
             runtime.store.verify_operational_schema()?;
@@ -798,23 +879,41 @@ mod tests {
         let conn = Connection::open_in_memory().expect("in-memory sqlite");
         for migration in [
             include_str!("../../../crates/psysonic-library/migrations/001_initial.sql"),
-            include_str!("../../../crates/psysonic-library/migrations/012_track_genre_legacy_repair.sql"),
-            include_str!("../../../crates/psysonic-library/migrations/013_artist_artwork_lookup.sql"),
+            include_str!(
+                "../../../crates/psysonic-library/migrations/012_track_genre_legacy_repair.sql"
+            ),
+            include_str!(
+                "../../../crates/psysonic-library/migrations/013_artist_artwork_lookup.sql"
+            ),
             include_str!("../../../crates/psysonic-library/migrations/014_artist_name_sort.sql"),
             include_str!("../../../crates/psysonic-library/migrations/015_replay_gain_peak.sql"),
             include_str!("../../../crates/psysonic-library/migrations/016_multi_library_scope.sql"),
             include_str!("../../../crates/psysonic-library/migrations/017_library_tag_state.sql"),
             include_str!("../../../crates/psysonic-library/migrations/018_artist_synced_index.sql"),
-            include_str!("../../../crates/psysonic-library/migrations/019_mainstage_feed_indexes.sql"),
-            include_str!("../../../crates/psysonic-library/migrations/020_scope_browse_projection.sql"),
+            include_str!(
+                "../../../crates/psysonic-library/migrations/019_mainstage_feed_indexes.sql"
+            ),
+            include_str!(
+                "../../../crates/psysonic-library/migrations/020_scope_browse_projection.sql"
+            ),
             include_str!("../../../crates/psysonic-library/migrations/021_scope_browse_tracks.sql"),
             include_str!("../../../crates/psysonic-library/migrations/022_artist_name_fold.sql"),
-            include_str!("../../../crates/psysonic-library/migrations/023_starred_browse_indexes.sql"),
-            include_str!("../../../crates/psysonic-library/migrations/024_composer_browse_projection.sql"),
-            include_str!("../../../crates/psysonic-library/migrations/025_identity_invalidation.sql"),
+            include_str!(
+                "../../../crates/psysonic-library/migrations/023_starred_browse_indexes.sql"
+            ),
+            include_str!(
+                "../../../crates/psysonic-library/migrations/024_composer_browse_projection.sql"
+            ),
+            include_str!(
+                "../../../crates/psysonic-library/migrations/025_identity_invalidation.sql"
+            ),
             include_str!("../../../crates/psysonic-library/migrations/026_library_tag_cursor.sql"),
+            include_str!(
+                "../../../crates/psysonic-library/migrations/027_navidrome_canonical_ids.sql"
+            ),
         ] {
-            conn.execute_batch(migration).expect("apply library migration");
+            conn.execute_batch(migration)
+                .expect("apply library migration");
         }
         conn.execute_batch("PRAGMA foreign_keys = ON;")
             .expect("enable foreign keys");
@@ -849,9 +948,13 @@ mod tests {
                VALUES ('legacy-a', 'artist-1', 'fanart', 'hit', 1);
               INSERT INTO library_tag_state(server_id, folders_hash, completed_at)
                 VALUES ('legacy-a', 'hash', 1);
-              INSERT INTO library_tag_cursor(server_id, folders_hash, next_folder_id, updated_at)
-                VALUES ('legacy-a', 'hash', 'folder-1', 1);
-             INSERT INTO entity_user_rating(server_id, entity_kind, entity_id, rating, fetched_at)
+               INSERT INTO library_tag_cursor(server_id, folders_hash, next_folder_id, updated_at)
+                 VALUES ('legacy-a', 'hash', 'folder-1', 1);
+               INSERT INTO server_identity_transition(server_id, canonical_version, state, detected_at)
+                 VALUES ('legacy-a', 1, 'legacy', 1);
+               INSERT INTO entity_id_remap(server_id, entity_kind, old_id, new_id, remapped_at)
+                 VALUES ('legacy-a', 'track', 'old-track', 'track-1', 1);
+              INSERT INTO entity_user_rating(server_id, entity_kind, entity_id, rating, fetched_at)
                VALUES ('legacy-a', 'track', 'track-1', 5, 1);
               INSERT INTO album_browse_projection(
                server_id, library_id, album_id, name, song_count, duration_sec, synced_at, representative_track_id
@@ -880,8 +983,13 @@ mod tests {
 
         let known_legacy_ids = vec!["legacy-a".to_string()];
         let known_index_keys = vec!["idx-a".to_string()];
-        let unknown = count_unknown_rows(&conn, TEST_TRACK_TABLE, &known_legacy_ids, &known_index_keys)
-            .expect("unknown count");
+        let unknown = count_unknown_rows(
+            &conn,
+            TEST_TRACK_TABLE,
+            &known_legacy_ids,
+            &known_index_keys,
+        )
+        .expect("unknown count");
         assert_eq!(unknown, 1);
     }
 
@@ -923,9 +1031,15 @@ mod tests {
 
         let known_legacy_ids = vec!["legacy-a".to_string()];
         let known_index_keys = vec!["idx-a".to_string()];
-        let legacy = count_rows_in(&conn, TEST_TRACK_TABLE, &known_legacy_ids).expect("legacy count");
-        let unknown = count_unknown_rows(&conn, TEST_TRACK_TABLE, &known_legacy_ids, &known_index_keys)
-            .expect("unknown count");
+        let legacy =
+            count_rows_in(&conn, TEST_TRACK_TABLE, &known_legacy_ids).expect("legacy count");
+        let unknown = count_unknown_rows(
+            &conn,
+            TEST_TRACK_TABLE,
+            &known_legacy_ids,
+            &known_index_keys,
+        )
+        .expect("unknown count");
         assert_eq!(legacy, 0);
         assert_eq!(unknown, 1);
     }
@@ -946,8 +1060,13 @@ mod tests {
 
         let known_legacy_ids = vec!["legacy-a".to_string()];
         let known_index_keys = vec!["idx-a".to_string()];
-        purge_unknown_rows(&conn, TEST_TRACK_TABLE, &known_legacy_ids, &known_index_keys)
-            .expect("purge unknown rows");
+        purge_unknown_rows(
+            &conn,
+            TEST_TRACK_TABLE,
+            &known_legacy_ids,
+            &known_index_keys,
+        )
+        .expect("purge unknown rows");
 
         let remaining: i64 = conn
             .query_row("SELECT COUNT(*) FROM track", [], |row| row.get(0))

--- a/src/app/BlockingMigrationGate.test.tsx
+++ b/src/app/BlockingMigrationGate.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useMigrationStore } from '@/store/migrationStore';
+import BlockingMigrationGate from './BlockingMigrationGate';
+
+describe('BlockingMigrationGate', () => {
+  beforeEach(() => {
+    useMigrationStore.setState({
+      phase: 'running',
+      step: 'canonicalIds',
+      progress: { stage: 'legacy stage', table: 'legacy table', done: 8, total: 10 },
+      inspect: {
+        needsMigration: true,
+        canRun: true,
+        hasSkippedUnknownServerRows: true,
+        warnings: [],
+        unmappedEmptyBucket: false,
+        library: { totalLegacyRows: 10, skippedUnknownServerRows: 1, tables: {} },
+        analysis: { totalLegacyRows: 2, skippedUnknownServerRows: 0, tables: {} },
+        mappings: [],
+      },
+      lastError: null,
+    });
+  });
+
+  it('does not display stale server-index progress during canonical reconciliation', () => {
+    render(<BlockingMigrationGate><div>app</div></BlockingMigrationGate>);
+
+    expect(screen.queryByText('legacy stage - legacy table')).not.toBeInTheDocument();
+    expect(screen.queryByText('8 / 10')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/BlockingMigrationGate.tsx
+++ b/src/app/BlockingMigrationGate.tsx
@@ -12,6 +12,7 @@ function MigrationModal() {
   const scopeBrowseProjectionProgress = useMigrationStore(s => s.scopeBrowseProjectionProgress);
   const inspect = useMigrationStore(s => s.inspect);
   const error = useMigrationStore(s => s.lastError);
+  const isServerIndex = step === 'serverIndex';
   const isGenreTags = step === 'genreTags';
   const isScopeBrowseProjection = step === 'scopeBrowseProjection';
   const migrationTitle = isGenreTags
@@ -23,10 +24,18 @@ function MigrationModal() {
     ? t('migration.genreTagsBody')
     : isScopeBrowseProjection
       ? t('migration.scopeBrowseProjectionBody')
-      : (progress ? `${progress.stage} - ${progress.table}` : t('migration.working'));
-  const activeProgress = isGenreTags ? genreTagsProgress : isScopeBrowseProjection ? scopeBrowseProjectionProgress : progress;
+      : (isServerIndex && progress ? `${progress.stage} - ${progress.table}` : t('migration.working'));
+  const activeProgress = isGenreTags
+    ? genreTagsProgress
+    : isScopeBrowseProjection
+      ? scopeBrowseProjectionProgress
+      : isServerIndex
+        ? progress
+        : null;
 
-  const migratedRows = (inspect?.library.totalLegacyRows ?? 0) + (inspect?.analysis.totalLegacyRows ?? 0);
+  const migratedRows = isServerIndex
+    ? (inspect?.library.totalLegacyRows ?? 0) + (inspect?.analysis.totalLegacyRows ?? 0)
+    : 0;
   return (
     <div style={{
       position: 'fixed',
@@ -63,7 +72,7 @@ function MigrationModal() {
             <p style={{ color: 'var(--text-muted)' }}>
               {activeProgress ? `${activeProgress.done} / ${activeProgress.total}` : t('migration.working')}
             </p>
-            {!isGenreTags && inspect?.hasSkippedUnknownServerRows ? (
+            {isServerIndex && inspect?.hasSkippedUnknownServerRows ? (
               <p style={{ color: 'var(--text-muted)', marginTop: '0.5rem' }}>
                 {t('migration.skippedRows')}
               </p>

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -1,6 +1,6 @@
 import { initAudioListeners } from '@/features/playback/store/initAudioListeners';
 import '@/features/playback/store/playbackEngineBridgeRegister'; // installs the playback-engine bridge at boot
-import { lazy, Suspense, useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router';
 import { preloadMiniPlayer as preloadMiniPlayerWindow } from '@/lib/api/miniPlayer';
 import { showToast } from '@/lib/dom/toast';
@@ -25,9 +25,6 @@ import { runLegacyOfflineFileMigration } from '@/features/offline/utils/legacyOf
 import { reconcileLibraryTierForServer } from '@/features/offline/utils/libraryTierReconcile';
 import { initMiniPlayerBridgeOnMain } from '@/features/miniPlayer';
 import { runAdvancedModeMigration } from '@/app/migrations/advancedModeMigration';
-import { bootstrapAllIndexedServers } from '@/lib/library/librarySession';
-import { hydrateQueueFromIndex } from '@/features/playback/store/queueRestore';
-import { reconcileStartupPlayQueues } from '@/features/playback/store/startupPlayQueueReconcile';
 import { useLibraryAnalysisBackfill } from '@/lib/library/hooks/useLibraryAnalysisBackfill';
 import { useCoverArtPrefetch } from '../cover/useCoverArtPrefetch';
 import { useLibraryCoverBackfill } from '@/cover/useLibraryCoverBackfill';
@@ -42,6 +39,7 @@ import BlockingMigrationGate from './BlockingMigrationGate';
 import RequireAuth from './RequireAuth';
 import { useMigrationStore } from '../store/migrationStore';
 import BenchmarkRunner from './BenchmarkRunner';
+import { useStartupReadiness } from '@/app/hooks/useStartupReadiness';
 
 const Login = lazy(() => import('@/features/auth/pages/Login'));
 
@@ -67,31 +65,26 @@ export default function MainApp() {
   const serverIdsKey = useAuthStore(s => s.servers.map(srv => srv.id).join(','));
   const masterEnabled = useLibraryIndexStore(s => s.masterEnabled);
   const migrationPhase = useMigrationStore(s => s.phase);
+  const migrationRevision = useMigrationStore(s => s.blockingRevision);
   const migrationReady = migrationPhase === 'completed';
-  const startupQueueReconcileStartedRef = useRef(false);
   useMigrationOrchestrator();
-  useEffect(() => {
-    if (!migrationReady) return;
-    const shouldReconcileStartupQueue = !startupQueueReconcileStartedRef.current;
-    if (shouldReconcileStartupQueue) startupQueueReconcileStartedRef.current = true;
-    void (async () => {
-      await bootstrapAllIndexedServers();
-      await hydrateQueueFromIndex();
-      if (shouldReconcileStartupQueue) {
-        await reconcileStartupPlayQueues();
-      }
-    })();
-  }, [activeServerId, serverIdsKey, masterEnabled, migrationReady]);
+  const startupReady = useStartupReadiness({
+    migrationReady,
+    activeServerId,
+    serverIdsKey,
+    masterEnabled,
+    migrationRevision,
+  });
 
-  useLibraryAnalysisBackfill(migrationReady);
-  useCoverArtPrefetch(migrationReady);
-  useLibraryCoverBackfill(migrationReady);
-  useCoverRevalidateScheduler(migrationReady);
+  useLibraryAnalysisBackfill(startupReady);
+  useCoverArtPrefetch(startupReady);
+  useLibraryCoverBackfill(startupReady);
+  useCoverRevalidateScheduler(startupReady);
 
   useEffect(() => {
-    if (!migrationReady) return;
+    if (!startupReady) return;
     void runCoverIdbUpgradeMigration();
-  }, [migrationReady]);
+  }, [startupReady]);
 
   // Push playback state to mini window + handle control events.
   useEffect(() => {
@@ -103,22 +96,22 @@ export default function MainApp() {
   // a hang workaround — skip here to avoid double-building.
   const preloadMiniPlayer = useAuthStore(s => s.preloadMiniPlayer);
   useEffect(() => {
-    if (!migrationReady || IS_WINDOWS || !preloadMiniPlayer) return;
+    if (!startupReady || IS_WINDOWS || !preloadMiniPlayer) return;
     preloadMiniPlayerWindow().catch(() => {});
-  }, [preloadMiniPlayer, migrationReady]);
+  }, [preloadMiniPlayer, startupReady]);
 
   useEffect(() => {
-    if (!migrationReady) return undefined;
+    if (!startupReady) return undefined;
     return initAudioListeners();
-  }, [migrationReady]);
+  }, [startupReady]);
 
   useEffect(() => {
-    if (!migrationReady) return undefined;
+    if (!startupReady) return undefined;
     return initHotCachePrefetch();
-  }, [migrationReady]);
+  }, [startupReady]);
 
   useEffect(() => {
-    if (!migrationReady) return undefined;
+    if (!startupReady) return undefined;
     void (async () => {
       await runLegacyOfflineFileMigration();
       const servers = useAuthStore.getState().servers;
@@ -137,12 +130,12 @@ export default function MainApp() {
       stopPinnedOfflineSync();
       stopOfflineResume();
     };
-  }, [migrationReady, serverIdsKey]);
+  }, [startupReady, serverIdsKey]);
 
   useEffect(() => {
-    if (!migrationReady) return;
+    if (!startupReady) return;
     useGlobalShortcutsStore.getState().registerAll();
-  }, [migrationReady]);
+  }, [startupReady]);
 
   // ── Easter egg: Ctrl+Shift+Alt+N → export new albums image ──
   useEffect(() => {

--- a/src/app/TauriEventBridge.tsx
+++ b/src/app/TauriEventBridge.tsx
@@ -9,6 +9,7 @@ import { useMediaAndWindowBridge } from '@/app/tauriBridge/useMediaAndWindowBrid
 import { usePlayerSnapshotPublisher } from '@/app/tauriBridge/usePlayerSnapshotPublisher';
 import { useLibraryDevSyncLog } from '@/app/tauriBridge/useLibraryDevSyncLog';
 import { useCoverArtBridge } from '@/app/tauriBridge/useCoverArtBridge';
+import { useLibraryIdentityBridge } from '@/app/tauriBridge/useLibraryIdentityBridge';
 
 /**
  * Single mount point for everything that bridges Rust ↔ React in the main
@@ -37,6 +38,7 @@ export function TauriEventBridge() {
   usePlayerSnapshotPublisher();
   useLibraryDevSyncLog();
   useCoverArtBridge();
+  useLibraryIdentityBridge();
 
   return null;
 }

--- a/src/app/hooks/useMigrationOrchestrator.test.ts
+++ b/src/app/hooks/useMigrationOrchestrator.test.ts
@@ -10,6 +10,7 @@ const libraryGenreTagsRunMock = vi.fn();
 const libraryScopeBrowseProjectionInspectMock = vi.fn();
 const libraryScopeBrowseProjectionRunMock = vi.fn();
 const rewriteFrontendStoreKeysMock = vi.fn(async (_servers: unknown) => undefined);
+const retryCanonicalIdentityMigrationMock = vi.fn();
 
 vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn(async () => () => {}),
@@ -31,7 +32,14 @@ vi.mock('@/utils/server/rewriteFrontendStoreKeys', () => ({
   rewriteFrontendStoreKeys: (servers: unknown) => rewriteFrontendStoreKeysMock(servers),
 }));
 
-import { useMigrationOrchestrator } from '@/app/hooks/useMigrationOrchestrator';
+vi.mock('@/utils/server/reconcileCanonicalEntityIds', () => ({
+  retryCanonicalIdentityMigration: () => retryCanonicalIdentityMigrationMock(),
+}));
+
+import {
+  retryBlockingMigration,
+  useMigrationOrchestrator,
+} from '@/app/hooks/useMigrationOrchestrator';
 
 const DONE_FLAG = 'psysonic-server-key-migration-v1';
 const REAL_MIGRATION_TEST_OVERRIDE = '__PSYSONIC_REAL_MIGRATION_TEST__';
@@ -49,6 +57,7 @@ describe('useMigrationOrchestrator', () => {
     libraryScopeBrowseProjectionInspectMock.mockResolvedValue({ needed: false, totalTracks: 0, doneTracks: 0 });
     libraryScopeBrowseProjectionRunMock.mockResolvedValue(undefined);
     rewriteFrontendStoreKeysMock.mockClear();
+    retryCanonicalIdentityMigrationMock.mockReset();
     localStorage.clear();
     useAuthStore.setState({
       servers: [
@@ -70,6 +79,14 @@ describe('useMigrationOrchestrator', () => {
       lastError: null,
     });
     (globalThis as Record<string, unknown>)[REAL_MIGRATION_TEST_OVERRIDE] = true;
+  });
+
+  it('routes canonical-ID retries to the canonical migration flow', () => {
+    useMigrationStore.setState({ step: 'canonicalIds', phase: 'error' });
+
+    retryBlockingMigration();
+
+    expect(retryCanonicalIdentityMigrationMock).toHaveBeenCalledTimes(1);
   });
 
   afterEach(() => {

--- a/src/app/hooks/useMigrationOrchestrator.test.ts
+++ b/src/app/hooks/useMigrationOrchestrator.test.ts
@@ -10,7 +10,6 @@ const libraryGenreTagsRunMock = vi.fn();
 const libraryScopeBrowseProjectionInspectMock = vi.fn();
 const libraryScopeBrowseProjectionRunMock = vi.fn();
 const rewriteFrontendStoreKeysMock = vi.fn(async (_servers: unknown) => undefined);
-const retryCanonicalIdentityMigrationMock = vi.fn();
 
 vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn(async () => () => {}),
@@ -32,14 +31,10 @@ vi.mock('@/utils/server/rewriteFrontendStoreKeys', () => ({
   rewriteFrontendStoreKeys: (servers: unknown) => rewriteFrontendStoreKeysMock(servers),
 }));
 
-vi.mock('@/utils/server/reconcileCanonicalEntityIds', () => ({
-  retryCanonicalIdentityMigration: () => retryCanonicalIdentityMigrationMock(),
-}));
-
 import {
-  retryBlockingMigration,
   useMigrationOrchestrator,
 } from '@/app/hooks/useMigrationOrchestrator';
+import { resetBlockingMigrationCoordinatorForTests } from '@/store/migrationCoordinator';
 
 const DONE_FLAG = 'psysonic-server-key-migration-v1';
 const REAL_MIGRATION_TEST_OVERRIDE = '__PSYSONIC_REAL_MIGRATION_TEST__';
@@ -57,7 +52,7 @@ describe('useMigrationOrchestrator', () => {
     libraryScopeBrowseProjectionInspectMock.mockResolvedValue({ needed: false, totalTracks: 0, doneTracks: 0 });
     libraryScopeBrowseProjectionRunMock.mockResolvedValue(undefined);
     rewriteFrontendStoreKeysMock.mockClear();
-    retryCanonicalIdentityMigrationMock.mockReset();
+    resetBlockingMigrationCoordinatorForTests();
     localStorage.clear();
     useAuthStore.setState({
       servers: [
@@ -67,7 +62,7 @@ describe('useMigrationOrchestrator', () => {
       isLoggedIn: true,
     });
     useMigrationStore.setState({
-      phase: 'inspecting',
+      phase: 'idle',
       step: null,
       needsMigration: false,
       inspect: null,
@@ -79,14 +74,6 @@ describe('useMigrationOrchestrator', () => {
       lastError: null,
     });
     (globalThis as Record<string, unknown>)[REAL_MIGRATION_TEST_OVERRIDE] = true;
-  });
-
-  it('routes canonical-ID retries to the canonical migration flow', () => {
-    useMigrationStore.setState({ step: 'canonicalIds', phase: 'error' });
-
-    retryBlockingMigration();
-
-    expect(retryCanonicalIdentityMigrationMock).toHaveBeenCalledTimes(1);
   });
 
   afterEach(() => {

--- a/src/app/hooks/useMigrationOrchestrator.ts
+++ b/src/app/hooks/useMigrationOrchestrator.ts
@@ -11,6 +11,7 @@ import { useAuthStore } from '@/store/authStore';
 import { useMigrationStore } from '@/store/migrationStore';
 import { serverIndexKeyFromUrl } from '@/lib/server/serverIndexKey';
 import { rewriteFrontendStoreKeys } from '@/utils/server/rewriteFrontendStoreKeys';
+import { retryCanonicalIdentityMigration } from '@/utils/server/reconcileCanonicalEntityIds';
 
 const MIGRATION_DONE_FLAG = 'psysonic-server-key-migration-v1';
 let migrationInFlight: Promise<void> | null = null;
@@ -207,6 +208,10 @@ export function retryGenreTagsMigration(): void {
 
 export function retryBlockingMigration(): void {
   const step = useMigrationStore.getState().step;
+  if (step === 'canonicalIds') {
+    retryCanonicalIdentityMigration();
+    return;
+  }
   if (step === 'genreTags') {
     retryGenreTagsMigration();
     return;

--- a/src/app/hooks/useMigrationOrchestrator.ts
+++ b/src/app/hooks/useMigrationOrchestrator.ts
@@ -9,12 +9,16 @@ import {
 import { migrationInspect, migrationRun, type ServerIndexMapping } from '@/lib/api/migration';
 import { useAuthStore } from '@/store/authStore';
 import { useMigrationStore } from '@/store/migrationStore';
+import {
+  enqueueBlockingMigration,
+  blockingMigrationStatus,
+  retryCurrentBlockingMigration,
+  type BlockingMigrationContext,
+} from '@/store/migrationCoordinator';
 import { serverIndexKeyFromUrl } from '@/lib/server/serverIndexKey';
 import { rewriteFrontendStoreKeys } from '@/utils/server/rewriteFrontendStoreKeys';
-import { retryCanonicalIdentityMigration } from '@/utils/server/reconcileCanonicalEntityIds';
 
 const MIGRATION_DONE_FLAG = 'psysonic-server-key-migration-v1';
-let migrationInFlight: Promise<void> | null = null;
 const REAL_MIGRATION_TEST_OVERRIDE = '__PSYSONIC_REAL_MIGRATION_TEST__';
 
 function logSkippedUnknownRowsOnce(
@@ -37,7 +41,7 @@ function buildMappings(): ServerIndexMapping[] {
     .filter(mapping => mapping.legacyId.trim().length > 0 && mapping.indexKey.trim().length > 0);
 }
 
-async function runGenreTagsPhase(): Promise<void> {
+async function runGenreTagsPhase(context: BlockingMigrationContext): Promise<void> {
   const state = useMigrationStore.getState();
   state.setGenreTagsProgress(null);
 
@@ -46,137 +50,110 @@ async function runGenreTagsPhase(): Promise<void> {
   // modal briefly appeared on every startup once the backfill was complete).
   const inspect = await libraryGenreTagsInspect();
   state.setGenreTagsInspect(inspect);
-  if (!inspect.needed) {
-    state.setStep(null);
-    return;
-  }
+  if (!inspect.needed) return;
 
-  state.setStep('genreTags');
-  state.setError(null);
-  state.setPhase('running');
+  context.setView({ step: 'genreTags', needsMigration: true, phase: 'running' });
   const maxAttempts = 3;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     await libraryGenreTagsRun();
     const after = await libraryGenreTagsInspect();
     state.setGenreTagsInspect(after);
     if (!after.needed) {
-      state.setStep(null);
       state.setGenreTagsProgress(null);
       return;
     }
   }
   const after = await libraryGenreTagsInspect();
   if (after.needed) {
-    state.setError('Genre index update incomplete. Retry after restart.');
-    state.setPhase('error');
-    throw new Error('genre_tags_incomplete');
+    throw new Error('Genre index update incomplete. Retry after restart.');
   }
 }
 
-async function runScopeBrowseProjectionPhase(): Promise<void> {
+async function runScopeBrowseProjectionPhase(context: BlockingMigrationContext): Promise<void> {
   const state = useMigrationStore.getState();
   state.setScopeBrowseProjectionProgress(null);
   const inspect = await libraryScopeBrowseProjectionInspect();
   state.setScopeBrowseProjectionInspect(inspect);
   if (!inspect.needed) return;
 
-  state.setStep('scopeBrowseProjection');
-  state.setError(null);
-  state.setPhase('running');
+  context.setView({ step: 'scopeBrowseProjection', needsMigration: true, phase: 'running' });
   await libraryScopeBrowseProjectionRun();
   const after = await libraryScopeBrowseProjectionInspect();
   state.setScopeBrowseProjectionInspect(after);
   if (after.needed) {
-    state.setError('Library browse index update incomplete. Retry after restart.');
-    state.setPhase('error');
-    throw new Error('scope_browse_projection_incomplete');
+    throw new Error('Library browse index update incomplete. Retry after restart.');
   }
-  state.setStep(null);
   state.setScopeBrowseProjectionProgress(null);
 }
 
 async function runOrchestrator(force = false): Promise<void> {
-  if (migrationInFlight) {
-    await migrationInFlight;
-    return;
-  }
-  migrationInFlight = (async () => {
-    const state = useMigrationStore.getState();
-    let skippedLogged = false;
-    if (import.meta.env.MODE === 'test' && !(globalThis as Record<string, unknown>)[REAL_MIGRATION_TEST_OVERRIDE]) {
-      state.setNeedsMigration(false);
-      state.setPhase('completed');
-      return;
-    }
-    const servers = useAuthStore.getState().servers;
-    if (servers.length === 0) {
-      state.setNeedsMigration(false);
-      state.setPhase('completed');
-      return;
-    }
-    const mappings = buildMappings();
-    const hasDoneFlag = localStorage.getItem(MIGRATION_DONE_FLAG) === '1';
-    state.setError(null);
-    state.setProgress(null);
-    state.setGenreTagsProgress(null);
-    state.setStep('serverIndex');
-    state.setPhase(force ? 'inspecting' : 'idle');
-    let inspect = null as Awaited<ReturnType<typeof migrationInspect>> | null;
-    if (!force && hasDoneFlag) {
-      inspect = await migrationInspect(mappings);
+  const promise = enqueueBlockingMigration({
+    id: 'ordinary-migrations',
+    step: 'serverIndex',
+    initialPhase: force ? 'inspecting' : 'idle',
+    retry: () => { void runOrchestrator(true); },
+    run: async (context) => {
+      const state = useMigrationStore.getState();
+      let skippedLogged = false;
+      if (import.meta.env.MODE === 'test' && !(globalThis as Record<string, unknown>)[REAL_MIGRATION_TEST_OVERRIDE]) {
+        return;
+      }
+      const servers = useAuthStore.getState().servers;
+      if (servers.length === 0) {
+        return;
+      }
+      const mappings = buildMappings();
+      const hasDoneFlag = localStorage.getItem(MIGRATION_DONE_FLAG) === '1';
+      state.setProgress(null);
+      state.setGenreTagsProgress(null);
+      context.setView({
+        step: 'serverIndex',
+        needsMigration: false,
+        phase: force ? 'inspecting' : 'idle',
+      });
+      let inspect = null as Awaited<ReturnType<typeof migrationInspect>> | null;
+      if (!force && hasDoneFlag) {
+        inspect = await migrationInspect(mappings);
+        state.setInspect(inspect);
+        state.setNeedsMigration(inspect.needsMigration);
+        skippedLogged = logSkippedUnknownRowsOnce(inspect, skippedLogged);
+        if (!inspect.needsMigration) {
+          await runGenreTagsPhase(context);
+          await runScopeBrowseProjectionPhase(context);
+          return;
+        }
+      }
+      if (!inspect) {
+        inspect = await migrationInspect(mappings);
+      }
       state.setInspect(inspect);
       state.setNeedsMigration(inspect.needsMigration);
       skippedLogged = logSkippedUnknownRowsOnce(inspect, skippedLogged);
       if (!inspect.needsMigration) {
-        await runGenreTagsPhase();
-        await runScopeBrowseProjectionPhase();
-        state.setPhase('completed');
+        await rewriteFrontendStoreKeys(servers);
+        localStorage.setItem(MIGRATION_DONE_FLAG, '1');
+        await runGenreTagsPhase(context);
+        await runScopeBrowseProjectionPhase(context);
         return;
       }
-    }
-    if (!inspect) {
-      inspect = await migrationInspect(mappings);
-    }
-    state.setInspect(inspect);
-    state.setNeedsMigration(inspect.needsMigration);
-    skippedLogged = logSkippedUnknownRowsOnce(inspect, skippedLogged);
-    if (!inspect.needsMigration) {
+      context.setView({ step: 'serverIndex', needsMigration: true, phase: 'running' });
+      await migrationRun(mappings);
       await rewriteFrontendStoreKeys(servers);
-      localStorage.setItem(MIGRATION_DONE_FLAG, '1');
-      await runGenreTagsPhase();
-      await runScopeBrowseProjectionPhase();
-      state.setPhase('completed');
-      return;
-    }
-    state.setPhase('inspecting');
-    state.setPhase('running');
-    await migrationRun(mappings);
-    await rewriteFrontendStoreKeys(servers);
-    state.setPhase('inspecting');
-    const after = await migrationInspect(mappings);
-    state.setInspect(after);
-    state.setNeedsMigration(after.needsMigration);
-    logSkippedUnknownRowsOnce(after, skippedLogged);
-    if (!after.needsMigration) {
-      localStorage.setItem(MIGRATION_DONE_FLAG, '1');
-        await runGenreTagsPhase();
-        await runScopeBrowseProjectionPhase();
-      state.setPhase('completed');
-      return;
-    }
-    state.setError('Migration incomplete. Retry after adding missing server mapping.');
-    state.setPhase('error');
-  })()
-    .catch((error: unknown) => {
-      if (!(error instanceof Error && error.message === 'genre_tags_incomplete')) {
-        useMigrationStore.getState().setError(error instanceof Error ? error.message : String(error));
+      context.setView({ phase: 'inspecting' });
+      const after = await migrationInspect(mappings);
+      state.setInspect(after);
+      state.setNeedsMigration(after.needsMigration);
+      logSkippedUnknownRowsOnce(after, skippedLogged);
+      if (!after.needsMigration) {
+        localStorage.setItem(MIGRATION_DONE_FLAG, '1');
+        await runGenreTagsPhase(context);
+        await runScopeBrowseProjectionPhase(context);
+        return;
       }
-      useMigrationStore.getState().setPhase('error');
-    })
-    .finally(() => {
-      migrationInFlight = null;
-    });
-  await migrationInFlight;
+      throw new Error('Migration incomplete. Retry after adding missing server mapping.');
+    },
+  });
+  await promise.catch(() => {});
 }
 
 export function retryServerIndexMigration(): void {
@@ -184,43 +161,11 @@ export function retryServerIndexMigration(): void {
 }
 
 export function retryGenreTagsMigration(): void {
-  if (migrationInFlight) {
-    void migrationInFlight.then(() => retryGenreTagsMigration());
-    return;
-  }
-  migrationInFlight = (async () => {
-    const state = useMigrationStore.getState();
-    state.setError(null);
-    state.setGenreTagsProgress(null);
-    try {
-      await runGenreTagsPhase();
-      state.setPhase('completed');
-    } catch (error: unknown) {
-      if (!(error instanceof Error && error.message === 'genre_tags_incomplete')) {
-        state.setError(error instanceof Error ? error.message : String(error));
-      }
-      state.setPhase('error');
-    }
-  })().finally(() => {
-    migrationInFlight = null;
-  });
+  void runOrchestrator(true);
 }
 
 export function retryBlockingMigration(): void {
-  const step = useMigrationStore.getState().step;
-  if (step === 'canonicalIds') {
-    retryCanonicalIdentityMigration();
-    return;
-  }
-  if (step === 'genreTags') {
-    retryGenreTagsMigration();
-    return;
-  }
-  if (step === 'scopeBrowseProjection') {
-    void runOrchestrator();
-    return;
-  }
-  retryServerIndexMigration();
+  retryCurrentBlockingMigration();
 }
 
 export function useMigrationOrchestrator(): void {
@@ -260,6 +205,7 @@ export function useMigrationOrchestrator(): void {
   }, []);
 
   useEffect(() => {
+    if (blockingMigrationStatus('ordinary-migrations') === 'failed') return;
     void runOrchestrator();
   }, [servers]);
 }

--- a/src/app/hooks/useMusicFoldersDiscovery.test.tsx
+++ b/src/app/hooks/useMusicFoldersDiscovery.test.tsx
@@ -3,6 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAuthStore } from '@/store/authStore';
 import { resetAuthStore } from '@/test/helpers/storeReset';
 import { useMusicFoldersDiscovery } from './useMusicFoldersDiscovery';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
 
 const getMusicFoldersForServerMock = vi.hoisted(() => vi.fn());
 
@@ -11,6 +16,7 @@ vi.mock('@/lib/api/subsonicLibrary', () => ({
 }));
 
 beforeEach(() => {
+  deactivateCanonicalNavidromeOwners(['active', 'active.test']);
   resetAuthStore();
   getMusicFoldersForServerMock.mockReset().mockResolvedValue([
     { id: 'music', name: 'Music' },
@@ -36,5 +42,35 @@ describe('useMusicFoldersDiscovery', () => {
       { id: 'music', name: 'Music' },
     ]));
     expect(getMusicFoldersForServerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('canonicalizes a folder response that started before canonical ACK without losing selection', async () => {
+    const legacyFolderId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const canonicalFolderId = canonicalizeNavidromeId(legacyFolderId);
+    let resolveFolders!: (folders: Array<{ id: string; name: string }>) => void;
+    getMusicFoldersForServerMock.mockImplementation(() => new Promise(resolve => {
+      resolveFolders = resolve;
+    }));
+    useAuthStore.setState({
+      servers: [
+        { id: 'active', name: 'Active', url: 'https://active.test', username: 'u', password: 'p' },
+      ],
+      activeServerId: 'active',
+      libraryBrowseServerIds: ['active'],
+      libraryBrowseSelectionByServer: { active: [canonicalFolderId] },
+      isLoggedIn: true,
+    });
+
+    renderHook(() => useMusicFoldersDiscovery());
+    await waitFor(() => expect(getMusicFoldersForServerMock).toHaveBeenCalledWith('active'));
+
+    activateCanonicalNavidromeOwners(['active', 'active.test']);
+    resolveFolders([{ id: legacyFolderId, name: 'Music' }]);
+
+    await waitFor(() => expect(useAuthStore.getState().musicFoldersByServer.active).toEqual([
+      { id: canonicalFolderId, name: 'Music' },
+    ]));
+    expect(useAuthStore.getState().libraryBrowseSelectionByServer.active).toEqual([canonicalFolderId]);
+    deactivateCanonicalNavidromeOwners(['active', 'active.test']);
   });
 });

--- a/src/app/hooks/useStartupReadiness.test.ts
+++ b/src/app/hooks/useStartupReadiness.test.ts
@@ -1,0 +1,193 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useStartupReadiness } from './useStartupReadiness';
+
+const bindMock = vi.hoisted(() => vi.fn());
+const startInitialSyncsMock = vi.hoisted(() => vi.fn());
+const hydrateMock = vi.hoisted(() => vi.fn());
+const reconcileMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/library/librarySession', () => ({
+  bindAllIndexedServers: bindMock,
+  startInitialSyncsForBoundServers: startInitialSyncsMock,
+}));
+vi.mock('@/features/playback/store/queueRestore', () => ({
+  hydrateQueueFromIndex: hydrateMock,
+}));
+vi.mock('@/features/playback/store/startupPlayQueueReconcile', () => ({
+  reconcileStartupPlayQueues: reconcileMock,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(res => { resolve = res; });
+  return { promise, resolve };
+}
+
+describe('useStartupReadiness', () => {
+  beforeEach(() => {
+    bindMock.mockReset().mockResolvedValue({});
+    startInitialSyncsMock.mockReset().mockResolvedValue(undefined);
+    hydrateMock.mockReset().mockResolvedValue(undefined);
+    reconcileMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not release startup work until bootstrap and canonical reconciliation finish', async () => {
+    const bootstrap = deferred<Record<string, string>>();
+    bindMock.mockReturnValue(bootstrap.promise);
+    const { result } = renderHook(() => useStartupReadiness({
+      migrationReady: true,
+      activeServerId: 'srv-a',
+      serverIdsKey: 'srv-a',
+      masterEnabled: true,
+      migrationRevision: 0,
+    }));
+
+    expect(result.current).toBe(false);
+    await waitFor(() => expect(bindMock).toHaveBeenCalledOnce());
+    expect(hydrateMock).not.toHaveBeenCalled();
+
+    bootstrap.resolve({ 'a.test': 'bound' });
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(hydrateMock).toHaveBeenCalledOnce();
+    expect(reconcileMock).toHaveBeenCalledOnce();
+    expect(startInitialSyncsMock).toHaveBeenCalledWith({ 'a.test': 'bound' });
+  });
+
+  it('resets immediately when migration blocks again and ignores the stale bootstrap completion', async () => {
+    const bootstrap = deferred<Record<string, string>>();
+    bindMock.mockReturnValueOnce(bootstrap.promise).mockResolvedValue({});
+    const { result, rerender } = renderHook(
+      ({ migrationReady, migrationRevision }) => useStartupReadiness({
+        migrationReady,
+        activeServerId: 'srv-a',
+        serverIdsKey: 'srv-a',
+        masterEnabled: true,
+        migrationRevision,
+      }),
+      { initialProps: { migrationReady: true, migrationRevision: 0 } },
+    );
+    await waitFor(() => expect(bindMock).toHaveBeenCalledOnce());
+
+    rerender({ migrationReady: false, migrationRevision: 1 });
+    expect(result.current).toBe(false);
+    bootstrap.resolve({ 'a.test': 'bound' });
+    await Promise.resolve();
+    expect(hydrateMock).not.toHaveBeenCalled();
+
+    rerender({ migrationReady: true, migrationRevision: 1 });
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(bindMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('becomes ready while initial sync remains pending', async () => {
+    const initialSync = deferred<void>();
+    bindMock.mockResolvedValue({ 'a.test': 'bound' });
+    startInitialSyncsMock.mockReturnValue(initialSync.promise);
+
+    const { result } = renderHook(() => useStartupReadiness({
+      migrationReady: true,
+      activeServerId: 'srv-a',
+      serverIdsKey: 'srv-a',
+      masterEnabled: true,
+      migrationRevision: 0,
+    }));
+
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(startInitialSyncsMock).toHaveBeenCalledOnce();
+  });
+
+  it('starts a fresh queue reconciliation when the server scope changes', async () => {
+    const first = deferred<void>();
+    const second = deferred<void>();
+    reconcileMock
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const { result, rerender } = renderHook(
+      ({ serverIdsKey }) => useStartupReadiness({
+        migrationReady: true,
+        activeServerId: 'srv-a',
+        serverIdsKey,
+        masterEnabled: true,
+        migrationRevision: 0,
+      }),
+      { initialProps: { serverIdsKey: 'srv-a' } },
+    );
+
+    await waitFor(() => expect(reconcileMock).toHaveBeenCalledTimes(1));
+    const firstOptions = reconcileMock.mock.calls[0]?.[0] as { shouldAbort(): boolean };
+    rerender({ serverIdsKey: 'srv-a,srv-b' });
+
+    await waitFor(() => expect(reconcileMock).toHaveBeenCalledTimes(2));
+    expect(firstOptions.shouldAbort()).toBe(true);
+    second.resolve();
+    await waitFor(() => expect(result.current).toBe(true));
+
+    first.resolve();
+    await Promise.resolve();
+    expect(reconcileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries one transient startup failure with bounded backoff', async () => {
+    vi.useFakeTimers();
+    bindMock.mockRejectedValueOnce(new Error('temporary')).mockResolvedValue({});
+    const { result } = renderHook(() => useStartupReadiness({
+      migrationReady: true,
+      activeServerId: 'srv-a',
+      serverIdsKey: 'srv-a',
+      masterEnabled: true,
+      migrationRevision: 0,
+    }));
+
+    await vi.waitFor(() => expect(bindMock).toHaveBeenCalledOnce());
+    expect(result.current).toBe(false);
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.waitFor(() => expect(result.current).toBe(true));
+    expect(bindMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps retrying with capped backoff until startup succeeds', async () => {
+    vi.useFakeTimers();
+    bindMock
+      .mockRejectedValueOnce(new Error('temporary-1'))
+      .mockRejectedValueOnce(new Error('temporary-2'))
+      .mockRejectedValueOnce(new Error('temporary-3'))
+      .mockRejectedValueOnce(new Error('temporary-4'))
+      .mockResolvedValue({});
+    const { result } = renderHook(() => useStartupReadiness({
+      migrationReady: true,
+      activeServerId: 'srv-a',
+      serverIdsKey: 'srv-a',
+      masterEnabled: true,
+      migrationRevision: 0,
+    }));
+
+    await vi.waitFor(() => expect(bindMock).toHaveBeenCalledTimes(1));
+    for (const delay of [250, 500, 1000, 2000]) {
+      await vi.advanceTimersByTimeAsync(delay);
+    }
+    await vi.waitFor(() => expect(result.current).toBe(true));
+    expect(bindMock).toHaveBeenCalledTimes(5);
+  });
+
+  it('cancels the pending retry when unmounted', async () => {
+    vi.useFakeTimers();
+    bindMock.mockRejectedValue(new Error('offline'));
+    const { unmount } = renderHook(() => useStartupReadiness({
+      migrationReady: true,
+      activeServerId: 'srv-a',
+      serverIdsKey: 'srv-a',
+      masterEnabled: true,
+      migrationRevision: 0,
+    }));
+
+    await vi.waitFor(() => expect(bindMock).toHaveBeenCalledOnce());
+    unmount();
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(bindMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/hooks/useStartupReadiness.ts
+++ b/src/app/hooks/useStartupReadiness.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  bindAllIndexedServers,
+  startInitialSyncsForBoundServers,
+} from '@/lib/library/librarySession';
+import { hydrateQueueFromIndex } from '@/features/playback/store/queueRestore';
+import { reconcileStartupPlayQueues } from '@/features/playback/store/startupPlayQueueReconcile';
+
+const STARTUP_RETRY_BASE_MS = 250;
+const STARTUP_RETRY_MAX_MS = 30_000;
+
+export function useStartupReadiness(options: {
+  migrationReady: boolean;
+  activeServerId: string | null;
+  serverIdsKey: string;
+  masterEnabled: boolean;
+  migrationRevision: number;
+}): boolean {
+  const { migrationReady, activeServerId, serverIdsKey, masterEnabled, migrationRevision } = options;
+  const readinessKey = `${migrationRevision}\u0000${activeServerId ?? ''}\u0000${serverIdsKey}\u0000${masterEnabled ? '1' : '0'}`;
+  const [readyKey, setReadyKey] = useState<string | null>(null);
+  const generationRef = useRef(0);
+  const queueReconciledGenerationRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const generation = ++generationRef.current;
+    if (!migrationReady) return;
+
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    void (async () => {
+      let attempt = 0;
+      while (!cancelled && generationRef.current === generation) {
+        try {
+          const results = await bindAllIndexedServers();
+          if (cancelled || generationRef.current !== generation) return;
+          void startInitialSyncsForBoundServers(results).catch(() => {});
+          await hydrateQueueFromIndex();
+          if (cancelled || generationRef.current !== generation) return;
+          if (queueReconciledGenerationRef.current !== readinessKey) {
+            await reconcileStartupPlayQueues({
+              shouldAbort: () => cancelled || generationRef.current !== generation,
+            });
+            if (cancelled || generationRef.current !== generation) return;
+            queueReconciledGenerationRef.current = readinessKey;
+          }
+          if (cancelled || generationRef.current !== generation) return;
+          setReadyKey(readinessKey);
+          return;
+        } catch {
+          if (cancelled || generationRef.current !== generation) return;
+          const delayMs = Math.min(
+            STARTUP_RETRY_MAX_MS,
+            STARTUP_RETRY_BASE_MS * 2 ** Math.min(attempt, 20),
+          );
+          attempt += 1;
+          await new Promise<void>(resolve => {
+            retryTimer = setTimeout(resolve, delayMs);
+          });
+          retryTimer = null;
+          if (cancelled || generationRef.current !== generation) return;
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+    };
+  }, [activeServerId, masterEnabled, migrationReady, readinessKey, serverIdsKey]);
+
+  return migrationReady && readyKey === readinessKey;
+}

--- a/src/app/tauriBridge/useLibraryIdentityBridge.test.ts
+++ b/src/app/tauriBridge/useLibraryIdentityBridge.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { emitTauriEvent, tauriMockListenerCount } from '@/test/mocks/tauri';
+import { makeServer } from '@/test/helpers/factories';
+import { resetAuthStore } from '@/test/helpers/storeReset';
+import { useAuthStore } from '@/store/authStore';
+import { serverIndexKeyForProfile } from '@/lib/server/serverIndexKey';
+
+vi.mock('@/utils/server/reconcileCanonicalEntityIds', () => ({
+  reconcileCanonicalEntityIds: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { reconcileCanonicalEntityIds } from '@/utils/server/reconcileCanonicalEntityIds';
+import { useLibraryIdentityBridge } from './useLibraryIdentityBridge';
+
+describe('useLibraryIdentityBridge', () => {
+  beforeEach(() => {
+    resetAuthStore();
+    vi.mocked(reconcileCanonicalEntityIds).mockClear();
+  });
+
+  it('starts the blocking transition flow after a sync detects canonical IDs', async () => {
+    const server = makeServer({ id: 'profile-1', url: 'https://music.test' });
+    const serverIndexKey = serverIndexKeyForProfile(server);
+    useAuthStore.setState({ servers: [server], activeServerId: server.id });
+    renderHook(() => useLibraryIdentityBridge());
+    await waitFor(() => expect(tauriMockListenerCount('library:sync-idle')).toBe(1));
+
+    emitTauriEvent('library:sync-idle', {
+      serverId: serverIndexKey,
+      libraryScope: '',
+      kind: 'delta_sync',
+      ok: false,
+      error: 'identity transition: canonical ID now resolves',
+    });
+
+    await waitFor(() => expect(reconcileCanonicalEntityIds).toHaveBeenCalledWith(
+      server,
+      serverIndexKey,
+    ));
+  });
+
+  it('ignores unrelated sync failures', async () => {
+    const server = makeServer({ id: 'profile-1', url: 'https://music.test' });
+    useAuthStore.setState({ servers: [server], activeServerId: server.id });
+    renderHook(() => useLibraryIdentityBridge());
+    await waitFor(() => expect(tauriMockListenerCount('library:sync-idle')).toBe(1));
+
+    emitTauriEvent('library:sync-idle', {
+      serverId: serverIndexKeyForProfile(server),
+      libraryScope: '',
+      kind: 'delta_sync',
+      ok: false,
+      error: 'network timeout',
+    });
+
+    expect(reconcileCanonicalEntityIds).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/tauriBridge/useLibraryIdentityBridge.ts
+++ b/src/app/tauriBridge/useLibraryIdentityBridge.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useAuthStore } from '@/store/authStore';
+import { serverIndexKeyForProfile } from '@/lib/server/serverIndexKey';
+import { reconcileCanonicalEntityIds } from '@/utils/server/reconcileCanonicalEntityIds';
+import { subscribeLibrarySyncIdle } from '@/lib/api/library';
+
+export function useLibraryIdentityBridge(): void {
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    void subscribeLibrarySyncIdle(payload => {
+      if (payload.ok || !payload.error?.startsWith('identity transition:')) return;
+      const serverIndexKey = payload.serverId;
+      const profile = useAuthStore.getState().servers.find(
+        server => serverIndexKeyForProfile(server) === serverIndexKey,
+      );
+      if (profile) void reconcileCanonicalEntityIds(profile, serverIndexKey).catch(() => {});
+    }).then(stop => {
+      if (disposed) stop();
+      else unlisten = stop;
+    });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
+}

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -212,6 +212,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Multi-server scope recovery and redacted selectable-depth diagnostics for reachability, music folders, and New Releases (PR #1331)',
       'Cover pipeline — Navidrome per-disc art in queue, playbar and Who is listening?; All Albums warm no longer creates mf-* album dirs (PR #1336)',
       'Performance benchmark CLI and faster scoped library browsing (PR #1382)',
+      'Navidrome canonical-ID migration with blocking, crash-safe library and persisted-state reconciliation (PR #1393)',
     ],
   },
   {

--- a/src/features/album/hooks/useAlbumOfflineState.test.ts
+++ b/src/features/album/hooks/useAlbumOfflineState.test.ts
@@ -2,9 +2,15 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useOfflineJobStore } from '@/features/offline';
 import { useAlbumOfflineState } from '@/features/album/hooks/useAlbumOfflineState';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
 
 describe('useAlbumOfflineState', () => {
   beforeEach(() => {
+    deactivateCanonicalNavidromeOwners(['srv']);
     useOfflineJobStore.setState({ jobs: [], pinQueue: [], bulkProgress: {} });
   });
 
@@ -68,5 +74,24 @@ describe('useAlbumOfflineState', () => {
 
     const { result } = renderHook(() => useAlbumOfflineState('alb-1', 'srv', ['t1']));
     expect(result.current.resolvedOfflineStatus).toBe('none');
+  });
+
+  it('keeps a legacy active job visible after canonical owner activation', () => {
+    const legacyAlbumId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const canonicalAlbumId = canonicalizeNavidromeId(legacyAlbumId);
+    useOfflineJobStore.setState({
+      jobs: [{
+        trackId: 't1', albumId: legacyAlbumId, albumName: 'One', trackTitle: 'Track',
+        trackIndex: 0, totalTracks: 1, status: 'downloading', downloadId: 'dl-1', serverId: 'srv',
+      }],
+      pinQueue: [],
+      bulkProgress: {},
+    });
+    activateCanonicalNavidromeOwners(['srv']);
+
+    const { result } = renderHook(() => useAlbumOfflineState(canonicalAlbumId, 'srv', ['missing']));
+
+    expect(result.current.resolvedOfflineStatus).toBe('downloading');
+    expect(result.current.offlineProgress).toEqual({ done: 0, total: 1 });
   });
 });

--- a/src/features/album/hooks/useAlbumOfflineState.ts
+++ b/src/features/album/hooks/useAlbumOfflineState.ts
@@ -1,5 +1,5 @@
 import { useLocalPlaybackStore } from '@/store/localPlaybackStore';
-import { useOfflineJobStore } from '@/features/offline';
+import { offlineAlbumIdsMatch, useOfflineJobStore } from '@/features/offline';
 import { isOfflinePinComplete } from '@/features/offline';
 
 export type AlbumOfflineStatus = 'none' | 'queued' | 'downloading' | 'cached';
@@ -36,7 +36,7 @@ export function useAlbumOfflineState(
   const isPinQueued = useOfflineJobStore(s =>
     !pinComplete
     && !!albumId
-    && s.pinQueue.some(p => p.albumId === albumId
+    && s.pinQueue.some(p => offlineAlbumIdsMatch(albumId, p.albumId, p.serverId ?? serverId)
       && p.serverId === serverId
       && p.status === 'queued'),
   );
@@ -44,23 +44,24 @@ export function useAlbumOfflineState(
     !pinComplete
     && !!albumId
     && (
-      s.pinQueue.some(p => p.albumId === albumId
+      s.pinQueue.some(p => offlineAlbumIdsMatch(albumId, p.albumId, p.serverId ?? serverId)
         && p.serverId === serverId
         && p.status === 'downloading')
-      || s.jobs.some(j => j.albumId === albumId
+      || s.jobs.some(j => offlineAlbumIdsMatch(albumId, j.albumId, j.serverId ?? serverId)
         && j.serverId === serverId
         && (j.status === 'queued' || j.status === 'downloading'))
     ),
   );
   const offlineProgressDone = useOfflineJobStore(s => {
     if (!albumId || pinComplete) return 0;
-    return s.jobs.filter(j => j.albumId === albumId
+    return s.jobs.filter(j => offlineAlbumIdsMatch(albumId, j.albumId, j.serverId ?? serverId)
       && j.serverId === serverId
       && (j.status === 'done' || j.status === 'error')).length;
   });
   const offlineProgressTotal = useOfflineJobStore(s => {
     if (!albumId || pinComplete) return 0;
-    return s.jobs.filter(j => j.albumId === albumId && j.serverId === serverId).length;
+    return s.jobs.filter(j => offlineAlbumIdsMatch(albumId, j.albumId, j.serverId ?? serverId)
+      && j.serverId === serverId).length;
   });
   const resolvedOfflineStatus = pinComplete
     ? 'cached'

--- a/src/features/artist/hooks/useArtistOfflineState.test.ts
+++ b/src/features/artist/hooks/useArtistOfflineState.test.ts
@@ -3,9 +3,15 @@ import { renderHook } from '@testing-library/react';
 import { useLocalPlaybackStore } from '@/store/localPlaybackStore';
 import { useOfflineJobStore } from '@/features/offline';
 import { useArtistOfflineState } from '@/features/artist/hooks/useArtistOfflineState';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
 
 describe('useArtistOfflineState', () => {
   beforeEach(() => {
+    deactivateCanonicalNavidromeOwners(['srv']);
     useOfflineJobStore.setState({ jobs: [], pinQueue: [], bulkProgress: {} });
     useLocalPlaybackStore.setState({ entries: {} });
   });
@@ -72,5 +78,28 @@ describe('useArtistOfflineState', () => {
 
     const { result } = renderHook(() => useArtistOfflineState('artist-1', 'srv', ['al-1']));
     expect(result.current.status).toBe('downloading');
+  });
+
+  it('keeps legacy bulk progress and jobs visible after canonical activation', () => {
+    const legacyArtistId = '00112233-4455-6677-8899-aabbccddeeff';
+    const canonicalArtistId = canonicalizeNavidromeId(legacyArtistId);
+    const legacyAlbumId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const canonicalAlbumId = canonicalizeNavidromeId(legacyAlbumId);
+    useOfflineJobStore.setState({
+      bulkProgress: { [`srv:${legacyArtistId}`]: { done: 0, total: 1 } },
+      pinQueue: [{
+        albumId: legacyAlbumId, albumName: 'One', pinKind: 'artist',
+        status: 'downloading', queuedAt: 1, serverId: 'srv',
+      }],
+      jobs: [],
+    });
+    activateCanonicalNavidromeOwners(['srv']);
+
+    const { result } = renderHook(() =>
+      useArtistOfflineState(canonicalArtistId, 'srv', [canonicalAlbumId]),
+    );
+
+    expect(result.current.status).toBe('downloading');
+    expect(result.current.progress).toEqual({ done: 0, total: 1 });
   });
 });

--- a/src/features/artist/hooks/useArtistOfflineState.ts
+++ b/src/features/artist/hooks/useArtistOfflineState.ts
@@ -1,7 +1,8 @@
 import { useLocalPlaybackStore } from '@/store/localPlaybackStore';
-import { useOfflineJobStore } from '@/features/offline';
+import { offlineAlbumIdsMatch, useOfflineJobStore } from '@/features/offline';
 import { isOfflinePinComplete } from '@/features/offline';
 import { ownedEntityKey } from '@/lib/util/ownedEntityKey';
+import { canonicalizeConfirmedNavidromeId } from '@/lib/server/navidromeCanonicalIds';
 
 export type ArtistOfflineStatus = 'none' | 'queued' | 'downloading' | 'cached';
 
@@ -21,24 +22,41 @@ export function useArtistOfflineState(
 ): UseArtistOfflineStateResult {
   useLocalPlaybackStore(s => s.entries);
   const progressKey = ownedEntityKey({ id: artistId, serverId });
+  const canonicalArtistId = canonicalizeConfirmedNavidromeId(serverId, artistId);
+  const canonicalProgressKey = ownedEntityKey({ id: canonicalArtistId, serverId });
+  const readBulkProgress = (bulkProgress: Record<string, { done: number; total: number }>) => {
+    const direct = bulkProgress[canonicalProgressKey] ?? bulkProgress[progressKey];
+    if (direct) return direct;
+    const prefix = `${serverId}:`;
+    return Object.entries(bulkProgress).find(([key]) => (
+      key.startsWith(prefix)
+      && canonicalizeConfirmedNavidromeId(serverId, key.slice(prefix.length)) === canonicalArtistId
+    ))?.[1];
+  };
 
   const allPinned = albumIds.length > 0
     && albumIds.every(id => isOfflinePinComplete(id, serverId));
 
-  const bulkDone = useOfflineJobStore(s => (artistId ? s.bulkProgress[progressKey]?.done : undefined));
-  const bulkTotal = useOfflineJobStore(s => (artistId ? s.bulkProgress[progressKey]?.total : undefined));
+  const bulkDone = useOfflineJobStore(s => (artistId
+    ? readBulkProgress(s.bulkProgress)?.done
+    : undefined));
+  const bulkTotal = useOfflineJobStore(s => (artistId
+    ? readBulkProgress(s.bulkProgress)?.total
+    : undefined));
   const hasQueuedAlbums = useOfflineJobStore(s =>
     albumIds.length > 0
     && albumIds.some(id => s.pinQueue.some(
-      p => p.albumId === id && p.serverId === serverId && p.status === 'queued',
+      p => offlineAlbumIdsMatch(id, p.albumId, p.serverId ?? serverId)
+        && p.serverId === serverId && p.status === 'queued',
     )),
   );
   const hasDownloadingAlbums = useOfflineJobStore(s =>
     albumIds.length > 0
     && albumIds.some(id =>
-      s.pinQueue.some(p => p.albumId === id && p.serverId === serverId && p.status === 'downloading')
+      s.pinQueue.some(p => offlineAlbumIdsMatch(id, p.albumId, p.serverId ?? serverId)
+        && p.serverId === serverId && p.status === 'downloading')
       || s.jobs.some(j => (
-        j.albumId === id
+        offlineAlbumIdsMatch(id, j.albumId, j.serverId ?? serverId)
         && j.serverId === serverId
         && (j.status === 'queued' || j.status === 'downloading')
       )),

--- a/src/features/deviceSync/store/deviceSyncStore.test.ts
+++ b/src/features/deviceSync/store/deviceSyncStore.test.ts
@@ -7,6 +7,7 @@ import {
   useDeviceSyncStore,
   type DeviceSyncSource,
 } from './deviceSyncStore';
+import { activateCanonicalNavidromeOwners } from '@/lib/server/navidromeCanonicalIds';
 
 const sourceA: DeviceSyncSource = {
   type: 'album',
@@ -80,17 +81,22 @@ describe('deviceSyncStore ownership', () => {
   });
 
   it('preserves ownerless v0 selections until a server is explicitly selected', () => {
-    const legacy = { type: 'album' as const, id: 'legacy', name: 'Legacy' };
+    const legacy = {
+      type: 'album' as const,
+      id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      name: 'Legacy',
+    };
     const migrated = migrateDeviceSyncPersistedState({ sources: [legacy] });
     expect(migrated.sources).toEqual([]);
     expect(migrated.legacySources).toEqual([legacy]);
 
     useDeviceSyncStore.setState(migrated);
+    activateCanonicalNavidromeOwners([sourceA.serverIndexKey]);
     useDeviceSyncStore.getState().addSource(sourceA);
 
     expect(useDeviceSyncStore.getState().legacySources).toEqual([]);
     expect(useDeviceSyncStore.getState().sources).toEqual([
-      { ...legacy, serverIndexKey: sourceA.serverIndexKey },
+      { ...legacy, id: '7rke2SAWaicSeSYzkhww6R', serverIndexKey: sourceA.serverIndexKey },
       sourceA,
     ]);
   });

--- a/src/features/deviceSync/store/deviceSyncStore.ts
+++ b/src/features/deviceSync/store/deviceSyncStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { resolveStorageServerIndexKey } from '@/lib/server/serverIndexKey';
+import { canonicalizeConfirmedNavidromeId } from '@/lib/server/navidromeCanonicalIds';
 
 export interface DeviceSyncSource {
   type: 'album' | 'playlist' | 'artist';
@@ -65,10 +66,18 @@ export function deviceSyncSourcesFromManifest(
   const sources = manifest.sources.flatMap(source => {
     if (isDeviceSyncSource(source)) {
       const serverIndexKey = resolveStorageServerIndexKey(source.serverIndexKey);
-      return serverIndexKey ? [{ ...source, serverIndexKey }] : [];
+      return serverIndexKey ? [{
+        ...source,
+        serverIndexKey,
+        id: canonicalizeConfirmedNavidromeId(serverIndexKey, source.id),
+      }] : [];
     }
     return isLegacyDeviceSyncSource(source) && fallbackOwner
-      ? [{ ...source, serverIndexKey: fallbackOwner }]
+      ? [{
+        ...source,
+        serverIndexKey: fallbackOwner,
+        id: canonicalizeConfirmedNavidromeId(fallbackOwner, source.id),
+      }]
       : [];
   });
   const owner = deviceSyncOwnerKey(sources);
@@ -131,12 +140,18 @@ export const useDeviceSyncStore = create<DeviceSyncState>()(
 
       addSource: (source) =>
         set((s) => {
+          source = {
+            ...source,
+            id: canonicalizeConfirmedNavidromeId(source.serverIndexKey, source.id),
+          };
           const owner = deviceSyncOwnerKey(s.sources);
           const key = deviceSyncSourceKey(source);
           if (!source.serverIndexKey || (owner && owner !== source.serverIndexKey)) return s;
+          const recoveredOwner = owner ?? source.serverIndexKey;
           const recovered = s.legacySources.map(legacy => ({
             ...legacy,
-            serverIndexKey: owner ?? source.serverIndexKey,
+            serverIndexKey: recoveredOwner,
+            id: canonicalizeConfirmedNavidromeId(recoveredOwner, legacy.id),
           }));
           const nextSources = [...s.sources, ...recovered];
           return {

--- a/src/features/offline/store/offlineJobStore.ts
+++ b/src/features/offline/store/offlineJobStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { cancelOfflineDownloads } from '@/lib/api/syncfs';
+import { canonicalizeConfirmedNavidromeId } from '@/lib/server/navidromeCanonicalIds';
 
 export interface DownloadJob {
   trackId: string;
@@ -38,6 +39,35 @@ interface OfflineJobState {
 // Module-level cancellation set — checked by downloadAlbum before each track.
 export const cancelledDownloads = new Set<string>();
 
+function cancellationKey(albumId: string, serverId?: string): string {
+  return serverId ? `${serverId}:${albumId}` : albumId;
+}
+
+export function offlineAlbumIdsMatch(albumId: string, candidateId: string, serverId?: string): boolean {
+  if (albumId === candidateId) return true;
+  if (!serverId) return false;
+  return canonicalizeConfirmedNavidromeId(serverId, albumId)
+    === canonicalizeConfirmedNavidromeId(serverId, candidateId);
+}
+
+function addCancellationAliases(albumId: string, serverId?: string): void {
+  cancelledDownloads.add(cancellationKey(albumId, serverId));
+  if (!serverId) return;
+  cancelledDownloads.add(cancellationKey(
+    canonicalizeConfirmedNavidromeId(serverId, albumId),
+    serverId,
+  ));
+}
+
+export function isOfflineDownloadCancelled(albumId: string, serverId?: string): boolean {
+  if (cancelledDownloads.has(cancellationKey(albumId, serverId))) return true;
+  if (!serverId) return cancelledDownloads.has(albumId);
+  const canonicalId = canonicalizeConfirmedNavidromeId(serverId, albumId);
+  return cancelledDownloads.has(cancellationKey(canonicalId, serverId))
+    || cancelledDownloads.has(albumId)
+    || cancelledDownloads.has(canonicalId);
+}
+
 /** Tells Rust to abort any in-flight `download_track_offline` calls for these jobs. */
 function abortDownloadsInRust(jobs: DownloadJob[]) {
   const downloadIds = [...new Set(jobs.map(j => j.downloadId).filter(Boolean))];
@@ -54,7 +84,8 @@ export const useOfflineJobStore = create<OfflineJobState>()((set, get) => ({
   setPinQueueStatus: (albumId, status, serverId) => {
     set(state => ({
       pinQueue: state.pinQueue.map(p => (
-        p.albumId === albumId && (!serverId || !p.serverId || p.serverId === serverId)
+        offlineAlbumIdsMatch(albumId, p.albumId, p.serverId ?? serverId)
+          && (!serverId || !p.serverId || p.serverId === serverId)
           ? { ...p, status }
           : p
       )),
@@ -64,7 +95,8 @@ export const useOfflineJobStore = create<OfflineJobState>()((set, get) => ({
   removePinFromQueue: (albumId, serverId) => {
     set(state => ({
       pinQueue: state.pinQueue.filter(p => (
-        p.albumId !== albumId || (serverId && p.serverId && p.serverId !== serverId)
+        !offlineAlbumIdsMatch(albumId, p.albumId, p.serverId ?? serverId)
+          || (serverId && p.serverId && p.serverId !== serverId)
       )),
     }));
   },
@@ -84,19 +116,29 @@ export const useOfflineJobStore = create<OfflineJobState>()((set, get) => ({
   },
 
   cancelDownload: (albumId, serverId) => {
-    const cancelKey = serverId ? `${serverId}:${albumId}` : albumId;
-    cancelledDownloads.add(cancelKey);
+    const state = get();
+    const matchingJobs = state.jobs.filter(j => (
+      offlineAlbumIdsMatch(albumId, j.albumId, j.serverId ?? serverId)
+        && (!serverId || !j.serverId || j.serverId === serverId)
+    ));
+    const matchingPins = state.pinQueue.filter(p => (
+      offlineAlbumIdsMatch(albumId, p.albumId, p.serverId ?? serverId)
+        && (!serverId || !p.serverId || p.serverId === serverId)
+    ));
+    addCancellationAliases(albumId, serverId);
+    for (const job of matchingJobs) addCancellationAliases(job.albumId, job.serverId ?? serverId);
+    for (const pin of matchingPins) addCancellationAliases(pin.albumId, pin.serverId ?? serverId);
     // Abort the in-flight Rust transfers, then drop every job for this album
     // (queued AND downloading) so the sidebar toast clears right away.
-    abortDownloadsInRust(get().jobs.filter(j => (
-      j.albumId === albumId && (!serverId || !j.serverId || j.serverId === serverId)
-    )));
+    abortDownloadsInRust(matchingJobs);
     set(state => ({
       jobs: state.jobs.filter(j => (
-        j.albumId !== albumId || (serverId && j.serverId && j.serverId !== serverId)
+        !offlineAlbumIdsMatch(albumId, j.albumId, j.serverId ?? serverId)
+          || (serverId && j.serverId && j.serverId !== serverId)
       )),
       pinQueue: state.pinQueue.filter(p => (
-        p.albumId !== albumId || (serverId && p.serverId && p.serverId !== serverId)
+        !offlineAlbumIdsMatch(albumId, p.albumId, p.serverId ?? serverId)
+          || (serverId && p.serverId && p.serverId !== serverId)
       )),
     }));
   },

--- a/src/features/offline/store/offlineStore.test.ts
+++ b/src/features/offline/store/offlineStore.test.ts
@@ -7,6 +7,11 @@ import { resetAuthStore } from '@/test/helpers/storeReset';
 import { invokeMock, onInvoke } from '@/test/mocks/tauri';
 import { cancelledDownloads, useOfflineJobStore } from '@/features/offline/store/offlineJobStore';
 import { clearOfflinePinTasks } from '@/features/offline/utils/offlinePinQueue';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
 
 const mocks = vi.hoisted(() => ({
   buildOriginalStreamUrlForServer: vi.fn(
@@ -36,6 +41,7 @@ const SONG: SubsonicSong = {
 };
 
 beforeEach(() => {
+  deactivateCanonicalNavidromeOwners(['srv-a', 'a.test']);
   resetAuthStore();
   clearOfflinePinTasks();
   cancelledDownloads.clear();
@@ -122,5 +128,138 @@ describe('offlineStore download producer', () => {
     await waitFor(() => expect(
       useLocalPlaybackStore.getState().getEntry('track-1', 'a.test')?.originalBytesVerified,
     ).toBe(true));
+  });
+
+  it('canonicalizes a later active-download batch after owner activation', async () => {
+    const legacyFirst = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    const legacySecond = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const canonicalSecond = canonicalizeNavidromeId(legacySecond);
+    const songs = Array.from({ length: 9 }, (_, index): SubsonicSong => ({
+      ...SONG,
+      id: index === 0 ? legacyFirst : index === 8 ? legacySecond : `track-${index}`,
+      albumId: 'album-1',
+    }));
+    let releaseFirstBatch!: () => void;
+    const firstBatchGate = new Promise<void>(resolve => { releaseFirstBatch = resolve; });
+    let firstBatchCalls = 0;
+    onInvoke('download_track_local', async (args) => {
+      firstBatchCalls += 1;
+      if (firstBatchCalls <= 8) {
+        await firstBatchGate;
+      }
+      return {
+        path: `/media/${String((args as { trackId: string }).trackId)}.flac`,
+        size: 1,
+        layoutFingerprint: 'layout',
+        originalBytesVerified: true,
+      };
+    });
+
+    await useOfflineStore.getState().downloadAlbum(
+      'album-1', 'Album', 'Artist', undefined, undefined, songs, 'srv-a',
+    );
+    await waitFor(() => expect(firstBatchCalls).toBe(8));
+
+    activateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+    releaseFirstBatch();
+    await waitFor(() => expect(mocks.buildOriginalStreamUrlForServer)
+      .toHaveBeenCalledWith('srv-a', canonicalSecond));
+    expect(invokeMock).toHaveBeenCalledWith(
+      'download_track_local',
+      expect.objectContaining({ trackId: canonicalSecond }),
+    );
+  });
+
+  it('cancels a legacy active download when removal uses its canonical album id', async () => {
+    const legacyAlbumId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const canonicalAlbumId = canonicalizeNavidromeId(legacyAlbumId);
+    const songs = Array.from({ length: 9 }, (_, index): SubsonicSong => ({
+      ...SONG,
+      id: `track-${index}`,
+      albumId: legacyAlbumId,
+    }));
+    let releaseFirstBatch!: () => void;
+    const firstBatchGate = new Promise<void>(resolve => { releaseFirstBatch = resolve; });
+    let downloadCalls = 0;
+    onInvoke('download_track_local', async args => {
+      downloadCalls += 1;
+      if (downloadCalls <= 8) await firstBatchGate;
+      return {
+        path: `/media/${String((args as { trackId: string }).trackId)}.flac`,
+        size: 1,
+        layoutFingerprint: 'layout',
+        originalBytesVerified: true,
+      };
+    });
+    onInvoke('cancel_offline_downloads', () => undefined);
+
+    await useOfflineStore.getState().downloadAlbum(
+      legacyAlbumId, 'Album', 'Artist', undefined, undefined, songs, 'srv-a',
+    );
+    await waitFor(() => expect(downloadCalls).toBe(8));
+    activateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+
+    await useOfflineStore.getState().deleteAlbum(canonicalAlbumId, 'srv-a');
+    releaseFirstBatch();
+    await waitFor(() => expect(useOfflineJobStore.getState().pinQueue).toEqual([]));
+
+    expect(downloadCalls).toBe(8);
+    expect(Object.keys(useLocalPlaybackStore.getState().entries)).toEqual([]);
+  });
+
+  it('resolves status and deletion across legacy and canonical album ids', async () => {
+    const legacyAlbumId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const canonicalAlbumId = canonicalizeNavidromeId(legacyAlbumId);
+    const legacyTrackId = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    const canonicalTrackId = canonicalizeNavidromeId(legacyTrackId);
+    activateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+    useOfflineStore.setState({
+      albums: {
+        [`a.test:${canonicalAlbumId}`]: {
+          id: canonicalAlbumId,
+          serverId: 'a.test',
+          name: 'Album',
+          artist: 'Artist',
+          trackIds: [canonicalTrackId],
+          type: 'album',
+        },
+      },
+    });
+    useLocalPlaybackStore.getState().upsertEntry({
+      serverIndexKey: 'a.test',
+      trackId: canonicalTrackId,
+      localPath: `/media/${canonicalTrackId}.flac`,
+      sizeBytes: 1,
+      layoutFingerprint: 'canonical',
+      tier: 'library',
+      pinSource: { kind: 'album', sourceId: canonicalAlbumId },
+      suffix: 'flac',
+    });
+    useOfflineJobStore.setState({
+      jobs: [{
+        trackId: canonicalTrackId,
+        albumId: canonicalAlbumId,
+        albumName: 'Album',
+        trackTitle: 'Track',
+        trackIndex: 0,
+        totalTracks: 1,
+        status: 'downloading',
+        downloadId: 'download-1',
+        serverId: 'srv-a',
+      }],
+      pinQueue: [],
+      bulkProgress: {},
+    });
+    onInvoke('cancel_offline_downloads', () => undefined);
+    onInvoke('delete_media_file', () => undefined);
+
+    expect(useOfflineStore.getState().isAlbumDownloaded(legacyAlbumId, 'srv-a')).toBe(true);
+    expect(useOfflineStore.getState().isAlbumDownloading(legacyAlbumId, 'srv-a')).toBe(true);
+    expect(useOfflineStore.getState().getAlbumProgress(legacyAlbumId, 'srv-a')).toEqual({ done: 0, total: 1 });
+
+    await useOfflineStore.getState().deleteAlbum(legacyAlbumId, 'srv-a');
+
+    expect(useLocalPlaybackStore.getState().entries).toEqual({});
+    expect(useOfflineStore.getState().albums).toEqual({});
   });
 });

--- a/src/features/offline/store/offlineStore.ts
+++ b/src/features/offline/store/offlineStore.ts
@@ -8,10 +8,15 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 import { invoke } from '@tauri-apps/api/core';
 import { useAuthStore } from '@/store/authStore';
 import { showToast } from '@/lib/dom/toast';
-import { useOfflineJobStore, cancelledDownloads } from '@/features/offline/store/offlineJobStore';
+import {
+  useOfflineJobStore,
+  cancelledDownloads,
+  isOfflineDownloadCancelled,
+  offlineAlbumIdsMatch,
+} from '@/features/offline/store/offlineJobStore';
 import { useLocalPlaybackStore, type PinSource } from '@/store/localPlaybackStore';
 import { getMediaDir } from '@/lib/media/mediaDir';
-import { checkDirAccessible, clearOfflineCancel } from '@/lib/api/syncfs';
+import { checkDirAccessible, clearOfflineCancel, deleteMediaFile } from '@/lib/api/syncfs';
 import { findLocalPlaybackEntry } from '@/store/localPlaybackResolve';
 import {
   isOfflinePinComplete,
@@ -23,6 +28,7 @@ import { resolveIndexKey, serverIndexKeyForProfile } from '@/lib/server/serverIn
 import { isSmartPlaylistName } from '@/lib/format/playlistDetailHelpers';
 import {
   enqueueOfflinePin,
+  canonicalizeOfflinePinTask,
   registerOfflinePinExecutor,
   removeOfflinePinTask,
   type OfflinePinTask,
@@ -72,13 +78,9 @@ function serverIndexKeyForOffline(serverId: string): string {
   return resolveIndexKey(serverId) || serverId;
 }
 
-/** Library SQLite scope (host index key) — not the auth profile UUID. */
-function librarySqlScopeForOffline(serverId: string): string {
-  return librarySqlServerId(serverId);
-}
-
 /** Runs one queued offline pin (all tracks for a single album / playlist). */
 async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
+  task = canonicalizeOfflinePinTask(task, serverIndexKeyForOffline(task.serverId));
   const {
     albumId,
     albumName,
@@ -90,14 +92,14 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
     type = 'album',
   } = task;
   const cancelKey = `${serverId}:${albumId}`;
-  if (cancelledDownloads.has(cancelKey)) return;
+  if (isOfflineDownloadCancelled(albumId, serverId)) return;
   cancelledDownloads.delete(cancelKey);
 
   const CONCURRENCY = 8;
   const jobStore = useOfflineJobStore;
   const downloadId = `${serverId}-${albumId}-${Date.now()}`;
   const serverIndexKey = serverIndexKeyForOffline(serverId);
-  const libraryServerId = librarySqlScopeForOffline(serverId);
+  const libraryServerId = librarySqlServerId(serverId);
   const pinSource: PinSource = { kind: type, sourceId: albumId, displayName: albumName };
   const mediaDir = getMediaDir();
 
@@ -109,44 +111,13 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
     }
   }
 
-  // The server may have completed its ID migration while this task was waiting
-  // on storage. Resolve IDs immediately before the first durable/network write.
-  const activeAlbumId = canonicalizeConfirmedNavidromeId(serverIndexKey, albumId);
-  const activeSongs = songs.map(song => ({
-    ...song,
-    id: canonicalizeConfirmedNavidromeId(serverIndexKey, song.id),
-    albumId: canonicalizeConfirmedNavidromeId(serverIndexKey, song.albumId),
-    artistId: song.artistId
-      ? canonicalizeConfirmedNavidromeId(serverIndexKey, song.artistId)
-      : song.artistId,
-    coverArt: song.coverArt
-      ? canonicalizeConfirmedNavidromeId(serverIndexKey, song.coverArt)
-      : song.coverArt,
-    artists: song.artists?.map(artist => ({
-      ...artist,
-      id: artist.id ? canonicalizeConfirmedNavidromeId(serverIndexKey, artist.id) : artist.id,
-    })),
-    albumArtists: song.albumArtists?.map(artist => ({
-      ...artist,
-      id: artist.id ? canonicalizeConfirmedNavidromeId(serverIndexKey, artist.id) : artist.id,
-    })),
-    contributors: song.contributors?.map(contributor => ({
-      ...contributor,
-      artist: {
-        ...contributor.artist,
-        id: contributor.artist.id
-          ? canonicalizeConfirmedNavidromeId(serverIndexKey, contributor.artist.id)
-          : contributor.artist.id,
-      },
-    })),
-  }));
-  const activeTrackIds = activeSongs.map(song => song.id);
+  const activeTrackIds = songs.map(song => song.id);
 
   useOfflineStore.setState(state => ({
     albums: {
       ...state.albums,
-      [`${serverIndexKey}:${activeAlbumId}`]: {
-        id: activeAlbumId,
+      [`${serverIndexKey}:${albumId}`]: {
+        id: albumId,
         serverId: serverIndexKey,
         name: albumName,
         artist: albumArtist,
@@ -158,15 +129,14 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
     },
   }));
 
-  await libraryUpsertSongsFromApi(libraryServerId, activeSongs).catch(() => {});
+  await libraryUpsertSongsFromApi(libraryServerId, songs).catch(() => {});
 
-  const lp = useLocalPlaybackStore.getState();
-  const pendingSongs = pendingOfflinePinSongs(activeSongs, serverId);
+  const pendingSongs = pendingOfflinePinSongs(songs, serverId);
   if (pendingSongs.length === 0) {
-    for (const song of activeSongs) {
+    for (const song of songs) {
       const prev = findLocalPlaybackEntry(song.id, serverId);
       if (!prev) continue;
-      lp.upsertEntry({
+      useLocalPlaybackStore.getState().upsertEntry({
         ...prev,
         serverIndexKey,
         tier: 'library',
@@ -174,17 +144,17 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
       });
     }
     jobStore.setState(state => ({
-      jobs: state.jobs.filter(j => j.albumId !== activeAlbumId || (j.serverId && j.serverId !== serverId)),
+      jobs: state.jobs.filter(j => j.albumId !== albumId || (j.serverId && j.serverId !== serverId)),
     }));
     return;
   }
 
   jobStore.setState(state => ({
     jobs: [
-      ...state.jobs.filter(j => j.albumId !== activeAlbumId || (j.serverId && j.serverId !== serverId)),
+      ...state.jobs.filter(j => j.albumId !== albumId || (j.serverId && j.serverId !== serverId)),
       ...pendingSongs.map((s, i) => ({
         trackId: s.id,
-        albumId: activeAlbumId,
+        albumId,
         albumName,
         trackTitle: s.title,
         trackIndex: i,
@@ -197,30 +167,47 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
   }));
 
   for (let i = 0; i < pendingSongs.length; i += CONCURRENCY) {
-    if (cancelledDownloads.has(cancelKey)) {
+    if (isOfflineDownloadCancelled(albumId, serverId)) {
       cancelledDownloads.delete(cancelKey);
       jobStore.setState(state => ({
-        jobs: state.jobs.filter(j => j.albumId !== activeAlbumId || (j.serverId && j.serverId !== serverId)),
+        jobs: state.jobs.filter(j => j.albumId !== albumId || (j.serverId && j.serverId !== serverId)),
       }));
       clearOfflineCancel({ downloadId }).catch(() => {});
       return;
     }
 
-    const batch = pendingSongs.slice(i, i + CONCURRENCY);
+    const activeBatch = canonicalizeOfflinePinTask({
+      ...task,
+      albumId,
+      songs: pendingSongs.slice(i, i + CONCURRENCY),
+    }, serverIndexKey);
+    const batch = activeBatch.songs;
+    const batchAlbumId = activeBatch.albumId;
+    const batchPinSource: PinSource = {
+      ...pinSource,
+      sourceId: canonicalizeConfirmedNavidromeId(serverIndexKey, pinSource.sourceId),
+    };
     const batchIds = new Set(batch.map(s => s.id));
 
     jobStore.setState(state => ({
       jobs: state.jobs.map(j =>
-        j.albumId === activeAlbumId && (!j.serverId || j.serverId === serverId) && batchIds.has(j.trackId)
-          ? { ...j, status: 'downloading' }
-          : j,
+        j.albumId === albumId && (!j.serverId || j.serverId === serverId)
+          ? {
+            ...j,
+            albumId: batchAlbumId,
+            trackId: canonicalizeConfirmedNavidromeId(serverIndexKey, j.trackId),
+            ...(batchIds.has(canonicalizeConfirmedNavidromeId(serverIndexKey, j.trackId))
+              ? { status: 'downloading' as const }
+              : {}),
+          }
+          : j
       ),
     }));
 
     const results = await Promise.all(
       batch.map(async song => {
         const suffix = song.suffix || 'mp3';
-        if (cancelledDownloads.has(cancelKey)) {
+        if (isOfflineDownloadCancelled(batchAlbumId, serverId)) {
           return { song, localPath: null as string | null, error: 'CANCELLED' };
         }
         const existing = findLocalPlaybackEntry(song.id, serverId);
@@ -231,12 +218,13 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
           useLocalPlaybackStore.getState().upsertEntry({
             ...existing,
             serverIndexKey,
-            pinSource,
+            pinSource: batchPinSource,
             suffix: existing.suffix || suffix,
           });
           return { song, localPath: existing.localPath, error: null as string | null };
         }
         try {
+          const trackId = canonicalizeConfirmedNavidromeId(serverIndexKey, song.id);
           const res = await invoke<{
             path: string;
             size: number;
@@ -246,30 +234,38 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
             'download_track_local',
             {
               tier: 'library',
-              trackId: song.id,
+              trackId,
               serverIndexKey,
               libraryServerId,
-              url: buildOriginalStreamUrlForServer(serverId, song.id),
+              url: buildOriginalStreamUrlForServer(serverId, trackId),
               suffix,
               mediaDir,
               downloadId,
             },
           );
+          if (isOfflineDownloadCancelled(batchAlbumId, serverId)) {
+            await deleteMediaFile({ localPath: res.path, mediaDir }).catch(() => {});
+            return { song, localPath: null as string | null, error: 'CANCELLED' };
+          }
           useLocalPlaybackStore.getState().upsertEntry({
             serverIndexKey,
-            trackId: song.id,
+            trackId,
             localPath: res.path,
             sizeBytes: res.size,
             layoutFingerprint: res.layoutFingerprint,
             tier: 'library',
-            pinSource,
+            pinSource: batchPinSource,
             suffix,
             originalBytesVerified: res.originalBytesVerified,
           });
-          return { song, localPath: res.path, error: null as string | null };
+          return {
+            song: { ...song, id: trackId },
+            localPath: res.path,
+            error: null as string | null,
+          };
         } catch (err) {
           const msg = typeof err === 'string' ? err : (err instanceof Error ? err.message : '');
-          if (msg === 'VOLUME_NOT_FOUND' && !cancelledDownloads.has(cancelKey)) {
+          if (msg === 'VOLUME_NOT_FOUND' && !isOfflineDownloadCancelled(batchAlbumId, serverId)) {
             cancelledDownloads.add(cancelKey);
             showToast('Speichermedium nicht gefunden. Bitte Verzeichnis in den Einstellungen prüfen.', 6000, 'error');
           }
@@ -281,7 +277,7 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
     const resultMap = new Map(results.map(r => [r.song.id, r]));
     jobStore.setState(state => ({
       jobs: state.jobs.map(j => {
-        if (j.albumId !== activeAlbumId || (j.serverId && j.serverId !== serverId)) return j;
+        if (j.albumId !== batchAlbumId || (j.serverId && j.serverId !== serverId)) return j;
         const r = resultMap.get(j.trackId);
         if (!r) return j;
         if (r.error === 'CANCELLED') return j;
@@ -291,10 +287,11 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
   }
 
   clearOfflineCancel({ downloadId }).catch(() => {});
+  const completedAlbumId = canonicalizeConfirmedNavidromeId(serverIndexKey, albumId);
   setTimeout(() => {
     jobStore.setState(state => ({
       jobs: state.jobs.filter(
-        j => j.albumId !== activeAlbumId
+        j => j.albumId !== completedAlbumId
           || (j.serverId && j.serverId !== serverId)
           || (j.status !== 'done' && j.status !== 'error'),
       ),
@@ -337,7 +334,7 @@ export const useOfflineStore = create<OfflineState>()(
       isAlbumDownloaded: (albumId, serverId) => {
         const indexKey = serverIndexKeyForOffline(serverId);
         const group = useLocalPlaybackStore.getState().listPinnedGroups(indexKey)
-          .find(g => g.pinSource.sourceId === albumId);
+          .find(g => offlineAlbumIdsMatch(albumId, g.pinSource.sourceId, indexKey));
         if (!group || group.trackIds.length === 0) return false;
         return group.trackIds.every(tid =>
           useLocalPlaybackStore.getState().isPinned(tid, indexKey),
@@ -346,9 +343,10 @@ export const useOfflineStore = create<OfflineState>()(
 
       isAlbumDownloading: (albumId, serverId) => {
         const jobState = useOfflineJobStore.getState();
-        return jobState.pinQueue.some(p => p.albumId === albumId && (!serverId || !p.serverId || p.serverId === serverId))
+        return jobState.pinQueue.some(p => offlineAlbumIdsMatch(albumId, p.albumId, p.serverId ?? serverId)
+          && (!serverId || !p.serverId || p.serverId === serverId))
           || jobState.jobs.some(
-            j => j.albumId === albumId
+            j => offlineAlbumIdsMatch(albumId, j.albumId, j.serverId ?? serverId)
               && (!serverId || !j.serverId || j.serverId === serverId)
               && (j.status === 'queued' || j.status === 'downloading'),
           );
@@ -380,7 +378,8 @@ export const useOfflineStore = create<OfflineState>()(
 
       getAlbumProgress: (albumId, serverId) => {
         const albumJobs = useOfflineJobStore.getState().jobs.filter(
-          j => j.albumId === albumId && (!serverId || !j.serverId || j.serverId === serverId),
+          j => offlineAlbumIdsMatch(albumId, j.albumId, j.serverId ?? serverId)
+            && (!serverId || !j.serverId || j.serverId === serverId),
         );
         if (albumJobs.length === 0) return null;
         const done = albumJobs.filter(j => j.status === 'done' || j.status === 'error').length;
@@ -473,23 +472,39 @@ export const useOfflineStore = create<OfflineState>()(
 
       deleteAlbum: async (albumId, serverId) => {
         useOfflineJobStore.getState().cancelDownload(albumId, serverId);
-        cancelledDownloads.delete(`${serverId}:${albumId}`);
         removeOfflinePinTask(albumId, serverId);
         const indexKey = serverIndexKeyForOffline(serverId);
-        const album = get().albums[`${indexKey}:${albumId}`]
-          ?? get().albums[`${serverId}:${albumId}`];
-        const pinSource: PinSource = album
-          ? { kind: album.type ?? 'album', sourceId: albumId, displayName: album.name }
-          : { kind: 'album', sourceId: albumId };
-        await useLocalPlaybackStore.getState().removeEntriesByPinSource(
-          indexKey,
-          pinSource,
-          getMediaDir(),
-        );
+        const activeAlbumId = canonicalizeConfirmedNavidromeId(indexKey, albumId);
+        const album = Object.values(get().albums).find(meta => (
+          (meta.serverId === indexKey || meta.serverId === serverId)
+          && offlineAlbumIdsMatch(activeAlbumId, meta.id, indexKey)
+        ));
+        const groups = useLocalPlaybackStore.getState().listPinnedGroups(indexKey)
+          .filter(group => offlineAlbumIdsMatch(activeAlbumId, group.pinSource.sourceId, indexKey));
+        if (groups.length > 0) {
+          for (const group of groups) {
+            await useLocalPlaybackStore.getState().removeEntriesByPinSource(
+              indexKey,
+              group.pinSource,
+              getMediaDir(),
+            );
+          }
+        } else if (album) {
+          const pinSource: PinSource = {
+            kind: album.type ?? 'album',
+            sourceId: activeAlbumId,
+            displayName: album.name,
+          };
+          await useLocalPlaybackStore.getState().removeEntriesByPinSource(indexKey, pinSource, getMediaDir());
+        }
         set(state => {
           const albums = { ...state.albums };
-          delete albums[`${indexKey}:${albumId}`];
-          delete albums[`${serverId}:${albumId}`];
+          for (const [key, meta] of Object.entries(albums)) {
+            if (
+              (meta.serverId === indexKey || meta.serverId === serverId)
+              && offlineAlbumIdsMatch(activeAlbumId, meta.id, indexKey)
+            ) delete albums[key];
+          }
           return { albums };
         });
       },

--- a/src/features/offline/store/offlineStore.ts
+++ b/src/features/offline/store/offlineStore.ts
@@ -28,6 +28,7 @@ import {
   type OfflinePinTask,
 } from '@/features/offline/utils/offlinePinQueue';
 import { ownedEntityKey } from '@/lib/util/ownedEntityKey';
+import { canonicalizeConfirmedNavidromeId } from '@/lib/server/navidromeCanonicalIds';
 
 /** @deprecated Metadata lives in the library index; kept for type-compat during transition. */
 export interface OfflineTrackMeta {
@@ -93,7 +94,6 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
   cancelledDownloads.delete(cancelKey);
 
   const CONCURRENCY = 8;
-  const trackIds = songs.map(s => s.id);
   const jobStore = useOfflineJobStore;
   const downloadId = `${serverId}-${albumId}-${Date.now()}`;
   const serverIndexKey = serverIndexKeyForOffline(serverId);
@@ -109,28 +109,61 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
     }
   }
 
+  // The server may have completed its ID migration while this task was waiting
+  // on storage. Resolve IDs immediately before the first durable/network write.
+  const activeAlbumId = canonicalizeConfirmedNavidromeId(serverIndexKey, albumId);
+  const activeSongs = songs.map(song => ({
+    ...song,
+    id: canonicalizeConfirmedNavidromeId(serverIndexKey, song.id),
+    albumId: canonicalizeConfirmedNavidromeId(serverIndexKey, song.albumId),
+    artistId: song.artistId
+      ? canonicalizeConfirmedNavidromeId(serverIndexKey, song.artistId)
+      : song.artistId,
+    coverArt: song.coverArt
+      ? canonicalizeConfirmedNavidromeId(serverIndexKey, song.coverArt)
+      : song.coverArt,
+    artists: song.artists?.map(artist => ({
+      ...artist,
+      id: artist.id ? canonicalizeConfirmedNavidromeId(serverIndexKey, artist.id) : artist.id,
+    })),
+    albumArtists: song.albumArtists?.map(artist => ({
+      ...artist,
+      id: artist.id ? canonicalizeConfirmedNavidromeId(serverIndexKey, artist.id) : artist.id,
+    })),
+    contributors: song.contributors?.map(contributor => ({
+      ...contributor,
+      artist: {
+        ...contributor.artist,
+        id: contributor.artist.id
+          ? canonicalizeConfirmedNavidromeId(serverIndexKey, contributor.artist.id)
+          : contributor.artist.id,
+      },
+    })),
+  }));
+  const activeTrackIds = activeSongs.map(song => song.id);
+
   useOfflineStore.setState(state => ({
     albums: {
       ...state.albums,
-      [`${serverIndexKey}:${albumId}`]: {
-        id: albumId,
+      [`${serverIndexKey}:${activeAlbumId}`]: {
+        id: activeAlbumId,
         serverId: serverIndexKey,
         name: albumName,
         artist: albumArtist,
         coverArt,
         year,
-        trackIds,
+        trackIds: activeTrackIds,
         type,
       },
     },
   }));
 
-  await libraryUpsertSongsFromApi(libraryServerId, songs).catch(() => {});
+  await libraryUpsertSongsFromApi(libraryServerId, activeSongs).catch(() => {});
 
   const lp = useLocalPlaybackStore.getState();
-  const pendingSongs = pendingOfflinePinSongs(songs, serverId);
+  const pendingSongs = pendingOfflinePinSongs(activeSongs, serverId);
   if (pendingSongs.length === 0) {
-    for (const song of songs) {
+    for (const song of activeSongs) {
       const prev = findLocalPlaybackEntry(song.id, serverId);
       if (!prev) continue;
       lp.upsertEntry({
@@ -141,17 +174,17 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
       });
     }
     jobStore.setState(state => ({
-      jobs: state.jobs.filter(j => j.albumId !== albumId || (j.serverId && j.serverId !== serverId)),
+      jobs: state.jobs.filter(j => j.albumId !== activeAlbumId || (j.serverId && j.serverId !== serverId)),
     }));
     return;
   }
 
   jobStore.setState(state => ({
     jobs: [
-      ...state.jobs.filter(j => j.albumId !== albumId || (j.serverId && j.serverId !== serverId)),
+      ...state.jobs.filter(j => j.albumId !== activeAlbumId || (j.serverId && j.serverId !== serverId)),
       ...pendingSongs.map((s, i) => ({
         trackId: s.id,
-        albumId,
+        albumId: activeAlbumId,
         albumName,
         trackTitle: s.title,
         trackIndex: i,
@@ -167,7 +200,7 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
     if (cancelledDownloads.has(cancelKey)) {
       cancelledDownloads.delete(cancelKey);
       jobStore.setState(state => ({
-        jobs: state.jobs.filter(j => j.albumId !== albumId || (j.serverId && j.serverId !== serverId)),
+        jobs: state.jobs.filter(j => j.albumId !== activeAlbumId || (j.serverId && j.serverId !== serverId)),
       }));
       clearOfflineCancel({ downloadId }).catch(() => {});
       return;
@@ -178,7 +211,7 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
 
     jobStore.setState(state => ({
       jobs: state.jobs.map(j =>
-        j.albumId === albumId && (!j.serverId || j.serverId === serverId) && batchIds.has(j.trackId)
+        j.albumId === activeAlbumId && (!j.serverId || j.serverId === serverId) && batchIds.has(j.trackId)
           ? { ...j, status: 'downloading' }
           : j,
       ),
@@ -248,7 +281,7 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
     const resultMap = new Map(results.map(r => [r.song.id, r]));
     jobStore.setState(state => ({
       jobs: state.jobs.map(j => {
-        if (j.albumId !== albumId || (j.serverId && j.serverId !== serverId)) return j;
+        if (j.albumId !== activeAlbumId || (j.serverId && j.serverId !== serverId)) return j;
         const r = resultMap.get(j.trackId);
         if (!r) return j;
         if (r.error === 'CANCELLED') return j;
@@ -261,7 +294,7 @@ async function runOfflinePinDownload(task: OfflinePinTask): Promise<void> {
   setTimeout(() => {
     jobStore.setState(state => ({
       jobs: state.jobs.filter(
-        j => j.albumId !== albumId
+        j => j.albumId !== activeAlbumId
           || (j.serverId && j.serverId !== serverId)
           || (j.status !== 'done' && j.status !== 'error'),
       ),

--- a/src/features/offline/utils/favoritesOfflineSync.test.ts
+++ b/src/features/offline/utils/favoritesOfflineSync.test.ts
@@ -8,6 +8,11 @@ import {
   mergeStarredSongsUnion,
   onFavoritesOfflineStarChange,
 } from '@/features/offline/utils/favoritesOfflineSync';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
 
 const getStarredForServerMock = vi.fn(async (_serverId: string) => ({
   artists: [],
@@ -59,6 +64,7 @@ function song(id: string): SubsonicSong {
 
 describe('onFavoritesOfflineStarChange', () => {
   beforeEach(() => {
+    deactivateCanonicalNavidromeOwners(['srv-a', 'a.test', 'srv-b', 'b.test']);
     vi.useFakeTimers();
     isActiveServerReachableMock.mockReturnValue(true);
     getStarredForServerMock.mockClear();
@@ -138,6 +144,142 @@ describe('onFavoritesOfflineStarChange', () => {
       { downloadIds: ['favorites-111'] },
     );
     expect(useOfflineJobStore.getState().jobs).toEqual([]);
+  });
+
+  it('does not prune canonical favorites from a stale starred response', async () => {
+    const legacyTrackId = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    const canonicalTrackId = canonicalizeNavidromeId(legacyTrackId);
+    let resolveStarred!: (value: { artists: []; albums: []; songs: [] }) => void;
+    getStarredForServerMock.mockImplementationOnce(() => new Promise(resolve => {
+      resolveStarred = resolve;
+    }));
+    useLocalPlaybackStore.setState({
+      entries: {
+        [`a.test:${legacyTrackId}`]: {
+          serverIndexKey: 'a.test',
+          trackId: legacyTrackId,
+          localPath: `/media/${legacyTrackId}.flac`,
+          layoutFingerprint: 'legacy',
+          sizeBytes: 1,
+          tier: 'favorite-auto',
+          cachedAt: 1,
+          suffix: 'flac',
+        },
+      },
+    });
+
+    onFavoritesOfflineStarChange(legacyTrackId, 'song', false, 'srv-a');
+    await vi.advanceTimersByTimeAsync(700);
+    await vi.waitFor(() => expect(getStarredForServerMock).toHaveBeenCalledWith('srv-a'));
+
+    activateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+    useLocalPlaybackStore.setState({
+      entries: {
+        [`a.test:${canonicalTrackId}`]: {
+          serverIndexKey: 'a.test',
+          trackId: canonicalTrackId,
+          localPath: `/media/${canonicalTrackId}.flac`,
+          layoutFingerprint: 'canonical',
+          sizeBytes: 1,
+          tier: 'favorite-auto',
+          cachedAt: 1,
+          suffix: 'flac',
+        },
+      },
+    });
+    resolveStarred({ artists: [], albums: [], songs: [] });
+    await vi.runAllTimersAsync();
+
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      'delete_media_file',
+      expect.objectContaining({ localPath: `/media/${canonicalTrackId}.flac` }),
+    );
+    expect(useLocalPlaybackStore.getState().entries[`a.test:${canonicalTrackId}`]).toBeDefined();
+  });
+
+  it('deletes a stale download result when identity changes in flight', async () => {
+    const legacyTrackId = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    const localPath = `/media/${legacyTrackId}.flac`;
+    let resolveDownload!: (value: {
+      path: string;
+      size: number;
+      layoutFingerprint: string;
+      originalBytesVerified: boolean;
+    }) => void;
+    getStarredForServerMock.mockResolvedValueOnce({
+      artists: [],
+      albums: [],
+      songs: [song(legacyTrackId)],
+    });
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'download_track_local') {
+        return new Promise(resolve => { resolveDownload = resolve; });
+      }
+      return Promise.resolve({});
+    });
+
+    onFavoritesOfflineStarChange(legacyTrackId, 'song', true, 'srv-a');
+    await vi.advanceTimersByTimeAsync(700);
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      'download_track_local',
+      expect.objectContaining({ trackId: legacyTrackId }),
+    ));
+
+    activateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+    resolveDownload({
+      path: localPath,
+      size: 1,
+      layoutFingerprint: 'legacy',
+      originalBytesVerified: true,
+    });
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      'delete_media_file',
+      expect.objectContaining({ localPath }),
+    ));
+
+    expect(useLocalPlaybackStore.getState().entries).toEqual({});
+  });
+
+  it('stops pruning when a newer favorites run cancels the current one', async () => {
+    let resolveDelete!: () => void;
+    getStarredForServerMock.mockResolvedValueOnce({ artists: [], albums: [], songs: [] });
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'delete_media_file') {
+        return new Promise(resolve => { resolveDelete = () => resolve({}); });
+      }
+      return Promise.resolve({});
+    });
+    useLocalPlaybackStore.setState({
+      entries: Object.fromEntries(['t1', 't2'].map(id => [`a.test:${id}`, {
+        serverIndexKey: 'a.test',
+        trackId: id,
+        localPath: `/media/${id}.flac`,
+        layoutFingerprint: id,
+        sizeBytes: 1,
+        tier: 'favorite-auto' as const,
+        cachedAt: 1,
+        suffix: 'flac',
+      }])),
+    });
+
+    onFavoritesOfflineStarChange('t1', 'song', false, 'srv-a');
+    await vi.advanceTimersByTimeAsync(700);
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      'delete_media_file',
+      expect.objectContaining({ localPath: '/media/t1.flac' }),
+    ));
+
+    onFavoritesOfflineStarChange('t2', 'song', true, 'srv-a');
+    resolveDelete();
+    await vi.waitFor(() => {
+    expect(useLocalPlaybackStore.getState().entries['a.test:t1']).toBeDefined();
+    });
+
+    expect(useLocalPlaybackStore.getState().entries['a.test:t2']).toBeDefined();
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      'delete_media_file',
+      expect.objectContaining({ localPath: '/media/t2.flac' }),
+    );
   });
 });
 

--- a/src/features/offline/utils/favoritesOfflineSync.ts
+++ b/src/features/offline/utils/favoritesOfflineSync.ts
@@ -16,6 +16,7 @@ import {
   cancelOfflineDownloads,
   clearOfflineCancel,
   deleteMediaFile,
+  probeMediaFiles,
   pruneEmptyMediaTierDirs,
 } from '@/lib/api/syncfs';
 import { resolveIndexKey, serverIndexKeyForProfile } from '@/lib/server/serverIndexKey';
@@ -28,6 +29,10 @@ import {
   findFavoriteAutoEntry,
   hasLocalLibraryBytes,
 } from '@/store/localPlaybackResolve';
+import {
+  canonicalIdentityGeneration,
+  canonicalIdentityGenerationChanged,
+} from '@/lib/server/navidromeCanonicalIds';
 
 const CONCURRENCY = 2;
 const DEBOUNCE_MS = 600;
@@ -36,6 +41,8 @@ let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 /** Accumulates server ids across debounced calls; `'all'` means fan-out to every server. */
 let pendingSyncServerIds: Set<string> | 'all' = new Set();
 let runToken = 0;
+let syncPauseDepth = 0;
+const serverRunTail = new Map<string, Promise<void>>();
 /** Rust cancellation key for the active favorites batch (`download_track_local`). */
 let activeFavoritesDownloadId: string | null = null;
 
@@ -50,21 +57,18 @@ function rustDownloadIdsForFavoritesJobs(): string[] {
 }
 
 /** Abort in-flight favorites transfers and invalidate the current JS batch loop. */
-function cancelInFlightFavoritesDownloads(): void {
+async function cancelInFlightFavoritesDownloads(): Promise<void> {
   runToken += 1;
   cancelledDownloads.add(FAVORITES_OFFLINE_JOB_ID);
   const downloadIds = rustDownloadIdsForFavoritesJobs();
-  if (downloadIds.length > 0) {
-    cancelOfflineDownloads({ downloadIds }).catch(() => {});
-    for (const id of downloadIds) {
-      clearOfflineCancel({ downloadId: id }).catch(() => {});
-    }
-  }
   activeFavoritesDownloadId = null;
   useOfflineJobStore.setState(state => ({
     jobs: state.jobs.filter(j => j.albumId !== FAVORITES_OFFLINE_JOB_ID),
   }));
   useFavoritesOfflineSyncStore.getState().setRunning(false);
+  if (downloadIds.length > 0) {
+    await cancelOfflineDownloads({ downloadIds }).catch(() => {});
+  }
 }
 
 function serverIndexKeyForSync(serverId: string): string {
@@ -110,8 +114,9 @@ export async function collectStarredSongs(serverId: string): Promise<SubsonicSon
       try {
         const local = await loadAlbumFromLibraryIndex(serverId, album.id);
         if (local) albumTrackLists.push(local.songs);
+        else throw new Error(`starred album unavailable: ${album.id}`);
       } catch {
-        // skip unavailable album
+        throw new Error(`starred album unavailable: ${album.id}`);
       }
     }
   }
@@ -128,13 +133,14 @@ export async function collectStarredSongs(serverId: string): Promise<SubsonicSon
           try {
             const local = await loadAlbumFromLibraryIndex(serverId, alb.id);
             if (local) artistAlbumTrackLists.push(local.songs);
+            else throw new Error(`starred artist album unavailable: ${alb.id}`);
           } catch {
-            // skip album
+            throw new Error(`starred artist album unavailable: ${alb.id}`);
           }
         }
       }
     } catch {
-      // skip unavailable artist
+      throw new Error(`starred artist unavailable: ${artist.id}`);
     }
   }
 
@@ -154,21 +160,35 @@ async function pruneOrphanFavoriteAuto(
   serverId: string,
   targetIds: Set<string>,
   mediaDir: string | null,
+  identityOwner: string,
+  identityGeneration: number,
+  isCurrent: () => boolean,
 ): Promise<void> {
   const lp = useLocalPlaybackStore.getState();
   for (const entry of Object.values(lp.entries)) {
+    if (!isCurrent()) return;
+    if (canonicalIdentityGenerationChanged(identityOwner, identityGeneration)) return;
     if (entry.tier !== 'favorite-auto') continue;
     if (!entryBelongsToServer(entry, serverId)) continue;
     if (targetIds.has(entry.trackId)) continue;
+    if (!isCurrent() || canonicalIdentityGenerationChanged(identityOwner, identityGeneration)) return;
     await deleteMediaFile({ localPath: entry.localPath, mediaDir }).catch(() => {});
-    lp.removeEntry(entry.trackId, entry.serverIndexKey, 'favorite-unstar-prune');
+    const [stillExists] = await probeMediaFiles({ localPaths: [entry.localPath] }).catch(() => [true]);
+    if (stillExists) continue;
+    const current = findFavoriteAutoEntry(entry.trackId, serverId);
+    if (current === entry) {
+      lp.removeEntry(current.trackId, current.serverIndexKey, 'favorite-unstar-prune');
+    }
+    if (!isCurrent() || canonicalIdentityGenerationChanged(identityOwner, identityGeneration)) return;
   }
+  if (!isCurrent() || canonicalIdentityGenerationChanged(identityOwner, identityGeneration)) return;
   await pruneEmptyMediaTierDirs({ tier: 'favorite-auto', mediaDir }).catch(() => {});
 }
 
 export async function disableFavoritesOfflineSync(): Promise<void> {
   useAuthStore.getState().setFavoritesOfflineEnabled(false);
-  cancelInFlightFavoritesDownloads();
+  await cancelInFlightFavoritesDownloads();
+  await Promise.allSettled([...serverRunTail.values()]);
   const mediaDir = getMediaDir();
   await useLocalPlaybackStore.getState().purgeFavoriteAutoDisk(mediaDir);
   useFavoritesOfflineSyncStore.getState().setTargetTrackIds([]);
@@ -176,9 +196,10 @@ export async function disableFavoritesOfflineSync(): Promise<void> {
 }
 
 export function scheduleFavoritesOfflineSync(serverId?: string): void {
+  if (syncPauseDepth > 0) return;
   if (!useAuthStore.getState().favoritesOfflineEnabled) return;
   if (!isActiveServerReachable()) return;
-  cancelInFlightFavoritesDownloads();
+  void cancelInFlightFavoritesDownloads();
   if (serverId) {
     if (pendingSyncServerIds !== 'all') {
       pendingSyncServerIds.add(serverId);
@@ -217,6 +238,7 @@ export function onFavoritesOfflineStarChange(
 }
 
 async function runFavoritesOfflineSyncBatch(serverIds: string[]): Promise<void> {
+  if (syncPauseDepth > 0) return;
   const auth = useAuthStore.getState();
   if (!auth.favoritesOfflineEnabled || serverIds.length === 0) return;
 
@@ -238,24 +260,51 @@ async function runFavoritesOfflineSyncBatch(serverIds: string[]): Promise<void> 
 }
 
 async function runFavoritesOfflineSyncOneServer(serverId: string, token: number): Promise<void> {
+  const previous = serverRunTail.get(serverId) ?? Promise.resolve();
+  const current = previous.catch(() => {}).then(() => runFavoritesOfflineSyncOneServerInner(serverId, token));
+  serverRunTail.set(serverId, current);
+  try {
+    await current;
+  } finally {
+    if (serverRunTail.get(serverId) === current) serverRunTail.delete(serverId);
+  }
+}
+
+async function runFavoritesOfflineSyncOneServerInner(serverId: string, token: number): Promise<void> {
+  if (syncPauseDepth > 0) return;
   const auth = useAuthStore.getState();
   if (!auth.favoritesOfflineEnabled) return;
   const syncStore = useFavoritesOfflineSyncStore.getState();
   const jobStore = useOfflineJobStore;
   const serverIndexKey = serverIndexKeyForSync(serverId);
+  const identityGeneration = canonicalIdentityGeneration(serverIndexKey);
   const libraryServerId = librarySqlScope(serverId);
   const mediaDir = getMediaDir();
   const albumName = i18n.t('favorites.offlineJobName');
+  let downloadId: string | null = null;
 
   try {
     const allSongs = await collectStarredSongs(serverId);
-    if (token !== runToken) return;
+    if (
+      token !== runToken
+      || canonicalIdentityGenerationChanged(serverIndexKey, identityGeneration)
+    ) return;
 
     const targetIds = new Set(allSongs.map(s => s.id));
     syncStore.setTargetTrackIds([...targetIds]);
 
-    await pruneOrphanFavoriteAuto(serverId, targetIds, mediaDir);
-    if (token !== runToken) return;
+    await pruneOrphanFavoriteAuto(
+      serverId,
+      targetIds,
+      mediaDir,
+      serverIndexKey,
+      identityGeneration,
+      () => token === runToken,
+    );
+    if (
+      token !== runToken
+      || canonicalIdentityGenerationChanged(serverIndexKey, identityGeneration)
+    ) return;
 
     await libraryUpsertSongsFromApi(libraryServerId, allSongs).catch(() => {});
 
@@ -270,8 +319,17 @@ async function runFavoritesOfflineSyncOneServer(serverId: string, token: number)
     if (token !== runToken) return;
 
     cancelledDownloads.delete(FAVORITES_OFFLINE_JOB_ID);
-    const downloadId = `favorites-${Date.now()}`;
-    activeFavoritesDownloadId = downloadId;
+    const currentDownloadId = `favorites-${Date.now()}`;
+    downloadId = currentDownloadId;
+    activeFavoritesDownloadId = currentDownloadId;
+
+    const abortStaleDownload = () => {
+      jobStore.setState(state => ({
+        jobs: state.jobs.filter(j => j.albumId !== FAVORITES_OFFLINE_JOB_ID),
+      }));
+      cancelOfflineDownloads({ downloadIds: [currentDownloadId] }).catch(() => {});
+      if (activeFavoritesDownloadId === currentDownloadId) activeFavoritesDownloadId = null;
+    };
 
     jobStore.setState(state => ({
       jobs: [
@@ -284,20 +342,19 @@ async function runFavoritesOfflineSyncOneServer(serverId: string, token: number)
           trackIndex: i,
           totalTracks: pending.length,
           status: 'queued' as const,
-          downloadId,
+          downloadId: currentDownloadId,
         })),
       ],
     }));
 
     for (let i = 0; i < pending.length; i += CONCURRENCY) {
-      if (token !== runToken || cancelledDownloads.has(FAVORITES_OFFLINE_JOB_ID)) {
+      if (
+        token !== runToken
+        || canonicalIdentityGenerationChanged(serverIndexKey, identityGeneration)
+        || cancelledDownloads.has(FAVORITES_OFFLINE_JOB_ID)
+      ) {
         cancelledDownloads.delete(FAVORITES_OFFLINE_JOB_ID);
-        jobStore.setState(state => ({
-          jobs: state.jobs.filter(j => j.albumId !== FAVORITES_OFFLINE_JOB_ID),
-        }));
-        cancelOfflineDownloads({ downloadIds: [downloadId] }).catch(() => {});
-        clearOfflineCancel({ downloadId }).catch(() => {});
-        activeFavoritesDownloadId = null;
+        abortStaleDownload();
         return;
       }
 
@@ -344,11 +401,12 @@ async function runFavoritesOfflineSyncOneServer(serverId: string, token: number)
                 url: buildOriginalStreamUrlForServer(serverId, song.id),
                 suffix,
                 mediaDir,
-                downloadId,
+                downloadId: currentDownloadId,
               },
             );
             if (
               token !== runToken
+              || canonicalIdentityGenerationChanged(serverIndexKey, identityGeneration)
               || cancelledDownloads.has(FAVORITES_OFFLINE_JOB_ID)
               || !targetIds.has(song.id)
             ) {
@@ -386,6 +444,10 @@ async function runFavoritesOfflineSyncOneServer(serverId: string, token: number)
           }),
         }));
       });
+      if (canonicalIdentityGenerationChanged(serverIndexKey, identityGeneration)) {
+        abortStaleDownload();
+        return;
+      }
     }
 
     if (token === runToken) {
@@ -394,10 +456,6 @@ async function runFavoritesOfflineSyncOneServer(serverId: string, token: number)
           j => j.albumId !== FAVORITES_OFFLINE_JOB_ID || (j.status !== 'done' && j.status !== 'error'),
         ),
       }));
-      if (activeFavoritesDownloadId === downloadId) {
-        clearOfflineCancel({ downloadId }).catch(() => {});
-        activeFavoritesDownloadId = null;
-      }
       await pruneEmptyMediaTierDirs({ tier: 'favorite-auto', mediaDir }).catch(() => {});
     }
   } catch (err) {
@@ -405,7 +463,29 @@ async function runFavoritesOfflineSyncOneServer(serverId: string, token: number)
       const msg = err instanceof Error ? err.message : String(err);
       syncStore.setLastError(msg);
     }
+  } finally {
+    if (downloadId) {
+      clearOfflineCancel({ downloadId }).catch(() => {});
+      if (activeFavoritesDownloadId === downloadId) activeFavoritesDownloadId = null;
+    }
   }
+}
+
+export async function pauseAndDrainFavoritesOfflineSync(): Promise<void> {
+  syncPauseDepth += 1;
+  if (syncPauseDepth > 1) return;
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = null;
+  pendingSyncServerIds = new Set();
+  await cancelInFlightFavoritesDownloads();
+  await Promise.allSettled([...serverRunTail.values()]);
+}
+
+export function resumeFavoritesOfflineSync(): void {
+  if (syncPauseDepth === 0) return;
+  syncPauseDepth -= 1;
+  if (syncPauseDepth > 0) return;
+  scheduleFavoritesOfflineSync();
 }
 
 /** Run an initial sync when the setting is enabled (app start / server change). */

--- a/src/features/offline/utils/libraryTierReconcile.test.ts
+++ b/src/features/offline/utils/libraryTierReconcile.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuthStore } from '@/store/authStore';
+import { useLocalPlaybackStore } from '@/store/localPlaybackStore';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
+
+const mocks = vi.hoisted(() => ({
+  discoverLibraryTierOnDisk: vi.fn(),
+  pruneOrphanLibraryTierFiles: vi.fn(async () => [] as string[]),
+}));
+
+vi.mock('@/lib/api/syncfs', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/api/syncfs')>()),
+  discoverLibraryTierOnDisk: mocks.discoverLibraryTierOnDisk,
+  pruneOrphanLibraryTierFiles: mocks.pruneOrphanLibraryTierFiles,
+}));
+
+import { reconcileLibraryTierForServer } from './libraryTierReconcile';
+
+const LEGACY_TRACK = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+const CANONICAL_TRACK = canonicalizeNavidromeId(LEGACY_TRACK);
+
+describe('library tier identity transitions', () => {
+  beforeEach(() => {
+    deactivateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+    mocks.discoverLibraryTierOnDisk.mockReset();
+    mocks.pruneOrphanLibraryTierFiles.mockClear();
+    useAuthStore.setState({
+      servers: [{ id: 'srv-a', name: 'A', url: 'https://a.test', username: 'u', password: 'p' }],
+      activeServerId: 'srv-a',
+    });
+    useLocalPlaybackStore.setState({
+      entries: {
+        [`a.test:${LEGACY_TRACK}`]: {
+          serverIndexKey: 'a.test',
+          trackId: LEGACY_TRACK,
+          localPath: `/media/${LEGACY_TRACK}.flac`,
+          layoutFingerprint: 'legacy',
+          sizeBytes: 1,
+          tier: 'library',
+          cachedAt: 1,
+          suffix: 'flac',
+        },
+      },
+    });
+  });
+
+  it('does not delete canonical entries or files from a stale discovery result', async () => {
+    let resolveDiscovery!: (hits: []) => void;
+    mocks.discoverLibraryTierOnDisk.mockImplementation(() => new Promise(resolve => {
+      resolveDiscovery = resolve;
+    }));
+
+    const reconcile = reconcileLibraryTierForServer('srv-a');
+    await vi.waitFor(() => expect(mocks.discoverLibraryTierOnDisk).toHaveBeenCalledOnce());
+
+    activateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+    useLocalPlaybackStore.setState({
+      entries: {
+        [`a.test:${CANONICAL_TRACK}`]: {
+          serverIndexKey: 'a.test',
+          trackId: CANONICAL_TRACK,
+          localPath: `/media/${CANONICAL_TRACK}.flac`,
+          layoutFingerprint: 'canonical',
+          sizeBytes: 1,
+          tier: 'library',
+          cachedAt: 1,
+          suffix: 'flac',
+        },
+      },
+    });
+    resolveDiscovery([]);
+    await reconcile;
+
+    expect(useLocalPlaybackStore.getState().entries[`a.test:${CANONICAL_TRACK}`]).toBeDefined();
+    expect(mocks.pruneOrphanLibraryTierFiles).not.toHaveBeenCalled();
+  });
+
+  it('preserves a download committed after the disk snapshot started', async () => {
+    let resolveDiscovery!: (hits: []) => void;
+    mocks.discoverLibraryTierOnDisk.mockImplementation(() => new Promise(resolve => {
+      resolveDiscovery = resolve;
+    }));
+    useLocalPlaybackStore.setState({ entries: {} });
+
+    const reconcile = reconcileLibraryTierForServer('srv-a');
+    await vi.waitFor(() => expect(mocks.discoverLibraryTierOnDisk).toHaveBeenCalledOnce());
+
+    useLocalPlaybackStore.getState().upsertEntry({
+      serverIndexKey: 'a.test',
+      trackId: 'new-track',
+      localPath: '/media/new-track.flac',
+      layoutFingerprint: 'new',
+      sizeBytes: 2,
+      tier: 'library',
+      suffix: 'flac',
+    });
+    resolveDiscovery([]);
+    await reconcile;
+
+    expect(useLocalPlaybackStore.getState().entries['a.test:new-track']).toBeDefined();
+    expect(mocks.pruneOrphanLibraryTierFiles).toHaveBeenCalledWith(expect.objectContaining({
+      keepPaths: ['/media/new-track.flac'],
+    }));
+  });
+
+  it('does not delete index rows or files when disk discovery fails', async () => {
+    mocks.discoverLibraryTierOnDisk.mockRejectedValue(new Error('disk unavailable'));
+
+    const result = await reconcileLibraryTierForServer('srv-a');
+
+    expect(result).toEqual({ syncedFromDisk: 0, removedStaleIndex: 0, orphansRemoved: 0 });
+    expect(useLocalPlaybackStore.getState().entries[`a.test:${LEGACY_TRACK}`]).toBeDefined();
+    expect(mocks.pruneOrphanLibraryTierFiles).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/offline/utils/libraryTierReconcile.ts
+++ b/src/features/offline/utils/libraryTierReconcile.ts
@@ -13,6 +13,10 @@ import {
   indexKeyBelongsToServer,
 } from '@/store/localPlaybackResolve';
 import type { LibraryTierDiskHit } from '@/generated/bindings';
+import {
+  canonicalIdentityGeneration,
+  canonicalIdentityGenerationChanged,
+} from '@/lib/server/navidromeCanonicalIds';
 
 interface LibraryTrackProbeResult {
   path: string;
@@ -25,6 +29,19 @@ export interface LibraryTierReconcileResult {
   syncedFromDisk: number;
   removedStaleIndex: number;
   orphansRemoved: number;
+}
+
+const reconcileTailByServer = new Map<string, Promise<unknown>>();
+
+async function serializeReconcile<T>(serverId: string, run: () => Promise<T>): Promise<T> {
+  const previous = reconcileTailByServer.get(serverId) ?? Promise.resolve();
+  const current = previous.catch(() => {}).then(run);
+  reconcileTailByServer.set(serverId, current);
+  try {
+    return await current;
+  } finally {
+    if (reconcileTailByServer.get(serverId) === current) reconcileTailByServer.delete(serverId);
+  }
 }
 
 function serverIndexKeyForServerId(serverId: string): string {
@@ -85,48 +102,50 @@ async function discoverLibraryTierHits(
 ): Promise<LibraryTierDiskHit[]> {
   const serverIndexKey = serverIndexKeyForServerId(serverId);
   const libraryServerId = librarySqlServerId(serverId);
-  try {
-    return await discoverLibraryTierOnDisk({
-      serverIndexKey,
-      libraryServerId,
-      candidateTrackIds,
-      mediaDir: getMediaDir(),
-    });
-  } catch {
-    return [];
-  }
+  return discoverLibraryTierOnDisk({
+    serverIndexKey,
+    libraryServerId,
+    candidateTrackIds,
+    mediaDir: getMediaDir(),
+  });
 }
 
 async function importLibraryTierFromDisk(
   serverId: string,
   candidateTrackIds: string[],
+  identityGeneration: number,
 ): Promise<{
   hits: LibraryTierDiskHit[];
-  imported: number;
   hitByTrackId: Map<string, LibraryTierDiskHit>;
 }> {
   const serverIndexKey = serverIndexKeyForServerId(serverId);
   const hits = await discoverLibraryTierHits(serverId, candidateTrackIds);
+  if (canonicalIdentityGenerationChanged(serverIndexKey, identityGeneration)) {
+    return { hits: [], hitByTrackId: new Map() };
+  }
   const hitByTrackId = new Map(hits.map(hit => [hit.trackId, hit]));
+  return { hits, hitByTrackId };
+}
+
+function applyDiskImports(
+  serverId: string,
+  serverIndexKey: string,
+  hits: LibraryTierDiskHit[],
+  entriesAtStart: Map<string, LocalPlaybackEntry | null>,
+): number {
   let imported = 0;
   for (const hit of hits) {
     const existing = findLocalPlaybackEntry(hit.trackId, serverId);
+    if (existing !== (entriesAtStart.get(hit.trackId) ?? null)) continue;
     if (
       existing
       && existing.localPath === hit.path
       && existing.layoutFingerprint === hit.layoutFingerprint
       && existing.sizeBytes === hit.size
       && existing.serverIndexKey === serverIndexKey
-    ) {
-      continue;
-    }
+    ) continue;
     upsertFromProbe(
-      {
-        path: hit.path,
-        size: hit.size,
-        layoutFingerprint: hit.layoutFingerprint,
-        exists: true,
-      },
+      { path: hit.path, size: hit.size, layoutFingerprint: hit.layoutFingerprint, exists: true },
       serverIndexKey,
       serverId,
       hit.trackId,
@@ -135,7 +154,7 @@ async function importLibraryTierFromDisk(
     );
     imported += 1;
   }
-  return { hits, imported, hitByTrackId };
+  return imported;
 }
 
 /**
@@ -154,31 +173,55 @@ export async function reconcileAllLibraryTiersFromDisk(): Promise<void> {
 export async function reconcileLibraryTierForServer(
   serverId: string,
 ): Promise<LibraryTierReconcileResult> {
+  return serializeReconcile(serverId, () => reconcileLibraryTierForServerInner(serverId));
+}
+
+async function reconcileLibraryTierForServerInner(
+  serverId: string,
+): Promise<LibraryTierReconcileResult> {
   const serverIndexKey = serverIndexKeyForServerId(serverId);
+  const identityGeneration = canonicalIdentityGeneration(serverIndexKey);
   const lp = useLocalPlaybackStore.getState();
   const keepPaths = new Set<string>();
   let syncedFromDisk = 0;
   let removedStaleIndex = 0;
+  const entriesAtStartList = libraryEntriesForServer(serverId);
+  const entriesAtStart = new Map(entriesAtStartList.map(entry => [entry.trackId, entry]));
 
   const candidates = collectCandidateTrackIds(serverId);
-  const diskImport = await importLibraryTierFromDisk(serverId, candidates);
-  syncedFromDisk += diskImport.imported;
+  let diskImport;
+  try {
+    diskImport = await importLibraryTierFromDisk(serverId, candidates, identityGeneration);
+  } catch {
+    return { syncedFromDisk: 0, removedStaleIndex: 0, orphansRemoved: 0 };
+  }
+  if (canonicalIdentityGenerationChanged(serverIndexKey, identityGeneration)) {
+    return { syncedFromDisk: 0, removedStaleIndex: 0, orphansRemoved: 0 };
+  }
+  syncedFromDisk += applyDiskImports(serverId, serverIndexKey, diskImport.hits, entriesAtStart);
   for (const hit of diskImport.hits) {
     keepPaths.add(hit.path);
   }
 
-  for (const entry of libraryEntriesForServer(serverId)) {
+  for (const entry of entriesAtStartList) {
     const hit = diskImport.hitByTrackId.get(entry.trackId);
     if (hit) {
       keepPaths.add(hit.path);
       continue;
     }
-    lp.removeEntry(entry.trackId, entry.serverIndexKey, 'reconcile-missing-bytes');
+    const current = findLocalPlaybackEntry(entry.trackId, serverId);
+    if (current !== entry) continue;
+    lp.removeEntry(current.trackId, current.serverIndexKey, 'reconcile-missing-bytes');
     removedStaleIndex += 1;
   }
 
+  for (const entry of libraryEntriesForServer(serverId)) keepPaths.add(entry.localPath);
+
   let orphansRemoved: number;
   try {
+    if (canonicalIdentityGenerationChanged(serverIndexKey, identityGeneration)) {
+      return { syncedFromDisk, removedStaleIndex, orphansRemoved: 0 };
+    }
     const removed = await pruneOrphanLibraryTierFiles({
       serverIndexKey,
       keepPaths: [...keepPaths],
@@ -198,7 +241,19 @@ export async function reconcileLibraryTierForAlbum(
   songs: SubsonicSong[],
   pinSource?: PinSource,
 ): Promise<LibraryTierReconcileResult> {
+  return serializeReconcile(
+    serverId,
+    () => reconcileLibraryTierForAlbumInner(serverId, songs, pinSource),
+  );
+}
+
+async function reconcileLibraryTierForAlbumInner(
+  serverId: string,
+  songs: SubsonicSong[],
+  pinSource?: PinSource,
+): Promise<LibraryTierReconcileResult> {
   const serverIndexKey = serverIndexKeyForServerId(serverId);
+  const identityGeneration = canonicalIdentityGeneration(serverIndexKey);
   const libraryServerId = librarySqlServerId(serverId);
   const lp = useLocalPlaybackStore.getState();
   const keepPaths = new Set<string>();
@@ -206,14 +261,35 @@ export async function reconcileLibraryTierForAlbum(
   let removedStaleIndex = 0;
 
   await libraryUpsertSongsFromApi(libraryServerId, songs).catch(() => {});
+  if (canonicalIdentityGenerationChanged(serverIndexKey, identityGeneration)) {
+    return { syncedFromDisk: 0, removedStaleIndex: 0, orphansRemoved: 0 };
+  }
 
+  const entriesAtStart = new Map(
+    songs.map(song => [song.id, findLocalPlaybackEntry(song.id, serverId)]),
+  );
   const candidates = collectCandidateTrackIds(serverId, songs.map(song => song.id));
-  const diskImport = await importLibraryTierFromDisk(serverId, candidates);
+  let diskImport;
+  try {
+    diskImport = await importLibraryTierFromDisk(serverId, candidates, identityGeneration);
+  } catch {
+    return { syncedFromDisk: 0, removedStaleIndex: 0, orphansRemoved: 0 };
+  }
+  if (canonicalIdentityGenerationChanged(serverIndexKey, identityGeneration)) {
+    return { syncedFromDisk: 0, removedStaleIndex: 0, orphansRemoved: 0 };
+  }
+
+  syncedFromDisk += applyDiskImports(serverId, serverIndexKey, diskImport.hits, entriesAtStart);
 
   for (const song of songs) {
     const hit = diskImport.hitByTrackId.get(song.id);
-    const existing = findLocalPlaybackEntry(song.id, serverId);
+    const existing = entriesAtStart.get(song.id) ?? null;
     if (hit) {
+      const current = findLocalPlaybackEntry(song.id, serverId);
+      if (current !== existing) {
+        if (current?.localPath) keepPaths.add(current.localPath);
+        continue;
+      }
       keepPaths.add(hit.path);
       const effectivePin = pinSource ?? existing?.pinSource;
       if (
@@ -221,6 +297,9 @@ export async function reconcileLibraryTierForAlbum(
         || existing.localPath !== hit.path
         || existing.layoutFingerprint !== hit.layoutFingerprint
         || existing.serverIndexKey !== serverIndexKey
+        || existing.pinSource?.kind !== effectivePin?.kind
+        || existing.pinSource?.sourceId !== effectivePin?.sourceId
+        || existing.pinSource?.displayName !== effectivePin?.displayName
       ) {
         upsertFromProbe(
           {
@@ -240,7 +319,9 @@ export async function reconcileLibraryTierForAlbum(
       continue;
     }
     if (existing) {
-      lp.removeEntry(song.id, existing.serverIndexKey, 'reconcile-album-missing-bytes');
+      const current = findLocalPlaybackEntry(song.id, serverId);
+      if (current !== existing) continue;
+      lp.removeEntry(current.trackId, current.serverIndexKey, 'reconcile-album-missing-bytes');
       removedStaleIndex += 1;
     }
   }
@@ -248,9 +329,13 @@ export async function reconcileLibraryTierForAlbum(
   for (const hit of diskImport.hits) {
     keepPaths.add(hit.path);
   }
+  for (const entry of libraryEntriesForServer(serverId)) keepPaths.add(entry.localPath);
 
   let orphansRemoved: number;
   try {
+    if (canonicalIdentityGenerationChanged(serverIndexKey, identityGeneration)) {
+      return { syncedFromDisk, removedStaleIndex, orphansRemoved: 0 };
+    }
     const removed = await pruneOrphanLibraryTierFiles({
       serverIndexKey,
       keepPaths: [...keepPaths],

--- a/src/features/offline/utils/offlineLibraryHelpers.test.ts
+++ b/src/features/offline/utils/offlineLibraryHelpers.test.ts
@@ -14,11 +14,17 @@ import {
   pendingOfflinePinSongs,
   offlineAlbumCoverScope,
   offlineTrackCount,
+  resolveOfflineAlbumMeta,
   type OfflineLibraryCard,
 } from '@/features/offline/utils/offlineLibraryHelpers';
 import * as libraryApi from '@/lib/api/library';
 import { coverStorageKey } from '@/cover/storageKeys';
 import { resolveCoverDisplayTier } from '@/cover/tiers';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
 
 vi.mock('@/utils/server/switchActiveServer', () => ({
   switchActiveServer: vi.fn(async () => true),
@@ -46,6 +52,7 @@ vi.mock('@/lib/api/library', async importOriginal => {
 
 describe('offlineLibraryHelpers', () => {
   beforeEach(() => {
+    deactivateCanonicalNavidromeOwners(['a', 'a.test']);
     useAuthStore.setState({
       servers: [{ id: 'a', name: 'Home', url: 'http://a.test', username: 'u', password: 'p' }],
       activeServerId: 'a',
@@ -172,6 +179,25 @@ describe('offlineLibraryHelpers', () => {
       },
     });
     expect(isOfflinePinComplete('al1', 'a')).toBe(true);
+  });
+
+  it('resolves canonical pin metadata when queried with a legacy album id', () => {
+    const legacyAlbumId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const canonicalAlbumId = canonicalizeNavidromeId(legacyAlbumId);
+    activateCanonicalNavidromeOwners(['a', 'a.test']);
+    useOfflineStore.setState({
+      albums: {
+        [`a.test:${canonicalAlbumId}`]: {
+          id: canonicalAlbumId,
+          serverId: 'a.test',
+          name: 'Al',
+          artist: 'Ar',
+          trackIds: ['t1'],
+        },
+      },
+    });
+
+    expect(resolveOfflineAlbumMeta(legacyAlbumId, 'a')?.id).toBe(canonicalAlbumId);
   });
 
   it('hasAnyOfflineAlbums is true when pinned groups exist', () => {

--- a/src/features/offline/utils/offlineLibraryHelpers.ts
+++ b/src/features/offline/utils/offlineLibraryHelpers.ts
@@ -12,6 +12,7 @@ import { canonicalQueueServerKey, resolveIndexKey } from '@/lib/server/serverInd
 import type { Track } from '@/lib/media/trackTypes';
 import { findServerByIdOrIndexKey, resolveServerIdForIndexKey } from '@/lib/server/serverLookup';
 import { serverIndexKeyForProfile } from '@/lib/server/serverIndexKey';
+import { canonicalizeConfirmedNavidromeId } from '@/lib/server/navidromeCanonicalIds';
 
 export interface OfflineLibraryCard {
   serverIndexKey: string;
@@ -41,7 +42,11 @@ export function resolveOfflineAlbumMeta(
   const albums = useOfflineStore.getState().albums;
   const server = useAuthStore.getState().servers.find(s => s.id === serverId);
   const indexKey = server ? serverIndexKeyForProfile(server) : serverId;
-  return albums[`${indexKey}:${albumId}`] ?? albums[`${serverId}:${albumId}`];
+  const activeAlbumId = canonicalizeConfirmedNavidromeId(indexKey, albumId);
+  return albums[`${indexKey}:${activeAlbumId}`]
+    ?? albums[`${serverId}:${activeAlbumId}`]
+    ?? albums[`${indexKey}:${albumId}`]
+    ?? albums[`${serverId}:${albumId}`];
 }
 
 /** Songs that still need a library-tier pin (used to skip redundant downloads). */
@@ -69,10 +74,11 @@ export function isOfflinePinComplete(
   }
   const server = useAuthStore.getState().servers.find(s => s.id === serverId);
   const indexKey = server ? (serverIndexKeyForProfile(server) || serverId) : serverId;
+  const activeAlbumId = canonicalizeConfirmedNavidromeId(indexKey, albumId);
   const meta = resolveOfflineAlbumMeta(albumId, serverId);
   const groupTrackIds = useLocalPlaybackStore.getState()
     .listPinnedGroups(indexKey)
-    .find(g => g.pinSource.sourceId === albumId)?.trackIds;
+    .find(g => canonicalizeConfirmedNavidromeId(indexKey, g.pinSource.sourceId) === activeAlbumId)?.trackIds;
   const trackIds = meta?.trackIds.length
     ? meta.trackIds
     : (groupTrackIds ?? []);

--- a/src/features/offline/utils/offlinePinQueue.test.ts
+++ b/src/features/offline/utils/offlinePinQueue.test.ts
@@ -6,12 +6,21 @@ import {
   enqueueOfflinePin,
   isAlbumPinQueued,
   registerOfflinePinExecutor,
+  removeOfflinePinTask,
+  cancelAndDrainOfflinePinQueue,
+  resumeOfflinePinQueue,
 } from '@/features/offline/utils/offlinePinQueue';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
 
 describe('offlinePinQueue', () => {
   beforeEach(() => {
+    deactivateCanonicalNavidromeOwners(['srv']);
     cancelledDownloads.clear();
-    clearOfflinePinTasks();
+    clearOfflinePinTasks(true);
     useOfflineJobStore.setState({ jobs: [], pinQueue: [], bulkProgress: {} });
     registerOfflinePinExecutor(async () => {});
   });
@@ -119,6 +128,37 @@ describe('offlinePinQueue', () => {
     expect(useOfflineJobStore.getState().pinQueue).toHaveLength(1);
   });
 
+  it('buffers a pin requested while the queue is paused', async () => {
+    const ran: string[] = [];
+    registerOfflinePinExecutor(async task => { ran.push(task.albumId); });
+    await cancelAndDrainOfflinePinQueue();
+
+    expect(enqueueOfflinePin({
+      albumId: 'alb-paused', albumName: 'Paused', albumArtist: 'A', coverArt: undefined,
+      year: undefined, songs: [], serverId: 'srv', type: 'album',
+    })).toBe(true);
+    expect(ran).toEqual([]);
+
+    resumeOfflinePinQueue();
+    await vi.waitFor(() => expect(ran).toEqual(['alb-paused']));
+  });
+
+  it('allows a buffered pin to be removed before resume', async () => {
+    const ran: string[] = [];
+    registerOfflinePinExecutor(async task => { ran.push(task.albumId); });
+    await cancelAndDrainOfflinePinQueue();
+    enqueueOfflinePin({
+      albumId: 'alb-cancelled', albumName: 'Cancelled', albumArtist: 'A', coverArt: undefined,
+      year: undefined, songs: [], serverId: 'srv', type: 'album',
+    });
+
+    removeOfflinePinTask('alb-cancelled', 'srv');
+    resumeOfflinePinQueue();
+    await Promise.resolve();
+
+    expect(ran).toEqual([]);
+  });
+
   it('keeps same-id pins from different servers separate', async () => {
     const gate = { unblock: undefined as (() => void) | undefined };
     registerOfflinePinExecutor(async () => {
@@ -221,5 +261,105 @@ describe('offlinePinQueue', () => {
 
     gate.unblock?.();
     await vi.waitFor(() => expect(order).toEqual(['alb-1', 'alb-2']));
+  });
+
+  it('canonicalizes a queued legacy payload again when execution begins after ACK', async () => {
+    const legacyAlbumId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const legacyTrackId = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    const legacyCoverId = '00112233-4455-6677-8899-aabbccddeeff';
+    const firstGate = { unblock: undefined as (() => void) | undefined };
+    const executed: Array<{ albumId: string; coverArt?: string; trackId?: string }> = [];
+    registerOfflinePinExecutor(async task => {
+      executed.push({
+        albumId: task.albumId,
+        coverArt: task.coverArt,
+        trackId: task.songs[0]?.id,
+      });
+      if (executed.length === 1) {
+        await new Promise<void>(resolve => { firstGate.unblock = resolve; });
+      }
+    });
+
+    enqueueOfflinePin({
+      albumId: 'first', albumName: 'First', albumArtist: 'A', coverArt: undefined,
+      year: undefined, songs: [], serverId: 'srv', type: 'album',
+    });
+    enqueueOfflinePin({
+      albumId: legacyAlbumId,
+      albumName: 'Legacy',
+      albumArtist: 'A',
+      coverArt: legacyCoverId,
+      year: undefined,
+      songs: [{
+        id: legacyTrackId,
+        title: 'Track',
+        artist: 'A',
+        album: 'Legacy',
+        albumId: legacyAlbumId,
+        coverArt: legacyCoverId,
+        duration: 1,
+      }],
+      serverId: 'srv',
+      type: 'album',
+    });
+    await vi.waitFor(() => expect(executed).toHaveLength(1));
+
+    activateCanonicalNavidromeOwners(['srv']);
+    firstGate.unblock?.();
+
+    await vi.waitFor(() => expect(executed).toHaveLength(2));
+    expect(executed[1]).toEqual({
+      albumId: canonicalizeNavidromeId(legacyAlbumId),
+      coverArt: canonicalizeNavidromeId(legacyCoverId),
+      trackId: canonicalizeNavidromeId(legacyTrackId),
+    });
+    deactivateCanonicalNavidromeOwners(['srv']);
+  });
+
+  it('merges legacy and canonical queued representations without dropping the latest task', async () => {
+    const legacyAlbumId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const legacyTrackId = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    const canonicalAlbumId = canonicalizeNavidromeId(legacyAlbumId);
+    const canonicalTrackId = canonicalizeNavidromeId(legacyTrackId);
+    const firstGate = { unblock: undefined as (() => void) | undefined };
+    const executed: Array<{ albumId: string; trackIds: string[] }> = [];
+    registerOfflinePinExecutor(async task => {
+      executed.push({ albumId: task.albumId, trackIds: task.songs.map(song => song.id) });
+      if (executed.length === 1) {
+        await new Promise<void>(resolve => { firstGate.unblock = resolve; });
+      }
+    });
+    enqueueOfflinePin({
+      albumId: 'first', albumName: 'First', albumArtist: 'A', coverArt: undefined,
+      year: undefined, songs: [], serverId: 'srv', type: 'album',
+    });
+    enqueueOfflinePin({
+      albumId: legacyAlbumId, albumName: 'Legacy', albumArtist: 'A', coverArt: undefined,
+      year: undefined,
+      songs: [{
+        id: legacyTrackId, title: 'Old', artist: 'A', album: 'Legacy',
+        albumId: legacyAlbumId, duration: 1,
+      }],
+      serverId: 'srv', type: 'album',
+    });
+    await vi.waitFor(() => expect(executed).toHaveLength(1));
+
+    activateCanonicalNavidromeOwners(['srv']);
+    expect(enqueueOfflinePin({
+      albumId: canonicalAlbumId, albumName: 'Canonical', albumArtist: 'A', coverArt: undefined,
+      year: undefined,
+      songs: [{
+        id: canonicalTrackId, title: 'New', artist: 'A', album: 'Canonical',
+        albumId: canonicalAlbumId, duration: 1,
+      }],
+      serverId: 'srv', type: 'album',
+    })).toBe(true);
+
+    expect(useOfflineJobStore.getState().pinQueue.filter(entry => entry.status === 'queued')).toEqual([
+      expect.objectContaining({ albumId: canonicalAlbumId, albumName: 'Canonical' }),
+    ]);
+    firstGate.unblock?.();
+    await vi.waitFor(() => expect(executed).toHaveLength(2));
+    expect(executed[1]).toEqual({ albumId: canonicalAlbumId, trackIds: [canonicalTrackId] });
   });
 });

--- a/src/features/offline/utils/offlinePinQueue.ts
+++ b/src/features/offline/utils/offlinePinQueue.ts
@@ -2,9 +2,11 @@ import type { SubsonicSong } from '@/lib/api/subsonicTypes';
 import type { PinSource } from '@/store/localPlaybackStore';
 import {
   cancelledDownloads,
+  offlineAlbumIdsMatch,
   useOfflineJobStore,
   type OfflinePinQueueEntry,
 } from '@/features/offline/store/offlineJobStore';
+import { canonicalizeConfirmedNavidromeId } from '@/lib/server/navidromeCanonicalIds';
 
 export type OfflinePinKind = PinSource['kind'];
 
@@ -26,27 +28,121 @@ type OfflinePinExecutor = (task: OfflinePinTask) => Promise<void>;
 const pinTasks = new Map<string, OfflinePinTask>();
 let executor: OfflinePinExecutor | null = null;
 let queueDraining = false;
+let drainPromise: Promise<void> | null = null;
+let queuePauseDepth = 0;
+let pausedPinTasks: OfflinePinTask[] = [];
 
 export function registerOfflinePinExecutor(fn: OfflinePinExecutor): void {
   executor = fn;
 }
 
-export function clearOfflinePinTasks(): void {
+export function clearOfflinePinTasks(resetDrain = false): void {
   pinTasks.clear();
+  if (resetDrain) {
+    queueDraining = false;
+    drainPromise = null;
+    queuePauseDepth = 0;
+    pausedPinTasks = [];
+  }
 }
 
 function pinKey(albumId: string, serverId?: string): string {
   return serverId ? `${serverId}:${albumId}` : albumId;
 }
 
+function canonicalAlbumId(albumId: string, serverId?: string): string {
+  return serverId ? canonicalizeConfirmedNavidromeId(serverId, albumId) : albumId;
+}
+
+export function canonicalizeOfflinePinTask(task: OfflinePinTask, owner = task.serverId): OfflinePinTask {
+  const canonicalize = (value: string): string => canonicalizeConfirmedNavidromeId(owner, value);
+  return {
+    ...task,
+    albumId: canonicalize(task.albumId),
+    coverArt: task.coverArt ? canonicalize(task.coverArt) : task.coverArt,
+    songs: task.songs.map(song => ({
+      ...song,
+      id: canonicalize(song.id),
+      albumId: canonicalize(song.albumId),
+      artistId: song.artistId ? canonicalize(song.artistId) : song.artistId,
+      coverArt: song.coverArt ? canonicalize(song.coverArt) : song.coverArt,
+      artists: song.artists?.map(artist => ({
+        ...artist,
+        id: artist.id ? canonicalize(artist.id) : artist.id,
+      })),
+      albumArtists: song.albumArtists?.map(artist => ({
+        ...artist,
+        id: artist.id ? canonicalize(artist.id) : artist.id,
+      })),
+      contributors: song.contributors?.map(contributor => ({
+        ...contributor,
+        artist: {
+          ...contributor.artist,
+          id: contributor.artist.id ? canonicalize(contributor.artist.id) : contributor.artist.id,
+        },
+      })),
+    })),
+  };
+}
+
+function normalizeQueuedPins(): void {
+  const queue = useOfflineJobStore.getState().pinQueue;
+  const nextQueue: OfflinePinQueueEntry[] = [];
+  const queueIndexByKey = new Map<string, number>();
+  let changed = false;
+
+  for (const entry of queue) {
+    if (entry.status === 'downloading') {
+      nextQueue.push(entry);
+      continue;
+    }
+    const albumId = canonicalAlbumId(entry.albumId, entry.serverId);
+    const oldKey = pinKey(entry.albumId, entry.serverId);
+    const nextKey = pinKey(albumId, entry.serverId);
+    const task = pinTasks.get(oldKey);
+    if (task) {
+      const activeTask = canonicalizeOfflinePinTask(task);
+      pinTasks.delete(oldKey);
+      pinTasks.set(nextKey, activeTask);
+    }
+    if (cancelledDownloads.delete(oldKey)) cancelledDownloads.add(nextKey);
+
+    const existingIndex = queueIndexByKey.get(nextKey);
+    const normalized = albumId === entry.albumId ? entry : { ...entry, albumId };
+    if (existingIndex === undefined) {
+      queueIndexByKey.set(nextKey, nextQueue.length);
+      nextQueue.push(normalized);
+    } else {
+      const existing = nextQueue[existingIndex]!;
+      nextQueue[existingIndex] = {
+        ...normalized,
+        queuedAt: Math.min(existing.queuedAt, normalized.queuedAt),
+      };
+      changed = true;
+    }
+    if (normalized !== entry) changed = true;
+  }
+
+  if (changed) useOfflineJobStore.setState({ pinQueue: nextQueue });
+}
+
 export function removeOfflinePinTask(albumId: string, serverId?: string): void {
-  pinTasks.delete(pinKey(albumId, serverId));
+  for (const [key, task] of pinTasks) {
+    if (
+      (!serverId || task.serverId === serverId)
+      && offlineAlbumIdsMatch(albumId, task.albumId, task.serverId)
+    ) pinTasks.delete(key);
+  }
+  pausedPinTasks = pausedPinTasks.filter(task => (
+    (serverId && task.serverId !== serverId)
+    || !offlineAlbumIdsMatch(albumId, task.albumId, task.serverId)
+  ));
 }
 
 /** True when the album is waiting in the pin queue (not actively downloading). */
 export function isAlbumPinQueued(albumId: string, serverId?: string): boolean {
   return useOfflineJobStore.getState().pinQueue.some(
-    p => p.albumId === albumId
+    p => offlineAlbumIdsMatch(albumId, p.albumId, p.serverId ?? serverId)
       && (!serverId || !p.serverId || p.serverId === serverId)
       && p.status === 'queued',
   );
@@ -56,7 +152,8 @@ export function isAlbumPinQueued(albumId: string, serverId?: string): boolean {
 export function dequeueOfflinePin(albumId: string, serverId?: string): boolean {
   const store = useOfflineJobStore.getState();
   const entry = store.pinQueue.find(p => (
-    p.albumId === albumId && (!serverId || !p.serverId || p.serverId === serverId)
+    offlineAlbumIdsMatch(albumId, p.albumId, p.serverId ?? serverId)
+      && (!serverId || !p.serverId || p.serverId === serverId)
   ));
   if (!entry || entry.status !== 'queued') return false;
   cancelledDownloads.add(pinKey(albumId, entry.serverId ?? serverId));
@@ -67,7 +164,10 @@ export function dequeueOfflinePin(albumId: string, serverId?: string): boolean {
 
 function isPinAlreadyScheduled(albumId: string, serverId: string): boolean {
   const { pinQueue } = useOfflineJobStore.getState();
-  return pinQueue.some(p => p.albumId === albumId && (!p.serverId || p.serverId === serverId));
+  return pinQueue.some(p => (
+    offlineAlbumIdsMatch(albumId, p.albumId, p.serverId ?? serverId)
+      && (!p.serverId || p.serverId === serverId)
+  ));
 }
 
 /**
@@ -75,35 +175,54 @@ function isPinAlreadyScheduled(albumId: string, serverId: string): boolean {
  * entry; the queue drains one album at a time so parallel pins do not evict each other.
  */
 export function enqueueOfflinePin(task: OfflinePinTask): boolean {
-  const taskKey = pinKey(task.albumId, task.serverId);
+  const activeTask = canonicalizeOfflinePinTask(task);
+  if (queuePauseDepth > 0) {
+    const existingIndex = pausedPinTasks.findIndex(candidate => (
+      candidate.serverId === activeTask.serverId
+      && offlineAlbumIdsMatch(activeTask.albumId, candidate.albumId, activeTask.serverId)
+    ));
+    if (existingIndex >= 0) pausedPinTasks[existingIndex] = activeTask;
+    else pausedPinTasks.push(activeTask);
+    return true;
+  }
+  normalizeQueuedPins();
+  const taskKey = pinKey(activeTask.albumId, activeTask.serverId);
   cancelledDownloads.delete(taskKey);
-  cancelledDownloads.delete(task.albumId);
+  cancelledDownloads.delete(activeTask.albumId);
 
   const store = useOfflineJobStore.getState();
   const existing = store.pinQueue.find(
-    p => p.albumId === task.albumId && (!p.serverId || p.serverId === task.serverId),
+    p => canonicalAlbumId(p.albumId, p.serverId) === activeTask.albumId
+      && (!p.serverId || p.serverId === activeTask.serverId),
   );
   if (existing?.status === 'downloading') {
     return false;
   }
 
-  pinTasks.set(taskKey, task);
+  pinTasks.set(taskKey, activeTask);
 
   if (existing?.status === 'queued') {
+    useOfflineJobStore.setState(state => ({
+      pinQueue: state.pinQueue.map(entry => (
+        entry === existing
+          ? { ...entry, albumName: activeTask.albumName, pinKind: activeTask.type }
+          : entry
+      )),
+    }));
     scheduleOfflinePinQueue();
     return true;
   }
-  if (isPinAlreadyScheduled(task.albumId, task.serverId)) {
+  if (isPinAlreadyScheduled(activeTask.albumId, activeTask.serverId)) {
     return false;
   }
 
   const entry: OfflinePinQueueEntry = {
-    albumId: task.albumId,
-    albumName: task.albumName,
-    pinKind: task.type,
+    albumId: activeTask.albumId,
+    albumName: activeTask.albumName,
+    pinKind: activeTask.type,
     status: 'queued',
     queuedAt: Date.now(),
-    serverId: task.serverId,
+    serverId: activeTask.serverId,
   };
   useOfflineJobStore.setState(state => ({
     pinQueue: [...state.pinQueue, entry],
@@ -113,7 +232,39 @@ export function enqueueOfflinePin(task: OfflinePinTask): boolean {
 }
 
 export function scheduleOfflinePinQueue(): void {
-  void drainOfflinePinQueue();
+  void ensureOfflinePinQueueDrain();
+}
+
+function ensureOfflinePinQueueDrain(): Promise<void> {
+  if (!drainPromise) {
+    const current = drainOfflinePinQueue();
+    drainPromise = current;
+    void current.finally(() => {
+      if (drainPromise !== current) return;
+      drainPromise = null;
+      if (useOfflineJobStore.getState().pinQueue.some(p => p.status === 'queued')) {
+        void ensureOfflinePinQueueDrain();
+      }
+    });
+  }
+  return drainPromise;
+}
+
+export async function cancelAndDrainOfflinePinQueue(): Promise<void> {
+  queuePauseDepth += 1;
+  if (queuePauseDepth === 1) pausedPinTasks = [...pinTasks.values()];
+  useOfflineJobStore.getState().cancelAllDownloads();
+  clearOfflinePinTasks();
+  await drainPromise;
+}
+
+export function resumeOfflinePinQueue(): void {
+  if (queuePauseDepth === 0) return;
+  queuePauseDepth -= 1;
+  if (queuePauseDepth > 0) return;
+  const tasks = pausedPinTasks;
+  pausedPinTasks = [];
+  for (const task of tasks) enqueueOfflinePin(canonicalizeOfflinePinTask(task));
 }
 
 async function drainOfflinePinQueue(): Promise<void> {
@@ -121,6 +272,7 @@ async function drainOfflinePinQueue(): Promise<void> {
   queueDraining = true;
   try {
     while (true) {
+      normalizeQueuedPins();
       const store = useOfflineJobStore.getState();
       const next = store.pinQueue.find(p => p.status === 'queued');
       if (!next) break;
@@ -140,7 +292,7 @@ async function drainOfflinePinQueue(): Promise<void> {
 
       store.setPinQueueStatus(next.albumId, 'downloading', next.serverId);
       try {
-        await executor(task);
+        await executor(canonicalizeOfflinePinTask(task));
       } catch {
         /* per-track errors are recorded on jobs; continue queue */
       } finally {
@@ -153,9 +305,5 @@ async function drainOfflinePinQueue(): Promise<void> {
     }
   } finally {
     queueDraining = false;
-    const stillQueued = useOfflineJobStore.getState().pinQueue.some(p => p.status === 'queued');
-    if (stillQueued) {
-      void drainOfflinePinQueue();
-    }
   }
 }

--- a/src/features/offline/utils/offlinePlaylistBrowse.ts
+++ b/src/features/offline/utils/offlinePlaylistBrowse.ts
@@ -10,6 +10,7 @@ import {
   indexKeyBelongsToServer,
 } from '@/store/localPlaybackResolve';
 import { resolveOfflineAlbumMeta } from '@/features/offline/utils/offlineLibraryHelpers';
+import { canonicalizeConfirmedNavidromeId } from '@/lib/server/navidromeCanonicalIds';
 
 function listPlaylistPinnedGroupsForServer(serverId: string): PinnedGroup[] {
   return useLocalPlaybackStore.getState()
@@ -77,7 +78,8 @@ export async function loadOfflineBrowsablePlaylist(
   serverId: string,
 ): Promise<{ playlist: SubsonicPlaylist; songs: SubsonicSong[] } | null> {
   const group = listPlaylistPinnedGroupsForServer(serverId)
-    .find(g => g.pinSource.sourceId === playlistId);
+    .find(g => canonicalizeConfirmedNavidromeId(g.serverIndexKey, g.pinSource.sourceId)
+      === canonicalizeConfirmedNavidromeId(g.serverIndexKey, playlistId));
   if (!group) return null;
   if (!isManualOfflinePlaylist(playlistId, serverId, group.pinSource.displayName)) return null;
 

--- a/src/features/offline/utils/pinnedOfflineSync.test.ts
+++ b/src/features/offline/utils/pinnedOfflineSync.test.ts
@@ -13,8 +13,15 @@ import {
   scheduleSyncPinnedAlbumsAndArtists,
   syncAllPinnedPlaylists,
   syncPinnedArtistIfNeeded,
+  syncPinnedSourceIfNeeded,
+  initPinnedOfflineSync,
 } from '@/features/offline/utils/pinnedOfflineSync';
 import { SMART_PREFIX } from '@/lib/format/playlistDetailHelpers';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
 
 const getPlaylistMock = vi.fn();
 const getAlbumForServerMock = vi.fn();
@@ -23,6 +30,7 @@ const filterSongsMock = vi.fn(async (songs: SubsonicSong[]) => songs);
 const isReachableMock = vi.fn(() => true);
 const enqueueMock = vi.fn((_task: unknown) => true);
 const invokeMock = vi.fn(async (_cmd: string, _args?: unknown) => ({}));
+const subscribeLibrarySyncIdleMock = vi.fn();
 
 vi.mock('@/lib/network/activeServerReachability', () => ({
   isActiveServerReachable: () => isReachableMock(),
@@ -44,7 +52,7 @@ vi.mock('@/lib/api/subsonicArtists', () => ({
 
 vi.mock('@/lib/api/library', () => ({
   libraryGetTracksByAlbum: vi.fn(async () => []),
-  subscribeLibrarySyncIdle: vi.fn(async () => () => {}),
+  subscribeLibrarySyncIdle: (listener: unknown) => subscribeLibrarySyncIdleMock(listener),
 }));
 
 vi.mock('@/features/offline/utils/offlinePinQueue', async (importOriginal) => {
@@ -56,7 +64,9 @@ vi.mock('@/features/offline/utils/offlinePinQueue', async (importOriginal) => {
 });
 
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: (cmd: string, args?: unknown) => invokeMock(cmd, args),
+  invoke: (cmd: string, args?: unknown) => (
+    cmd === 'probe_media_files' ? Promise.resolve([false]) : invokeMock(cmd, args)
+  ),
 }));
 
 function song(id: string): SubsonicSong {
@@ -76,6 +86,67 @@ function seedAuth(): void {
     servers: [{ id: 'srv-a', name: 'A', url: 'https://a.test', username: 'u', password: 'p' }],
   });
 }
+
+beforeEach(() => {
+  deactivateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+  subscribeLibrarySyncIdleMock.mockReset().mockResolvedValue(() => {});
+});
+
+describe('initPinnedOfflineSync', () => {
+  it('unsubscribes a delayed listener that resolves after cleanup', async () => {
+    let resolveSubscribe!: (unlisten: () => void) => void;
+    const unlisten = vi.fn();
+    subscribeLibrarySyncIdleMock.mockImplementation(() => new Promise(resolve => {
+      resolveSubscribe = resolve;
+    }));
+
+    const cleanup = initPinnedOfflineSync();
+    cleanup();
+    resolveSubscribe(unlisten);
+    await Promise.resolve();
+
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+
+  it('does not revive stale source work after cleanup and reinitialization', async () => {
+    useOfflineStore.setState({
+      albums: {
+        'a.test:al-1': {
+          id: 'al-1', serverId: 'a.test', name: 'Album', artist: 'Artist',
+          trackIds: [], type: 'album',
+        },
+      },
+    });
+    useLocalPlaybackStore.setState({ entries: {} });
+    seedAuth();
+    let resolveOld!: (value: {
+      album: { id: string; name: string; artist: string };
+      songs: SubsonicSong[];
+    }) => void;
+    getAlbumForServerMock
+      .mockImplementationOnce(() => new Promise(resolve => { resolveOld = resolve; }))
+      .mockResolvedValueOnce({
+        album: { id: 'al-1', name: 'New', artist: 'Artist' },
+        songs: [song('t-new')],
+      });
+
+    const cleanup = initPinnedOfflineSync();
+    const oldRun = syncPinnedSourceIfNeeded('al-1', 'srv-a', 'album');
+    cleanup();
+    const cleanupNew = initPinnedOfflineSync();
+    await syncPinnedSourceIfNeeded('al-1', 'srv-a', 'album');
+    resolveOld({
+      album: { id: 'al-1', name: 'Old', artist: 'Artist' },
+      songs: [song('t-old')],
+    });
+    await oldRun;
+    cleanupNew();
+
+    expect(useOfflineStore.getState().albums['a.test:al-1']).toMatchObject({
+      name: 'New', trackIds: ['t-new'],
+    });
+  });
+});
 
 describe('isPlaylistPinnedOffline', () => {
   beforeEach(() => {
@@ -306,6 +377,309 @@ describe('schedulePinnedAlbumSync', () => {
       }),
     );
     expect(useOfflineStore.getState().albums['a.test:al-1']?.trackIds).toEqual(['t2']);
+  });
+
+  it('canonicalizes a stale sync response after ACK before metadata and queue writes', async () => {
+    const legacyAlbumId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const legacyTrackId = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    const legacyCoverId = '00112233-4455-6677-8899-aabbccddeeff';
+    const canonicalAlbumId = canonicalizeNavidromeId(legacyAlbumId);
+    const canonicalTrackId = canonicalizeNavidromeId(legacyTrackId);
+    const canonicalCoverId = canonicalizeNavidromeId(legacyCoverId);
+    let resolveAlbum!: (value: {
+      album: { id: string; name: string; artist: string; coverArt: string };
+      songs: SubsonicSong[];
+    }) => void;
+    getAlbumForServerMock.mockImplementation(() => new Promise(resolve => {
+      resolveAlbum = resolve;
+    }));
+    useOfflineStore.setState({
+      albums: {
+        [`a.test:${legacyAlbumId}`]: {
+          id: legacyAlbumId,
+          serverId: 'a.test',
+          name: 'Album',
+          artist: 'Artist',
+          trackIds: [legacyTrackId],
+          type: 'album',
+        },
+      },
+    });
+
+    const sync = syncPinnedSourceIfNeeded(legacyAlbumId, 'srv-a', 'album');
+    await vi.waitFor(() => expect(getAlbumForServerMock).toHaveBeenCalled());
+
+    activateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+    useOfflineStore.setState({
+      albums: {
+        [`a.test:${canonicalAlbumId}`]: {
+          id: canonicalAlbumId,
+          serverId: 'a.test',
+          name: 'Album',
+          artist: 'Artist',
+          coverArt: canonicalCoverId,
+          trackIds: [canonicalTrackId],
+          type: 'album',
+        },
+      },
+    });
+    resolveAlbum({
+      album: { id: legacyAlbumId, name: 'Album', artist: 'Artist', coverArt: legacyCoverId },
+      songs: [{
+        ...song(legacyTrackId),
+        albumId: legacyAlbumId,
+        coverArt: legacyCoverId,
+      }],
+    });
+    await sync;
+
+    expect(useOfflineStore.getState().albums).toEqual({
+      [`a.test:${canonicalAlbumId}`]: expect.objectContaining({
+        id: canonicalAlbumId,
+        coverArt: canonicalCoverId,
+        trackIds: [canonicalTrackId],
+      }),
+    });
+    expect(enqueueMock).toHaveBeenCalledWith(expect.objectContaining({
+      albumId: canonicalAlbumId,
+      coverArt: canonicalCoverId,
+      songs: [expect.objectContaining({
+        id: canonicalTrackId,
+        albumId: canonicalAlbumId,
+        coverArt: canonicalCoverId,
+      })],
+    }));
+    deactivateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+  });
+
+  it('does not prune canonical pin bytes from a response started before activation', async () => {
+    const legacyAlbumId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const legacyRemovedTrackId = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    const canonicalAlbumId = canonicalizeNavidromeId(legacyAlbumId);
+    const canonicalRemovedTrackId = canonicalizeNavidromeId(legacyRemovedTrackId);
+    let resolveAlbum!: (value: {
+      album: { id: string; name: string; artist: string };
+      songs: SubsonicSong[];
+    }) => void;
+    getAlbumForServerMock.mockImplementation(() => new Promise(resolve => {
+      resolveAlbum = resolve;
+    }));
+    useOfflineStore.setState({
+      albums: {
+        [`a.test:${legacyAlbumId}`]: {
+          id: legacyAlbumId,
+          serverId: 'a.test',
+          name: 'Album',
+          artist: 'Artist',
+          trackIds: [legacyRemovedTrackId],
+          type: 'album',
+        },
+      },
+    });
+    useLocalPlaybackStore.setState({
+      entries: {
+        [`a.test:${legacyRemovedTrackId}`]: {
+          serverIndexKey: 'a.test',
+          trackId: legacyRemovedTrackId,
+          localPath: `/media/${legacyRemovedTrackId}.flac`,
+          layoutFingerprint: 'legacy',
+          sizeBytes: 1,
+          tier: 'library',
+          cachedAt: 1,
+          suffix: 'flac',
+          pinSource: { kind: 'album', sourceId: legacyAlbumId },
+        },
+      },
+    });
+
+    const sync = syncPinnedSourceIfNeeded(legacyAlbumId, 'srv-a', 'album');
+    await vi.waitFor(() => expect(getAlbumForServerMock).toHaveBeenCalled());
+    activateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+    useOfflineStore.setState({
+      albums: {
+        [`a.test:${canonicalAlbumId}`]: {
+          id: canonicalAlbumId,
+          serverId: 'a.test',
+          name: 'Album',
+          artist: 'Artist',
+          trackIds: [canonicalRemovedTrackId],
+          type: 'album',
+        },
+      },
+    });
+    useLocalPlaybackStore.setState({
+      entries: {
+        [`a.test:${canonicalRemovedTrackId}`]: {
+          serverIndexKey: 'a.test',
+          trackId: canonicalRemovedTrackId,
+          localPath: `/media/${canonicalRemovedTrackId}.flac`,
+          layoutFingerprint: 'canonical',
+          sizeBytes: 1,
+          tier: 'library',
+          cachedAt: 1,
+          suffix: 'flac',
+          pinSource: { kind: 'album', sourceId: canonicalAlbumId },
+        },
+      },
+    });
+    resolveAlbum({ album: { id: legacyAlbumId, name: 'Album', artist: 'Artist' }, songs: [] });
+    await sync;
+
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      'delete_media_file',
+      expect.objectContaining({ localPath: `/media/${canonicalRemovedTrackId}.flac` }),
+    );
+    expect(useLocalPlaybackStore.getState().entries[`a.test:${canonicalRemovedTrackId}`]).toBeDefined();
+  });
+
+  it('removes the canonical index row when identity changes during file deletion', async () => {
+    const legacyAlbumId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+    const legacyRemovedTrackId = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    const canonicalAlbumId = canonicalizeNavidromeId(legacyAlbumId);
+    const canonicalRemovedTrackId = canonicalizeNavidromeId(legacyRemovedTrackId);
+    const localPath = `/media/${legacyRemovedTrackId}.flac`;
+    let resolveDelete!: () => void;
+    invokeMock.mockImplementationOnce(() => new Promise<Record<string, never>>(resolve => {
+      resolveDelete = () => resolve({});
+    }));
+    getAlbumForServerMock.mockResolvedValue({
+      album: { id: legacyAlbumId, name: 'Album', artist: 'Artist' },
+      songs: [],
+    });
+    useOfflineStore.setState({
+      albums: {
+        [`a.test:${legacyAlbumId}`]: {
+          id: legacyAlbumId,
+          serverId: 'a.test',
+          name: 'Album',
+          artist: 'Artist',
+          trackIds: [legacyRemovedTrackId],
+          type: 'album',
+        },
+      },
+    });
+    useLocalPlaybackStore.setState({
+      entries: {
+        [`a.test:${legacyRemovedTrackId}`]: {
+          serverIndexKey: 'a.test',
+          trackId: legacyRemovedTrackId,
+          localPath,
+          layoutFingerprint: 'legacy',
+          sizeBytes: 1,
+          tier: 'library',
+          cachedAt: 1,
+          suffix: 'flac',
+          pinSource: { kind: 'album', sourceId: legacyAlbumId },
+        },
+      },
+    });
+
+    const sync = syncPinnedSourceIfNeeded(legacyAlbumId, 'srv-a', 'album');
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      'delete_media_file',
+      expect.objectContaining({ localPath }),
+    ));
+
+    activateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+    useLocalPlaybackStore.setState({
+      entries: {
+        [`a.test:${canonicalRemovedTrackId}`]: {
+          serverIndexKey: 'a.test',
+          trackId: canonicalRemovedTrackId,
+          localPath,
+          layoutFingerprint: 'canonical',
+          sizeBytes: 1,
+          tier: 'library',
+          cachedAt: 1,
+          suffix: 'flac',
+          pinSource: { kind: 'album', sourceId: canonicalAlbumId },
+        },
+      },
+    });
+    resolveDelete();
+    await sync;
+
+    expect(useLocalPlaybackStore.getState().entries[`a.test:${canonicalRemovedTrackId}`]).toBeUndefined();
+  });
+
+  it('ignores an older source refresh that settles after a newer one', async () => {
+    useOfflineStore.setState({
+      albums: {
+        'a.test:al-1': {
+          id: 'al-1',
+          serverId: 'a.test',
+          name: 'Album',
+          artist: 'Artist',
+          trackIds: [],
+          type: 'album',
+        },
+      },
+    });
+    useLocalPlaybackStore.setState({ entries: {} });
+    let resolveFirst!: (value: {
+      album: { id: string; name: string; artist: string };
+      songs: SubsonicSong[];
+    }) => void;
+    let resolveSecond!: (value: {
+      album: { id: string; name: string; artist: string };
+      songs: SubsonicSong[];
+    }) => void;
+    getAlbumForServerMock
+      .mockImplementationOnce(() => new Promise(resolve => { resolveFirst = resolve; }))
+      .mockImplementationOnce(() => new Promise(resolve => { resolveSecond = resolve; }));
+
+    const first = syncPinnedSourceIfNeeded('al-1', 'srv-a', 'album');
+    const second = syncPinnedSourceIfNeeded('al-1', 'srv-a', 'album');
+    resolveSecond({
+      album: { id: 'al-1', name: 'New Album', artist: 'Artist' },
+      songs: [song('t-new')],
+    });
+    await second;
+    resolveFirst({
+      album: { id: 'al-1', name: 'Old Album', artist: 'Artist' },
+      songs: [song('t-old')],
+    });
+    await first;
+
+    expect(useOfflineStore.getState().albums['a.test:al-1']).toMatchObject({
+      name: 'New Album',
+      trackIds: ['t-new'],
+    });
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenCalledWith(expect.objectContaining({
+      songs: [expect.objectContaining({ id: 't-new' })],
+    }));
+  });
+
+  it('keeps an older successful refresh when a newer request fails', async () => {
+    useOfflineStore.setState({
+      albums: {
+        'a.test:al-1': {
+          id: 'al-1', serverId: 'a.test', name: 'Album', artist: 'Artist',
+          trackIds: [], type: 'album',
+        },
+      },
+    });
+    useLocalPlaybackStore.setState({ entries: {} });
+    let resolveFirst!: (value: {
+      album: { id: string; name: string; artist: string };
+      songs: SubsonicSong[];
+    }) => void;
+    getAlbumForServerMock
+      .mockImplementationOnce(() => new Promise(resolve => { resolveFirst = resolve; }))
+      .mockRejectedValueOnce(new Error('offline'));
+
+    const first = syncPinnedSourceIfNeeded('al-1', 'srv-a', 'album');
+    await syncPinnedSourceIfNeeded('al-1', 'srv-a', 'album');
+    resolveFirst({
+      album: { id: 'al-1', name: 'Older Success', artist: 'Artist' },
+      songs: [song('t-success')],
+    });
+    await first;
+
+    expect(useOfflineStore.getState().albums['a.test:al-1']).toMatchObject({
+      name: 'Older Success', trackIds: ['t-success'],
+    });
   });
 });
 

--- a/src/features/offline/utils/pinnedOfflineSync.ts
+++ b/src/features/offline/utils/pinnedOfflineSync.ts
@@ -9,7 +9,7 @@ import { useLocalPlaybackStore } from '@/store/localPlaybackStore';
 import { useOfflineStore } from '@/features/offline/store/offlineStore';
 import { isSmartPlaylistName } from '@/lib/format/playlistDetailHelpers';
 import { getMediaDir } from '@/lib/media/mediaDir';
-import { deleteMediaFile } from '@/lib/api/syncfs';
+import { deleteMediaFile, probeMediaFiles } from '@/lib/api/syncfs';
 import {
   isActiveServerReachable,
   onActiveServerBecameReachable,
@@ -17,7 +17,16 @@ import {
 import { resolveIndexKey, serverIndexKeyForProfile } from '@/lib/server/serverIndexKey';
 import { resolveServerIdForIndexKey } from '@/lib/server/serverLookup';
 import { findLocalPlaybackEntry } from '@/store/localPlaybackResolve';
-import { enqueueOfflinePin } from '@/features/offline/utils/offlinePinQueue';
+import {
+  canonicalizeOfflinePinTask,
+  enqueueOfflinePin,
+} from '@/features/offline/utils/offlinePinQueue';
+import {
+  canonicalIdentityGeneration,
+  canonicalIdentityGenerationChanged,
+  canonicalizeConfirmedNavidromeId,
+  canonicalizeNavidromeId,
+} from '@/lib/server/navidromeCanonicalIds';
 
 export type OfflinePinKind = PinSource['kind'];
 
@@ -34,6 +43,10 @@ const pendingArtistJobs: { artistId: string; serverId: string; albumIds?: string
 /** Empty set entry means all servers; otherwise profile ids from library idle. */
 const pendingAlbumArtistServers = new Set<string | null>();
 const retryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const sourceSyncGeneration = new Map<string, number>();
+const sourceMutationTail = new Map<string, Promise<void>>();
+let sourceSyncLifecycle = 0;
+let syncPauseDepth = 0;
 let playlistSyncInterval: ReturnType<typeof setInterval> | null = null;
 let stopLibraryIdle: (() => void) | null = null;
 
@@ -41,6 +54,38 @@ function serverIndexKeyForOffline(serverId: string): string {
   const server = useAuthStore.getState().servers.find(s => s.id === serverId);
   if (server) return serverIndexKeyForProfile(server) || resolveIndexKey(serverId) || serverId;
   return resolveIndexKey(serverId) || serverId;
+}
+
+function beginSourceSync(sourceId: string, serverId: string, kind: OfflinePinKind): {
+  key: string;
+  isCurrent: () => boolean;
+  abandon: () => void;
+} {
+  const key = `${serverIndexKeyForOffline(serverId)}:${kind}:${canonicalizeNavidromeId(sourceId)}`;
+  const previous = sourceSyncGeneration.get(key) ?? 0;
+  const generation = previous + 1;
+  const lifecycle = sourceSyncLifecycle;
+  sourceSyncGeneration.set(key, generation);
+  return {
+    key,
+    isCurrent: () => sourceSyncLifecycle === lifecycle && sourceSyncGeneration.get(key) === generation,
+    abandon: () => {
+      if (sourceSyncGeneration.get(key) !== generation) return;
+      if (previous === 0) sourceSyncGeneration.delete(key);
+      else sourceSyncGeneration.set(key, previous);
+    },
+  };
+}
+
+async function runSourceMutation(key: string, mutation: () => Promise<void>): Promise<void> {
+  const previous = sourceMutationTail.get(key) ?? Promise.resolve();
+  const current = previous.catch(() => {}).then(mutation);
+  sourceMutationTail.set(key, current);
+  try {
+    await current;
+  } finally {
+    if (sourceMutationTail.get(key) === current) sourceMutationTail.delete(key);
+  }
 }
 
 function belongsToProfile(metaServerKey: string, profileServerId: string): boolean {
@@ -52,8 +97,12 @@ function belongsToProfile(metaServerKey: string, profileServerId: string): boole
 
 function offlineMeta(sourceId: string, serverId: string) {
   const indexKey = serverIndexKeyForOffline(serverId);
+  const activeSourceId = canonicalizeConfirmedNavidromeId(indexKey, sourceId);
   const albums = useOfflineStore.getState().albums;
-  return albums[`${indexKey}:${sourceId}`] ?? albums[`${serverId}:${sourceId}`];
+  return albums[`${indexKey}:${activeSourceId}`]
+    ?? albums[`${indexKey}:${sourceId}`]
+    ?? albums[`${serverId}:${activeSourceId}`]
+    ?? albums[`${serverId}:${sourceId}`];
 }
 
 function resolvePlaylistName(playlistId: string, serverId: string): string | undefined {
@@ -80,6 +129,7 @@ export function isSourcePinnedOffline(
   if (meta?.type === kind) return true;
 
   const indexKey = serverIndexKeyForOffline(serverId);
+  sourceId = canonicalizeConfirmedNavidromeId(indexKey, sourceId);
   const group = useLocalPlaybackStore.getState()
     .listPinnedGroups(indexKey)
     .find(g => g.pinSource.kind === kind && g.pinSource.sourceId === sourceId);
@@ -109,15 +159,22 @@ async function pruneRemovedPinTracks(
   serverId: string,
   kind: OfflinePinKind,
   keepIds: Set<string>,
+  expectedIdentityGeneration = canonicalIdentityGeneration(serverIndexKeyForOffline(serverId)),
+  isCurrent: () => boolean = () => true,
 ): Promise<void> {
   const indexKey = serverIndexKeyForOffline(serverId);
+  sourceId = canonicalizeConfirmedNavidromeId(indexKey, sourceId);
+  keepIds = new Set([...keepIds].map(id => canonicalizeConfirmedNavidromeId(indexKey, id)));
   const lp = useLocalPlaybackStore.getState();
   const mediaDir = getMediaDir();
   const group = lp.listPinnedGroups(indexKey)
     .find(g => g.pinSource.kind === kind && g.pinSource.sourceId === sourceId);
   const previousIds = group?.trackIds ?? offlineMeta(sourceId, serverId)?.trackIds ?? [];
 
-  for (const trackId of previousIds) {
+  for (const previousTrackId of previousIds) {
+    if (!isCurrent()) return;
+    if (canonicalIdentityGenerationChanged(indexKey, expectedIdentityGeneration)) return;
+    const trackId = canonicalizeConfirmedNavidromeId(indexKey, previousTrackId);
     if (keepIds.has(trackId)) continue;
     if (trackStillNeededByOtherPin(trackId, indexKey, kind, sourceId)) continue;
 
@@ -125,8 +182,19 @@ async function pruneRemovedPinTracks(
     if (!entry?.localPath || entry.tier !== 'library') continue;
     if (entry.pinSource?.kind !== kind || entry.pinSource.sourceId !== sourceId) continue;
 
+    if (!isCurrent() || canonicalIdentityGenerationChanged(indexKey, expectedIdentityGeneration)) return;
     await deleteMediaFile({ localPath: entry.localPath, mediaDir }).catch(() => {});
-    lp.removeEntry(trackId, entry.serverIndexKey, `${kind}-sync-prune`);
+    const [stillExists] = await probeMediaFiles({ localPaths: [entry.localPath] }).catch(() => [true]);
+    if (stillExists) continue;
+    const currentEntry = findLocalPlaybackEntry(entry.trackId, serverId);
+    const identityChanged = canonicalIdentityGenerationChanged(indexKey, expectedIdentityGeneration);
+    if (currentEntry !== entry && (!identityChanged || currentEntry?.localPath !== entry.localPath)) continue;
+    if (!currentEntry) continue;
+    useLocalPlaybackStore.getState().removeEntry(
+      currentEntry.trackId,
+      currentEntry.serverIndexKey,
+      `${kind}-sync-prune`,
+    );
   }
 }
 
@@ -152,25 +220,41 @@ function updateOfflineMeta(
   },
 ): void {
   const indexKey = serverIndexKeyForOffline(serverId);
+  const activeSourceId = canonicalizeConfirmedNavidromeId(indexKey, sourceId);
+  const activeCoverArt = patch.coverArt
+    ? canonicalizeConfirmedNavidromeId(indexKey, patch.coverArt)
+    : patch.coverArt;
+  const activeTrackIds = [...new Set(
+    patch.trackIds.map(id => canonicalizeConfirmedNavidromeId(indexKey, id)),
+  )];
   useOfflineStore.setState(state => {
-    const key = `${indexKey}:${sourceId}`;
-    const legacyKey = `${serverId}:${sourceId}`;
-    const existing = state.albums[key] ?? state.albums[legacyKey];
+    const key = `${indexKey}:${activeSourceId}`;
+    const rawIndexKey = `${indexKey}:${sourceId}`;
+    const rawProfileKey = `${serverId}:${sourceId}`;
+    const canonicalProfileKey = `${serverId}:${activeSourceId}`;
+    const existing = state.albums[key]
+      ?? state.albums[rawIndexKey]
+      ?? state.albums[canonicalProfileKey]
+      ?? state.albums[rawProfileKey];
     const nextAlbums = { ...state.albums };
-    delete nextAlbums[legacyKey];
+    delete nextAlbums[rawIndexKey];
+    delete nextAlbums[rawProfileKey];
+    delete nextAlbums[canonicalProfileKey];
     nextAlbums[key] = {
       ...(existing ?? {
-        id: sourceId,
+        id: activeSourceId,
         serverId: indexKey,
         artist: patch.albumArtist,
       }),
-      id: sourceId,
+      id: activeSourceId,
       serverId: indexKey,
       name: patch.name,
       artist: patch.albumArtist,
-      coverArt: patch.coverArt ?? existing?.coverArt,
+      coverArt: activeCoverArt ?? (existing?.coverArt
+        ? canonicalizeConfirmedNavidromeId(indexKey, existing.coverArt)
+        : existing?.coverArt),
       year: patch.year ?? existing?.year,
-      trackIds: patch.trackIds,
+      trackIds: activeTrackIds,
       type: kind,
     };
     return { albums: nextAlbums };
@@ -188,6 +272,20 @@ function scheduleRetryWhileDownloading(
   retryTimers.set(key, setTimeout(() => {
     retryTimers.delete(key);
     void syncPinnedSourceIfNeeded(sourceId, serverId, kind);
+  }, RETRY_WHILE_DOWNLOADING_MS));
+}
+
+function scheduleArtistRetryWhileDownloading(
+  artistId: string,
+  serverId: string,
+  albumIds?: string[],
+): void {
+  const key = `${serverId}:artist-scope:${artistId}`;
+  const prev = retryTimers.get(key);
+  if (prev) clearTimeout(prev);
+  retryTimers.set(key, setTimeout(() => {
+    retryTimers.delete(key);
+    void syncPinnedArtistIfNeeded(artistId, serverId, albumIds);
   }, RETRY_WHILE_DOWNLOADING_MS));
 }
 
@@ -212,10 +310,14 @@ export async function syncPinnedSourceIfNeeded(
   kind: OfflinePinKind,
   options: SyncPinOptions = {},
 ): Promise<void> {
+  if (syncPauseDepth > 0) return;
   if (!isActiveServerReachable()) return;
   const alreadyPinned = isSourcePinnedOffline(sourceId, serverId, kind);
   if (!alreadyPinned && !options.allowUnpinned) return;
   if (kind === 'playlist' && !isManualOfflinePlaylist(sourceId, serverId, options.name)) return;
+  const identityOwner = serverIndexKeyForOffline(serverId);
+  const identityGeneration = canonicalIdentityGeneration(identityOwner);
+  const sourceSync = beginSourceSync(sourceId, serverId, kind);
 
   let songs = options.prefetchedSongs;
   let displayName = options.name ?? offlineMeta(sourceId, serverId)?.name ?? sourceId;
@@ -223,8 +325,8 @@ export async function syncPinnedSourceIfNeeded(
   let coverArt = options.coverArt ?? offlineMeta(sourceId, serverId)?.coverArt;
   let year = options.year ?? offlineMeta(sourceId, serverId)?.year;
 
-  if (!songs) {
-    try {
+  try {
+    if (!songs) {
       if (kind === 'playlist') {
         const data = await getPlaylistForServer(serverId, sourceId);
         displayName = data.playlist.name;
@@ -238,45 +340,60 @@ export async function syncPinnedSourceIfNeeded(
         year = data.album.year ?? year;
         songs = await filterSongsToServerLibrary(data.songs, serverId);
       }
-    } catch {
-      return;
+    } else {
+      songs = await filterSongsToServerLibrary(songs, serverId);
     }
-  } else {
-    songs = await filterSongsToServerLibrary(songs, serverId);
-  }
-
-  const unique = dedupeSongs(songs);
-  const keepIds = new Set(unique.map(s => s.id));
-
-  await pruneRemovedPinTracks(sourceId, serverId, kind, keepIds);
-  updateOfflineMeta(sourceId, serverId, kind, {
-    name: displayName,
-    albumArtist,
-    coverArt,
-    year,
-    trackIds: unique.map(s => s.id),
-  });
-
-  const offline = useOfflineStore.getState();
-  if (offline.isAlbumDownloading(sourceId, serverId)) {
-    scheduleRetryWhileDownloading(sourceId, serverId, kind);
+  } catch {
+    sourceSync.abandon();
     return;
   }
 
-  const enqueued = enqueueOfflinePin({
-    albumId: sourceId,
+  const indexKey = serverIndexKeyForOffline(serverId);
+  const activeSourceId = canonicalizeConfirmedNavidromeId(indexKey, sourceId);
+  const activeTask = canonicalizeOfflinePinTask({
+    albumId: activeSourceId,
     albumName: displayName,
     albumArtist,
     coverArt,
     year,
-    songs: unique,
+    songs: dedupeSongs(songs),
     serverId,
     type: kind,
     artistProgressGroupId: options.artistProgressGroupId,
+  }, indexKey);
+  const unique = activeTask.songs;
+  const keepIds = new Set(unique.map(s => s.id));
+
+  await runSourceMutation(sourceSync.key, async () => {
+    if (!sourceSync.isCurrent()) return;
+    const offline = useOfflineStore.getState();
+    if (offline.isAlbumDownloading(activeSourceId, serverId)) {
+      scheduleRetryWhileDownloading(activeSourceId, serverId, kind);
+      return;
+    }
+    await pruneRemovedPinTracks(
+      sourceId,
+      serverId,
+      kind,
+      keepIds,
+      identityGeneration,
+      sourceSync.isCurrent,
+    );
+    if (!sourceSync.isCurrent()) return;
+    updateOfflineMeta(sourceId, serverId, kind, {
+      name: displayName,
+      albumArtist,
+      coverArt,
+      year,
+      trackIds: unique.map(s => s.id),
+    });
+
+    if (!sourceSync.isCurrent()) return;
+    const enqueued = enqueueOfflinePin(activeTask);
+    if (!enqueued && offline.isAlbumDownloading(activeSourceId, serverId)) {
+      scheduleRetryWhileDownloading(activeSourceId, serverId, kind);
+    }
   });
-  if (!enqueued && offline.isAlbumDownloading(sourceId, serverId)) {
-    scheduleRetryWhileDownloading(sourceId, serverId, kind);
-  }
 }
 
 /** @deprecated Use {@link syncPinnedSourceIfNeeded} with kind `playlist`. */
@@ -334,6 +451,9 @@ export async function syncPinnedArtistIfNeeded(
   serverId?: string,
   knownAlbumIds?: string[],
 ): Promise<void> {
+  if (syncPauseDepth > 0) return;
+  const lifecycle = sourceSyncLifecycle;
+  const lifecycleIsCurrent = () => sourceSyncLifecycle === lifecycle;
   if (!isActiveServerReachable()) return;
   const sid = serverId ?? useAuthStore.getState().activeServerId;
   if (!sid || !artistId) return;
@@ -341,6 +461,8 @@ export async function syncPinnedArtistIfNeeded(
   const pinnedBefore = listPinnedArtistAlbumIds(sid);
   const scopeIds = knownAlbumIds ?? pinnedBefore;
   if (!isArtistDiscographyPinnedOffline(sid, scopeIds) && pinnedBefore.length === 0) return;
+  const identityOwner = serverIndexKeyForOffline(sid);
+  const identityGeneration = canonicalIdentityGeneration(identityOwner);
 
   let liveAlbumIds: string[];
   try {
@@ -349,24 +471,47 @@ export async function syncPinnedArtistIfNeeded(
   } catch {
     return;
   }
+  if (!lifecycleIsCurrent()) return;
 
   const scopeFullyPinned = scopeIds.length > 0
     && scopeIds.every(id => isSourcePinnedOffline(id, sid, 'artist'));
   const liveSet = new Set(liveAlbumIds);
 
-  for (const oldAlbumId of pinnedBefore) {
+  for (const oldAlbumId of canonicalIdentityGenerationChanged(identityOwner, identityGeneration)
+    ? []
+    : pinnedBefore) {
+    if (!lifecycleIsCurrent()) return;
     if (liveSet.has(oldAlbumId)) continue;
-    await pruneRemovedPinTracks(oldAlbumId, sid, 'artist', new Set());
-    const indexKey = serverIndexKeyForOffline(sid);
-    useOfflineStore.setState(state => {
-      const albums = { ...state.albums };
-      delete albums[`${indexKey}:${oldAlbumId}`];
-      delete albums[`${sid}:${oldAlbumId}`];
-      return { albums };
+    if (useOfflineStore.getState().isAlbumDownloading(oldAlbumId, sid)) {
+      scheduleArtistRetryWhileDownloading(artistId, sid, scopeIds);
+      continue;
+    }
+    const mutationKey = `${identityOwner}:artist:${canonicalizeNavidromeId(oldAlbumId)}`;
+    await runSourceMutation(mutationKey, async () => {
+      await pruneRemovedPinTracks(
+        oldAlbumId,
+        sid,
+        'artist',
+        new Set(),
+        identityGeneration,
+        lifecycleIsCurrent,
+      );
+      if (!lifecycleIsCurrent()) return;
+      if (canonicalIdentityGenerationChanged(identityOwner, identityGeneration)) return;
+      const indexKey = serverIndexKeyForOffline(sid);
+      useOfflineStore.setState(state => {
+        const albums = { ...state.albums };
+        delete albums[`${indexKey}:${oldAlbumId}`];
+        delete albums[`${sid}:${oldAlbumId}`];
+        return { albums };
+      });
     });
+    if (!lifecycleIsCurrent()) return;
+    if (canonicalIdentityGenerationChanged(identityOwner, identityGeneration)) break;
   }
 
   for (const albumId of liveAlbumIds) {
+    if (!lifecycleIsCurrent()) return;
     const shouldSync = isSourcePinnedOffline(albumId, sid, 'artist')
       || (scopeFullyPinned && pinnedBefore.length > 0);
     if (!shouldSync) continue;
@@ -460,6 +605,7 @@ async function groupPinnedArtistAlbumsByArtistId(
 }
 
 export function schedulePinnedPlaylistSync(playlistId: string, serverId?: string): void {
+  if (syncPauseDepth > 0) return;
   const sid = serverId ?? useAuthStore.getState().activeServerId;
   if (!playlistId || !sid) return;
   if (!isSourcePinnedOffline(playlistId, sid, 'playlist')) return;
@@ -470,6 +616,7 @@ export function schedulePinnedPlaylistSync(playlistId: string, serverId?: string
 }
 
 export function schedulePinnedAlbumSync(albumId: string, serverId?: string): void {
+  if (syncPauseDepth > 0) return;
   const sid = serverId ?? useAuthStore.getState().activeServerId;
   if (!albumId || !sid) return;
   if (!isSourcePinnedOffline(albumId, sid, 'album')) return;
@@ -483,6 +630,7 @@ export function schedulePinnedArtistSync(
   serverId?: string,
   albumIds?: string[],
 ): void {
+  if (syncPauseDepth > 0) return;
   const sid = serverId ?? useAuthStore.getState().activeServerId;
   if (!sid || !artistId) return;
   if (!isArtistDiscographyPinnedOffline(sid, albumIds ?? listPinnedArtistAlbumIds(sid))) return;
@@ -493,6 +641,9 @@ export function schedulePinnedArtistSync(
 
 /** Reconcile every cached album pin and artist discography (optionally one server). */
 export async function syncAllPinnedAlbumsAndArtists(serverId?: string): Promise<void> {
+  if (syncPauseDepth > 0) return;
+  const lifecycle = sourceSyncLifecycle;
+  const lifecycleIsCurrent = () => sourceSyncLifecycle === lifecycle;
   if (!isActiveServerReachable()) return;
 
   const seenAlbums = new Set<string>();
@@ -527,17 +678,22 @@ export async function syncAllPinnedAlbumsAndArtists(serverId?: string): Promise<
   }
 
   for (const job of albumJobs) {
+    if (!lifecycleIsCurrent()) return;
     await syncPinnedSourceIfNeeded(job.sourceId, job.serverId, 'album');
   }
 
   for (const [sid, albumIds] of artistAlbumIdsByServer) {
+    if (!lifecycleIsCurrent()) return;
     const byArtist = await groupPinnedArtistAlbumsByArtistId(sid, albumIds);
+    if (!lifecycleIsCurrent()) return;
     const assignedAlbums = new Set<string>();
     for (const [artistId, ids] of byArtist) {
+      if (!lifecycleIsCurrent()) return;
       ids.forEach(id => assignedAlbums.add(id));
       await syncPinnedArtistIfNeeded(artistId, sid, ids);
     }
     for (const albumId of albumIds) {
+      if (!lifecycleIsCurrent()) return;
       if (assignedAlbums.has(albumId)) continue;
       await syncPinnedSourceIfNeeded(albumId, sid, 'artist');
     }
@@ -546,6 +702,7 @@ export async function syncAllPinnedAlbumsAndArtists(serverId?: string): Promise<
 
 /** Reconcile every manually cached regular playlist (optionally one server). */
 export async function syncAllPinnedPlaylists(serverId?: string): Promise<void> {
+  if (syncPauseDepth > 0) return;
   if (!isActiveServerReachable()) return;
 
   const seen = new Set<string>();
@@ -586,6 +743,7 @@ export async function syncAllPinnedOffline(): Promise<void> {
 }
 
 export function scheduleSyncPinnedAlbumsAndArtists(serverId?: string): void {
+  if (syncPauseDepth > 0) return;
   if (!isActiveServerReachable()) return;
   pendingAlbumArtistServers.add(serverId ?? null);
   scheduleDebouncedAlbumArtistSync();
@@ -599,6 +757,7 @@ export function scheduleSyncAllPinnedOffline(): void {
 
 /** @deprecated Use hourly {@link syncAllPinnedPlaylists}. */
 export function scheduleSyncAllPinnedPlaylists(): void {
+  if (syncPauseDepth > 0) return;
   if (!isActiveServerReachable()) return;
   void syncAllPinnedPlaylists();
 }
@@ -611,10 +770,41 @@ function onLibraryBecameIdle(serverIndexKey: string, kind: string, ok: boolean):
   scheduleSyncPinnedAlbumsAndArtists(serverId);
 }
 
+export async function pauseAndDrainPinnedOfflineSync(): Promise<void> {
+  syncPauseDepth += 1;
+  if (syncPauseDepth > 1) return;
+  sourceSyncLifecycle += 1;
+  if (playlistDebounceTimer) clearTimeout(playlistDebounceTimer);
+  if (albumArtistDebounceTimer) clearTimeout(albumArtistDebounceTimer);
+  playlistDebounceTimer = null;
+  albumArtistDebounceTimer = null;
+  pendingPlaylistJobs.length = 0;
+  pendingAlbumJobs.length = 0;
+  pendingArtistJobs.length = 0;
+  pendingAlbumArtistServers.clear();
+  for (const timer of retryTimers.values()) clearTimeout(timer);
+  retryTimers.clear();
+  await Promise.allSettled([...sourceMutationTail.values()]);
+}
+
+export function resumePinnedOfflineSync(): void {
+  if (syncPauseDepth === 0) return;
+  syncPauseDepth -= 1;
+  if (syncPauseDepth > 0) return;
+  scheduleSyncPinnedAlbumsAndArtists();
+  void syncAllPinnedPlaylists();
+}
+
 export function initPinnedOfflineSync(): () => void {
+  let disposed = false;
   void subscribeLibrarySyncIdle(payload => {
+    if (disposed) return;
     onLibraryBecameIdle(payload.serverId, payload.kind, payload.ok);
   }).then(unlisten => {
+    if (disposed) {
+      unlisten();
+      return;
+    }
     stopLibraryIdle = unlisten;
   });
 
@@ -627,8 +817,14 @@ export function initPinnedOfflineSync(): () => void {
   });
 
   return () => {
+    disposed = true;
+    sourceSyncLifecycle += 1;
     if (playlistDebounceTimer) clearTimeout(playlistDebounceTimer);
     if (albumArtistDebounceTimer) clearTimeout(albumArtistDebounceTimer);
+    pendingPlaylistJobs.length = 0;
+    pendingAlbumJobs.length = 0;
+    pendingArtistJobs.length = 0;
+    pendingAlbumArtistServers.clear();
     if (playlistSyncInterval) clearInterval(playlistSyncInterval);
     stopLibraryIdle?.();
     stopLibraryIdle = null;

--- a/src/features/playback/store/applyQueueHistorySnapshot.ts
+++ b/src/features/playback/store/applyQueueHistorySnapshot.ts
@@ -32,6 +32,10 @@ import { analysisTrackRef } from '@/features/playback/store/analysisTrackRef';
 import { stopRadio } from '@/features/playback/store/radioPlayer';
 import { clearAllPlaybackScheduleTimers } from '@/features/playback/store/scheduleTimers';
 import { syncUserQueueMutationToServer } from '@/features/playback/store/queueSync';
+import {
+  canonicalizePlaybackTrack,
+  canonicalizeQueueItemRef,
+} from '@/features/playback/store/queueItemRef';
 
 type SetState = (
   partial: Partial<PlayerState> | ((state: PlayerState) => Partial<PlayerState>),
@@ -69,10 +73,12 @@ export function applyQueueHistorySnapshot(
   // this resolved `nextQueue` is only for the engine restore / normalization /
   // prepend logic below. The playing track is restored separately from the full
   // `snap.currentTrack`.
-  let nextQueue = snap.queueItems.map(ref => resolveQueueTrack(ref));
-  let nextItems: QueueItemRef[] = [...snap.queueItems];
+  let nextItems: QueueItemRef[] = snap.queueItems.map(canonicalizeQueueItemRef);
+  let nextQueue = nextItems.map(ref => canonicalizePlaybackTrack(resolveQueueTrack(ref), ref.serverId));
   let nextIndex = snap.queueIndex;
-  let nextTrack = snap.currentTrack ? { ...snap.currentTrack } : null;
+  let nextTrack = snap.currentTrack
+    ? canonicalizePlaybackTrack({ ...snap.currentTrack }, nextItems[snap.queueIndex]?.serverId ?? '')
+    : null;
 
   if (snap.currentTrack == null && prior.currentTrack) {
     const playing = prior.currentTrack;
@@ -91,15 +97,16 @@ export function applyQueueHistorySnapshot(
         ?? get().queueServerId
         ?? '';
       const prependServerId = canonicalQueueServerKey(snapshotSid);
-      nextQueue = [{ ...playing }, ...nextQueue];
+      const activePlaying = canonicalizePlaybackTrack(playing, prependServerId);
+      nextQueue = [activePlaying, ...nextQueue];
       nextItems = [
-        { serverId: prependServerId, trackId: playing.id },
+        canonicalizeQueueItemRef({ serverId: prependServerId, trackId: activePlaying.id }),
         ...nextItems,
       ];
       nextIndex = 0;
-      nextTrack = { ...playing };
+      nextTrack = activePlaying;
     } else {
-      nextTrack = { ...playing };
+      nextTrack = canonicalizePlaybackTrack(playing, nextItems[pos]?.serverId ?? '');
       nextIndex = pos;
     }
   }
@@ -122,7 +129,7 @@ export function applyQueueHistorySnapshot(
       const idxPrior = nextItems.findIndex(ref => queueItemRefMatchesTrack(ref, playingKeep));
       if (idxPrior >= 0) {
         nextIndex = idxPrior;
-        nextTrack = { ...playingKeep };
+        nextTrack = canonicalizePlaybackTrack(playingKeep, nextItems[idxPrior]?.serverId ?? '');
       }
     }
   }

--- a/src/features/playback/store/applyServerPlayQueue.test.ts
+++ b/src/features/playback/store/applyServerPlayQueue.test.ts
@@ -1,17 +1,36 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/features/playback/store/pausedRestorePrepare', () => ({
+  preparePausedRestoreOnStartup: vi.fn(),
+}));
 import {
   applyMappedQueueProjection,
   fingerprintFromLocalQueue,
   fingerprintFromServer,
   mergeQueueServerProjection,
   playQueueFingerprintsEqual,
+  applyMappedQueue,
 } from '@/features/playback/store/applyServerPlayQueue';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { resetPlayerStore } from '@/test/helpers/storeReset';
+import { useAuthStore } from '@/store/authStore';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
+
+const LEGACY_TRACK = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+const LEGACY_ALBUM = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
 
 describe('playQueueFingerprintsEqual', () => {
   beforeEach(() => {
+    deactivateCanonicalNavidromeOwners(['srv-a', 'a.test']);
     resetPlayerStore();
+    useAuthStore.setState({
+      servers: [{ id: 'srv-a', name: 'A', url: 'https://a.test', username: 'u', password: 'p' }],
+      activeServerId: 'srv-a',
+    });
   });
 
   it('compares track order, current id, and position within tolerance', () => {
@@ -43,6 +62,57 @@ describe('playQueueFingerprintsEqual', () => {
       trackIds: ['a', 'b'],
       currentId: 'b',
       positionMs: 1200,
+    });
+  });
+});
+
+describe('applyMappedQueue identity boundary', () => {
+  beforeEach(() => {
+    deactivateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+    resetPlayerStore();
+    useAuthStore.setState({
+      servers: [{ id: 'srv-a', name: 'A', url: 'https://a.test', username: 'u', password: 'p' }],
+      activeServerId: 'srv-a',
+    });
+  });
+
+  it('does not persist a stale server response after canonical activation', () => {
+    activateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+    applyMappedQueue(
+      [
+        {
+          id: 'first',
+          title: 'First',
+          artist: 'Artist',
+          album: 'Album',
+          albumId: 'first-album',
+          duration: 60,
+          serverId: 'srv-a',
+        },
+        {
+          id: LEGACY_TRACK,
+          title: 'Track',
+          artist: 'Artist',
+          album: 'Album',
+          albumId: LEGACY_ALBUM,
+          duration: 60,
+          serverId: 'srv-a',
+        },
+      ],
+      { songs: [] as never, current: LEGACY_TRACK, position: 0 },
+      'srv-a',
+      true,
+      0,
+    );
+
+    expect(usePlayerStore.getState().queueItems).toEqual([
+      { serverId: 'a.test', trackId: 'first' },
+      { serverId: 'a.test', trackId: canonicalizeNavidromeId(LEGACY_TRACK) },
+    ]);
+    expect(usePlayerStore.getState().queueIndex).toBe(1);
+    expect(usePlayerStore.getState().currentTrack).toMatchObject({
+      id: canonicalizeNavidromeId(LEGACY_TRACK),
+      albumId: canonicalizeNavidromeId(LEGACY_ALBUM),
     });
   });
 });

--- a/src/features/playback/store/applyServerPlayQueue.ts
+++ b/src/features/playback/store/applyServerPlayQueue.ts
@@ -2,7 +2,10 @@ import { getPlayQueueForServer, type PlayQueueResult } from '@/lib/api/subsonicP
 import { songToTrack } from '@/lib/media/songToTrack';
 import { bindQueueServerId, queueIsMultiServer } from '@/features/playback/utils/playback/playbackServer';
 import { resolveServerIdForIndexKey } from '@/lib/server/serverLookup';
-import { toQueueItemRefs } from '@/features/playback/store/queueItemRef';
+import {
+  canonicalizePlaybackTrack,
+  toQueueItemRefs,
+} from '@/features/playback/store/queueItemRef';
 import { seedQueueResolver } from '@/features/playback/store/queueTrackResolver';
 import { profileIdFromQueueRef } from '@/lib/media/trackServerScope';
 import type { QueueItemRef, Track } from '@/lib/media/trackTypes';
@@ -23,6 +26,7 @@ import {
 } from '@/features/playback/store/queuePlaybackIdle';
 import { clearQueueHandoffPending } from '@/features/playback/store/queueSyncUiState';
 import { sameQueueTrack } from '@/features/playback/utils/playback/queueIdentity';
+import { canonicalizeConfirmedNavidromeId } from '@/lib/server/navidromeCanonicalIds';
 
 export type ApplyPlayQueueMode = 'startup' | 'idle' | 'manual';
 
@@ -91,11 +95,13 @@ export function applyMappedQueue(
   preferServerPosition: boolean,
   localTimeFallback: number,
 ): void {
+  mappedTracks = mappedTracks.map(track => canonicalizePlaybackTrack(track, serverProfileId));
   let currentTrack = mappedTracks[0];
   let queueIndex = 0;
 
   if (q.current) {
-    const idx = mappedTracks.findIndex(t => t.id === q.current);
+    const currentId = canonicalizeConfirmedNavidromeId(serverProfileId, q.current);
+    const idx = mappedTracks.findIndex(t => t.id === currentId);
     if (idx >= 0) {
       currentTrack = mappedTracks[idx];
       queueIndex = idx;
@@ -178,6 +184,7 @@ export function applyMappedQueueProjection(
   serverProfileId: string,
   preserveLocalSurplus = true,
 ): void {
+  mappedTracks = mappedTracks.map(track => canonicalizePlaybackTrack(track, serverProfileId));
   seedQueueResolver(serverProfileId, mappedTracks);
   const remoteRefs = toQueueItemRefs(serverProfileId, mappedTracks);
   const player = usePlayerStore.getState();
@@ -204,7 +211,9 @@ export function applyMappedQueueProjection(
     return;
   }
 
-  const currentId = q.current ?? mappedTracks[0]?.id;
+  const currentId = q.current
+    ? canonicalizeConfirmedNavidromeId(serverProfileId, q.current)
+    : mappedTracks[0]?.id;
   const remoteIndex = mappedTracks.findIndex(track => track.id === currentId);
   const currentTrack = mappedTracks[remoteIndex >= 0 ? remoteIndex : 0];
   if (!currentTrack) {

--- a/src/features/playback/store/gaplessQueueAdvance.ts
+++ b/src/features/playback/store/gaplessQueueAdvance.ts
@@ -38,6 +38,7 @@ import { analysisTrackRef } from '@/features/playback/store/analysisTrackRef';
 import { syncQueueToServer } from '@/features/playback/store/queueSync';
 import { useAuthStore } from '@/store/authStore';
 import { setIsAudioPaused } from '@/features/playback/store/engineState';
+import { canonicalizePlaybackTrack } from '@/features/playback/store/queueItemRef';
 import {
   getLastEngineProgressSec,
   noteEngineProgressForGapless,
@@ -90,6 +91,7 @@ function applyGaplessSuccessorUi(
   source: 'track-switched' | 'progress-reconcile',
 ): void {
   const switchRef = store.queueItems[newIndex];
+  nextTrack = canonicalizePlaybackTrack(nextTrack, switchRef?.serverId ?? '');
   const switchServerId = playbackCacheKeyForRef(switchRef);
   const switchResolvedUrl = resolvePlaybackUrlForTrack(nextTrack, switchServerId);
   const switchPlaybackSource = playbackSourceHintForResolvedUrl(

--- a/src/features/playback/store/miscActions.ts
+++ b/src/features/playback/store/miscActions.ts
@@ -15,7 +15,10 @@ import { analysisTrackRefForTrack } from '@/features/playback/store/analysisTrac
 import { getPlaybackProgressSnapshot } from '@/features/playback/store/playbackProgress';
 import { shouldRebindPlaybackToHotCache } from '@/features/playback/store/playbackUrlRouting';
 import type { PlayerState } from '@/features/playback/store/playerStoreTypes';
-import { toQueueItemRefs } from '@/features/playback/store/queueItemRef';
+import {
+  canonicalizePlaybackTrack,
+  toQueueItemRefs,
+} from '@/features/playback/store/queueItemRef';
 import { resolveQueueTrack } from '@/features/playback/store/queueTrackView';
 import { seedQueueResolver } from '@/features/playback/store/queueTrackResolver';
 import { pushQueueUndoFromGetter } from '@/features/playback/store/queueUndo';
@@ -177,6 +180,7 @@ export function createMiscActions(set: SetState, get: GetState): Pick<
     },
 
     reseedQueueForInstantMix: (track) => {
+      track = canonicalizePlaybackTrack(track, get().queueServerId ?? '');
       const s = get();
       if (!sameQueueTrack(s.currentTrack, track)) {
         get().playTrack(track, [track]);

--- a/src/features/playback/store/pendingStarSync.test.ts
+++ b/src/features/playback/store/pendingStarSync.test.ts
@@ -22,6 +22,12 @@ import {
   _resetQueueResolverForTest,
 } from '@/features/playback/store/queueTrackResolver';
 import { toQueueItemRefs } from '@/features/playback/store/queueItemRef';
+import { useAuthStore } from '@/store/authStore';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
 
 const track = (id: string): Track => ({
   id, title: id, artist: '', album: 'A', albumId: 'A', duration: 1,
@@ -29,6 +35,7 @@ const track = (id: string): Track => ({
 
 describe('pendingStarSync', () => {
   beforeEach(() => {
+    deactivateCanonicalNavidromeOwners(['srv-b']);
     vi.useFakeTimers();
     resetActiveServerConnectionSnapshot();
     setActiveServerReachable(true);
@@ -47,6 +54,7 @@ describe('pendingStarSync', () => {
       starredOverrides: {},
       userRatingOverrides: {},
     });
+    useAuthStore.setState({ activeServerId: 'srv-a' });
   });
   afterEach(() => {
     _resetPendingStarSyncForTest();
@@ -102,6 +110,21 @@ describe('pendingStarSync', () => {
     expect(starMock).toHaveBeenCalledWith('t1', 'song', { serverId: 'srv-b' });
   });
 
+  it('keeps a random-song retry on its stamped owner after the active server changes', async () => {
+    starMock.mockRejectedValueOnce(new Error('offline')).mockResolvedValue(undefined);
+    queueSongStar('shared', true, 'srv-b');
+    await vi.advanceTimersByTimeAsync(0);
+
+    useAuthStore.setState({ activeServerId: 'srv-c' });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(starMock).toHaveBeenNthCalledWith(1, 'shared', 'song', { serverId: 'srv-b' });
+    expect(starMock).toHaveBeenNthCalledWith(2, 'shared', 'song', { serverId: 'srv-b' });
+    expect(usePlayerStore.getState().starredOverrides).toEqual({
+      'srv-b:shared': true,
+    });
+  });
+
   it('isolates scoped favorite overrides that share a raw id', async () => {
     queueSongStar('shared', false, 'srv-b', { scopedOverride: true });
 
@@ -120,6 +143,26 @@ describe('pendingStarSync', () => {
     await vi.runAllTimersAsync();
     expect(unstarMock).toHaveBeenCalledWith('t1', 'song', undefined);
     expect(usePlayerStore.getState().starredOverrides.t1).toBe(false); // kept as durable false
+    expect(usePlayerStore.getState().currentTrack?.starred).toBeFalsy();
+  });
+
+  it('serializes an in-flight star toggle so the latest request reaches the server last', async () => {
+    let resolveFirst!: () => void;
+    starMock.mockImplementationOnce(() => new Promise<void>(resolve => { resolveFirst = resolve; }));
+
+    queueSongStar('t1', true);
+    await vi.advanceTimersByTimeAsync(0);
+    queueSongStar('t1', false);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(starMock).toHaveBeenCalledTimes(1);
+    expect(unstarMock).not.toHaveBeenCalled();
+
+    resolveFirst();
+    await vi.runAllTimersAsync();
+
+    expect(unstarMock).toHaveBeenCalledWith('t1', 'song', undefined);
+    expect(usePlayerStore.getState().starredOverrides.t1).toBe(false);
     expect(usePlayerStore.getState().currentTrack?.starred).toBeFalsy();
   });
 
@@ -150,5 +193,87 @@ describe('pendingStarSync', () => {
 
     expect(setRatingMock).toHaveBeenCalledWith('shared', 5, { serverId: 'srv-b' });
     expect(usePlayerStore.getState().userRatingOverrides['srv-b:shared']).toBeUndefined();
+  });
+
+  it('serializes in-flight ratings so an older response cannot overwrite the latest value', async () => {
+    let resolveFirst!: () => void;
+    setRatingMock.mockImplementationOnce(() => new Promise<void>(resolve => { resolveFirst = resolve; }));
+
+    queueSongRating('t1', 2);
+    await vi.advanceTimersByTimeAsync(0);
+    queueSongRating('t1', 5);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(setRatingMock).toHaveBeenCalledTimes(1);
+
+    resolveFirst();
+    await vi.runAllTimersAsync();
+
+    expect(setRatingMock).toHaveBeenNthCalledWith(2, 't1', 5);
+    expect(usePlayerStore.getState().currentTrack?.userRating).toBe(5);
+    expect(usePlayerStore.getState().userRatingOverrides.t1).toBeUndefined();
+  });
+
+  it('canonicalizes a deferred retry and its scoped override after owner activation', async () => {
+    const legacyId = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    const canonicalId = canonicalizeNavidromeId(legacyId);
+    starMock.mockRejectedValueOnce(new Error('offline')).mockResolvedValue(undefined);
+
+    queueSongStar(legacyId, true, 'srv-b', { scopedOverride: true });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(starMock).toHaveBeenLastCalledWith(legacyId, 'song', { serverId: 'srv-b' });
+
+    activateCanonicalNavidromeOwners(['srv-b']);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(starMock).toHaveBeenLastCalledWith(canonicalId, 'song', { serverId: 'srv-b' });
+    expect(starMock).toHaveBeenCalledTimes(2);
+    expect(usePlayerStore.getState().starredOverrides).toEqual({
+      [`srv-b:${canonicalId}`]: true,
+    });
+  });
+
+  it('drops a legacy retry when a newer canonical toggle supersedes it', async () => {
+    const legacyId = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    const canonicalId = canonicalizeNavidromeId(legacyId);
+    starMock.mockRejectedValueOnce(new Error('offline')).mockResolvedValue(undefined);
+
+    queueSongStar(legacyId, true, 'srv-b', { scopedOverride: true });
+    await vi.advanceTimersByTimeAsync(0);
+    activateCanonicalNavidromeOwners(['srv-b']);
+    queueSongStar(legacyId, false, 'srv-b', { scopedOverride: true });
+    await vi.runAllTimersAsync();
+
+    expect(unstarMock).toHaveBeenCalledWith(canonicalId, 'song', { serverId: 'srv-b' });
+    expect(usePlayerStore.getState().starredOverrides).toEqual({
+      [`srv-b:${canonicalId}`]: false,
+    });
+  });
+
+  it('canonicalizes successful in-flight legacy work before success patches', async () => {
+    const legacyId = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    const canonicalId = canonicalizeNavidromeId(legacyId);
+    let resolveStar!: () => void;
+    starMock.mockImplementation(() => new Promise<void>(resolve => { resolveStar = resolve; }));
+    seedQueueResolver('srv-b', [{ ...track(canonicalId), serverId: 'srv-b' }]);
+    usePlayerStore.setState({
+      currentTrack: { ...track(canonicalId), serverId: 'srv-b' },
+      starredOverrides: {},
+    });
+
+    queueSongStar(legacyId, true, 'srv-b', { scopedOverride: true });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(starMock).toHaveBeenCalledWith(legacyId, 'song', { serverId: 'srv-b' });
+
+    activateCanonicalNavidromeOwners(['srv-b']);
+    resolveStar();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(usePlayerStore.getState().starredOverrides).toEqual({
+      [`srv-b:${canonicalId}`]: true,
+    });
+    expect(usePlayerStore.getState().currentTrack?.starred).toBeTruthy();
+    expect(getCachedTrack({ serverId: 'srv-b', trackId: canonicalId })?.starred).toBeTruthy();
   });
 });

--- a/src/features/playback/store/pendingStarSync.ts
+++ b/src/features/playback/store/pendingStarSync.ts
@@ -3,6 +3,10 @@ import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { patchCachedTrack } from '@/features/playback/store/queueTrackResolver';
 import { onActiveServerBecameReachable } from '@/lib/network/activeServerReachability';
 import { ownedEntityKey } from '@/lib/util/ownedEntityKey';
+import {
+  canonicalizeConfirmedNavidromeId,
+  canonicalizeNavidromeId,
+} from '@/lib/server/navidromeCanonicalIds';
 
 /**
  * F4 — pending-sync for **song** star + rating (spec §6.5 / R7-18).
@@ -27,17 +31,23 @@ import { ownedEntityKey } from '@/lib/util/ownedEntityKey';
  */
 
 type Task =
-  | { kind: 'star'; id: string; starred: boolean; serverId?: string; overrideKey: string }
-  | { kind: 'rating'; id: string; rating: number; serverId?: string; overrideKey: string };
+  | { kind: 'star'; id: string; starred: boolean; serverId?: string; overrideKey: string; sequence: number }
+  | { kind: 'rating'; id: string; rating: number; serverId?: string; overrideKey: string; sequence: number };
 
 const pending = new Map<string, Task>(); // key `${kind}:${id}` — latest wins
 const timers = new Map<string, ReturnType<typeof setTimeout>>();
 const attempts = new Map<string, number>();
+const latestSequenceByKey = new Map<string, number>();
+const runningOperations = new Set<string>();
 const MAX_BACKOFF_MS = 30_000;
 let listenersArmed = false;
+let nextSequence = 0;
 
 const keyOf = (t: Task) =>
   `${t.kind}:${t.serverId ?? ''}:${t.id}`;
+
+const operationKeyOf = (t: Task) =>
+  `${t.kind}:${t.serverId ?? ''}:${t.serverId ? canonicalizeNavidromeId(t.id) : t.id}`;
 
 function armListeners(): void {
   if (listenersArmed || typeof window === 'undefined') return;
@@ -60,19 +70,75 @@ function schedule(k: string, delayMs: number): void {
   );
 }
 
+function normalizeTask(k: string, task: Task): { key: string; task: Task } | null {
+  const activeId = task.serverId
+    ? canonicalizeConfirmedNavidromeId(task.serverId, task.id)
+    : task.id;
+  const activeOverrideKey = task.serverId
+    ? ownedEntityKey({ id: activeId, serverId: task.serverId })
+    : task.overrideKey;
+  if (activeId === task.id && activeOverrideKey === task.overrideKey) return { key: k, task };
+
+  const activeTask = { ...task, id: activeId, overrideKey: activeOverrideKey } as Task;
+  const activeKey = keyOf(activeTask);
+  const latestSequence = latestSequenceByKey.get(activeKey) ?? 0;
+  if (latestSequence > task.sequence) {
+    pending.delete(k);
+    attempts.delete(k);
+    migrateOverride(task.overrideKey, activeOverrideKey, task.kind, false);
+    return null;
+  }
+  latestSequenceByKey.set(activeKey, Math.max(latestSequence, task.sequence));
+  const current = pending.get(activeKey);
+  if (current && current !== task) {
+    pending.delete(k);
+    attempts.delete(k);
+    migrateOverride(task.overrideKey, activeOverrideKey, task.kind, false);
+    return null;
+  }
+  pending.delete(k);
+  pending.set(activeKey, activeTask);
+  const attempt = attempts.get(k);
+  attempts.delete(k);
+  if (attempt !== undefined) attempts.set(activeKey, attempt);
+  migrateOverride(task.overrideKey, activeOverrideKey, task.kind, true);
+  return { key: activeKey, task: activeTask };
+}
+
 async function run(k: string): Promise<void> {
   timers.delete(k);
-  const task = pending.get(k);
+  let task = pending.get(k);
   if (!task) return;
+  const operationKey = operationKeyOf(task);
+  if (runningOperations.has(operationKey)) return;
+  runningOperations.add(operationKey);
+  const normalized = normalizeTask(k, task);
+  if (!normalized) {
+    runningOperations.delete(operationKey);
+    return;
+  }
+  k = normalized.key;
+  task = normalized.task;
+  const startedSequence = task.sequence;
   try {
     if (task.kind === 'star') {
       const meta = task.serverId ? { serverId: task.serverId } : undefined;
       if (task.starred) await star(task.id, 'song', meta);
       else await unstar(task.id, 'song', meta);
+      const after = normalizeTask(k, task);
+      if (!after || after.task.kind !== 'star') return;
+      k = after.key;
+      task = after.task;
+      if (pending.get(k) !== task) return;
       onStarSuccess(task);
     } else {
       if (task.serverId) await setRating(task.id, task.rating, { serverId: task.serverId });
       else await setRating(task.id, task.rating);
+      const after = normalizeTask(k, task);
+      if (!after || after.task.kind !== 'rating') return;
+      k = after.key;
+      task = after.task;
+      if (pending.get(k) !== task) return;
       onRatingSuccess(task);
     }
     // Only retire the entry if a newer toggle hasn't superseded it mid-flight.
@@ -85,7 +151,26 @@ async function run(k: string): Promise<void> {
     const n = (attempts.get(k) ?? 0) + 1;
     attempts.set(k, n);
     schedule(k, Math.min(MAX_BACKOFF_MS, 1000 * 2 ** (n - 1)));
+  } finally {
+    runningOperations.delete(operationKey);
+    const latest = [...pending.entries()].find(([, candidate]) =>
+      operationKeyOf(candidate) === operationKey && candidate.sequence > startedSequence,
+    );
+    if (latest) schedule(latest[0], 0);
   }
+}
+
+function migrateOverride(from: string, to: string, kind: Task['kind'], overwrite: boolean): void {
+  if (from === to) return;
+  usePlayerStore.setState(state => {
+    const field = kind === 'star' ? 'starredOverrides' : 'userRatingOverrides';
+    const overrides = state[field];
+    if (!(from in overrides)) return {};
+    const next = { ...overrides };
+    if (overwrite || !(to in next)) next[to] = overrides[from];
+    delete next[from];
+    return { [field]: next };
+  });
 }
 
 function onStarSuccess(task: Extract<Task, { kind: 'star' }>): void {
@@ -126,11 +211,13 @@ export function queueSongStar(
   serverId?: string,
   options?: { scopedOverride?: boolean },
 ): void {
+  if (serverId) id = canonicalizeConfirmedNavidromeId(serverId, id);
   const scopedOverride = options?.scopedOverride ?? Boolean(serverId);
   const overrideKey = scopedOverride ? ownedEntityKey({ id, serverId }) : id;
   usePlayerStore.getState().setStarredOverride(overrideKey, starred);
-  const t: Task = { kind: 'star', id, starred, serverId, overrideKey };
+  const t: Task = { kind: 'star', id, starred, serverId, overrideKey, sequence: ++nextSequence };
   const k = keyOf(t);
+  latestSequenceByKey.set(k, t.sequence);
   pending.set(k, t);
   attempts.delete(k);
   armListeners();
@@ -144,11 +231,13 @@ export function queueSongRating(
   serverId?: string,
   options?: { scopedOverride?: boolean },
 ): void {
+  if (serverId) id = canonicalizeConfirmedNavidromeId(serverId, id);
   const scopedOverride = options?.scopedOverride ?? Boolean(serverId);
   const overrideKey = scopedOverride ? ownedEntityKey({ id, serverId }) : id;
   usePlayerStore.getState().setUserRatingOverride(overrideKey, rating);
-  const t: Task = { kind: 'rating', id, rating, serverId, overrideKey };
+  const t: Task = { kind: 'rating', id, rating, serverId, overrideKey, sequence: ++nextSequence };
   const k = keyOf(t);
+  latestSequenceByKey.set(k, t.sequence);
   pending.set(k, t);
   attempts.delete(k);
   armListeners();
@@ -159,6 +248,9 @@ export function queueSongRating(
 export function _resetPendingStarSyncForTest(): void {
   pending.clear();
   attempts.clear();
+  latestSequenceByKey.clear();
+  runningOperations.clear();
+  nextSequence = 0;
   for (const t of timers.values()) clearTimeout(t);
   timers.clear();
 }

--- a/src/features/playback/store/playTrackAction.ts
+++ b/src/features/playback/store/playTrackAction.ts
@@ -71,7 +71,10 @@ import {
 } from '@/features/playback/store/playbackUrlRouting';
 import type { Track } from '@/lib/media/trackTypes';
 import type { PlayerState } from '@/features/playback/store/playerStoreTypes';
-import { toQueueItemRefs } from '@/features/playback/store/queueItemRef';
+import {
+  canonicalizePlaybackTrack,
+  toQueueItemRefs,
+} from '@/features/playback/store/queueItemRef';
 import { getQueueTracksView, resolveQueueTrack } from '@/features/playback/store/queueTrackView';
 import { getCachedTrack, seedQueueResolver, mergeDirectShareUrls } from '@/features/playback/store/queueTrackResolver';
 import { tracksArePublicShareQueue } from '@/lib/share/navidromePublicSharePlayback';
@@ -214,7 +217,7 @@ export function runPlayTrack(
 
   const stateBeforeLeave = get();
   const prevTrackForHistory = stateBeforeLeave.currentTrack;
-  const scopedTrackEarly = stampTrackServerId(track);
+  const scopedTrackEarly = canonicalizePlaybackTrack(stampTrackServerId(track));
   if (
     prevTrackForHistory
     && !sameQueueTrack(prevTrackForHistory, scopedTrackEarly)
@@ -247,7 +250,9 @@ export function runPlayTrack(
       playingRefEarly,
     )
     : scopedTrackEarly;
-  const scopedQueue = queue ? stampTrackServerIds(queue) : queue;
+  const scopedQueue = queue
+    ? stampTrackServerIds(queue).map(queueTrack => canonicalizePlaybackTrack(queueTrack))
+    : queue;
 
   clearAllPlaybackScheduleTimers();
   set({ scheduledPauseAtMs: null, scheduledPauseStartMs: null, scheduledResumeAtMs: null, scheduledResumeStartMs: null });
@@ -375,6 +380,10 @@ export function runPlayTrack(
     );
 
   const runPlayTrackBody = (trackForPlay: Track) => {
+    trackForPlay = canonicalizePlaybackTrack(
+      trackForPlay,
+      playingRef?.serverId ?? get().queueServerId ?? '',
+    );
     const playNormWindow = normWindow.map((t, i) => (i === normIdx ? trackForPlay : t));
     const authStateNow = useAuthStore.getState();
     const playbackSid = playbackProfileIdForTrack(trackForPlay, playingRef);

--- a/src/features/playback/store/playerStore.ts
+++ b/src/features/playback/store/playerStore.ts
@@ -6,7 +6,11 @@ import { createHydrationGatedStorage, createSafeJSONStorage } from '@/lib/util/s
 import { emitPlaybackProgress } from '@/features/playback/store/playbackProgress';
 import type { QueueItemRef, Track } from '@/lib/media/trackTypes';
 import type { PlayerState } from '@/features/playback/store/playerStoreTypes';
-import { toQueueItemRefs } from '@/features/playback/store/queueItemRef';
+import {
+  canonicalizePlaybackTrack,
+  canonicalizeQueueItemRef,
+  toQueueItemRefs,
+} from '@/features/playback/store/queueItemRef';
 import { canonicalQueueServerKey } from '@/lib/server/serverIndexKey';
 import {
   isActivePublicShareQueue,
@@ -115,13 +119,18 @@ export const usePlayerStore = create<PlayerState>()(
         // volume/repeatMode → psysonic_player_prefs; isQueueVisible →
         // psysonic_queue_visible; networkLovedCache → psysonic_network_loved_cache.
         // Kept out of this blob so a huge queue cannot block their writes.
-        currentTrack: state.currentTrack,
-        queueServerId: state.queueServerId,
+        currentTrack: state.currentTrack
+          ? canonicalizePlaybackTrack(
+            state.currentTrack,
+            state.queueItems?.[state.queueIndex]?.serverId ?? state.queueServerId ?? '',
+          )
+          : null,
+        queueServerId: state.queueServerId ? canonicalQueueServerKey(state.queueServerId) : null,
         // Thin-state: persist the whole ordered ref list (tiny) — no windowed
         // fat `queue: Track[]` anymore. `queueItemsIndex` doubles as the
         // restore-pending sentinel a fresh rehydrate carries back, telling
         // `hydrateQueueFromIndex` the refs still need a full resolve.
-        queueItems: state.queueItems,
+        queueItems: (state.queueItems ?? []).map(canonicalizeQueueItemRef),
         queueItemsIndex: state.queueIndex,
         // currentTime is intentionally NOT persisted here.
         // handleAudioProgress fires every 100ms and each setState with a
@@ -143,12 +152,9 @@ export const usePlayerStore = create<PlayerState>()(
 
         let queueItems: QueueItemRef[] | undefined;
         if (Array.isArray(blob.queueItems) && blob.queueItems.length > 0) {
-          queueItems = (blob.queueItems as QueueItemRef[]).map(ref => ({
-            ...ref,
-            serverId: canonicalQueueServerKey(ref.serverId),
-          }));
+          queueItems = (blob.queueItems as QueueItemRef[]).map(canonicalizeQueueItemRef);
         } else if (Array.isArray(blob.queueRefs) && blob.queueRefs.length > 0) {
-          queueItems = (blob.queueRefs as string[]).map(trackId => ({
+          queueItems = (blob.queueRefs as string[]).map(trackId => canonicalizeQueueItemRef({
             serverId: canonicalSid ?? '',
             trackId,
           }));
@@ -168,6 +174,9 @@ export const usePlayerStore = create<PlayerState>()(
         }
 
         const persistedTrack = blob.currentTrack as Track | null | undefined;
+        if (persistedTrack) {
+          blob.currentTrack = canonicalizePlaybackTrack(persistedTrack, canonicalSid ?? '');
+        }
         let strippedPublicShare = false;
         if (queueItems?.length && isActivePublicShareQueue(canonicalSid, queueItems)) {
           strippedPublicShare = true;

--- a/src/features/playback/store/queueItemRef.test.ts
+++ b/src/features/playback/store/queueItemRef.test.ts
@@ -1,32 +1,47 @@
-import { describe, expect, it } from 'vitest';
-import { toQueueItemRefs } from './queueItemRef';
-import type { Track } from '@/lib/media/trackTypes';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useAuthStore } from '@/store/authStore';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
+import { canonicalizePlaybackTrack, toQueueItemRefs } from './queueItemRef';
 
-describe('toQueueItemRefs', () => {
-  it('uses per-track serverId when present', () => {
-    const queue: Track[] = [
-      { id: 't1', title: 'A', artist: '', album: '', albumId: '', duration: 1, serverId: 'srv-a' },
-      { id: 't2', title: 'B', artist: '', album: '', albumId: '', duration: 1, serverId: 'srv-b' },
-    ];
-    const refs = toQueueItemRefs('fallback', queue);
-    expect(refs[0].serverId).not.toBe(refs[1].serverId);
-    expect(refs[0].trackId).toBe('t1');
-    expect(refs[1].trackId).toBe('t2');
+const LEGACY_TRACK = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+const LEGACY_ALBUM = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+
+describe('playback identity write boundaries', () => {
+  beforeEach(() => {
+    deactivateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+    useAuthStore.setState({
+      servers: [{ id: 'srv-a', name: 'A', url: 'https://a.test', username: 'u', password: 'p' }],
+      activeServerId: 'srv-a',
+    });
   });
 
-  it('persists Navidrome public share direct URLs on refs', () => {
-    const queue: Track[] = [{
-      id: 'ndshare:Ab12:0',
-      title: 'A',
-      artist: '',
-      album: '',
-      albumId: '',
+  it('canonicalizes stale full tracks and thin refs after owner activation', () => {
+    activateCanonicalNavidromeOwners(['srv-a', 'a.test']);
+    const staleTrack = {
+      id: LEGACY_TRACK,
+      title: 'Track',
+      artist: 'Artist',
+      album: 'Album',
+      albumId: LEGACY_ALBUM,
+      artistId: LEGACY_ALBUM,
+      coverArt: LEGACY_ALBUM,
       duration: 1,
-      directStreamUrl: 'https://music.example.com/share/s/jwt-a',
-      directCoverArtUrl: 'https://music.example.com/share/img/jwt-a?size=300',
-    }];
-    const refs = toQueueItemRefs('navidrome-public-share', queue);
-    expect(refs[0]?.directStreamUrl).toBe('https://music.example.com/share/s/jwt-a');
-    expect(refs[0]?.directCoverArtUrl).toBe('https://music.example.com/share/img/jwt-a?size=300');
+      serverId: 'srv-a',
+    };
+
+    expect(canonicalizePlaybackTrack(staleTrack)).toMatchObject({
+      id: canonicalizeNavidromeId(LEGACY_TRACK),
+      albumId: canonicalizeNavidromeId(LEGACY_ALBUM),
+      artistId: canonicalizeNavidromeId(LEGACY_ALBUM),
+      coverArt: canonicalizeNavidromeId(LEGACY_ALBUM),
+    });
+    expect(toQueueItemRefs('srv-a', [staleTrack])).toEqual([{
+      serverId: 'a.test',
+      trackId: canonicalizeNavidromeId(LEGACY_TRACK),
+    }]);
   });
 });

--- a/src/features/playback/store/queueItemRef.ts
+++ b/src/features/playback/store/queueItemRef.ts
@@ -1,6 +1,35 @@
 import type { QueueItemRef, Track } from '@/lib/media/trackTypes';
 import { stampTrackServerId } from '@/lib/media/trackServerScope';
 import { canonicalQueueServerKey } from '@/lib/server/serverIndexKey';
+import { canonicalizeConfirmedNavidromeId } from '@/lib/server/navidromeCanonicalIds';
+
+export function canonicalizePlaybackTrack(track: Track, fallbackServerId = ''): Track {
+  const owner = canonicalQueueServerKey(track.serverId ?? fallbackServerId);
+  if (!owner) return track;
+  const canonicalize = (value: string): string => canonicalizeConfirmedNavidromeId(owner, value);
+  const id = canonicalize(track.id);
+  const albumId = canonicalize(track.albumId);
+  const artistId = track.artistId ? canonicalize(track.artistId) : track.artistId;
+  const coverArt = track.coverArt ? canonicalize(track.coverArt) : track.coverArt;
+  const artists = track.artists?.map(artist => ({
+    ...artist,
+    id: artist.id ? canonicalize(artist.id) : artist.id,
+  }));
+  if (
+    id === track.id
+    && albumId === track.albumId
+    && artistId === track.artistId
+    && coverArt === track.coverArt
+    && artists?.every((artist, index) => artist.id === track.artists?.[index]?.id) !== false
+  ) return track;
+  return { ...track, id, albumId, artistId, coverArt, artists };
+}
+
+export function canonicalizeQueueItemRef(ref: QueueItemRef): QueueItemRef {
+  const serverId = canonicalQueueServerKey(ref.serverId);
+  const trackId = canonicalizeConfirmedNavidromeId(serverId, ref.trackId);
+  return serverId === ref.serverId && trackId === ref.trackId ? ref : { ...ref, serverId, trackId };
+}
 
 /**
  * Derive thin `QueueItemRef`s from a `Track[]` queue (thin-state). Per-item
@@ -16,7 +45,8 @@ export function toQueueItemRefs(serverId: string, queue: Track[]): QueueItemRef[
   return queue.map(t => {
     const scoped = stampTrackServerId(t, serverId);
     const canonicalId = canonicalQueueServerKey(scoped.serverId ?? serverId);
-    const ref: QueueItemRef = { serverId: canonicalId, trackId: t.id };
+    const activeTrack = canonicalizePlaybackTrack(scoped, canonicalId);
+    const ref: QueueItemRef = { serverId: canonicalId, trackId: activeTrack.id };
     if (t.autoAdded) ref.autoAdded = true;
     if (t.radioAdded) ref.radioAdded = true;
     if (t.playNextAdded) ref.playNextAdded = true;

--- a/src/features/playback/store/queueMutationActions.ts
+++ b/src/features/playback/store/queueMutationActions.ts
@@ -3,7 +3,10 @@ import { useAuthStore } from '@/store/authStore';
 import { prefetchLoudnessForEnqueuedTracks } from '@/features/playback/store/loudnessPrefetch';
 import type { QueueItemRef, Track } from '@/lib/media/trackTypes';
 import type { PlayerState } from '@/features/playback/store/playerStoreTypes';
-import { toQueueItemRefs } from '@/features/playback/store/queueItemRef';
+import {
+  canonicalizeQueueItemRef,
+  toQueueItemRefs,
+} from '@/features/playback/store/queueItemRef';
 import { seedQueueResolver } from '@/features/playback/store/queueTrackResolver';
 import { pushQueueUndoFromGetter } from '@/features/playback/store/queueUndo';
 import {
@@ -102,7 +105,7 @@ export function createQueueMutationActions(set: SetState, get: GetState): Pick<
 
       pushQueueUndoFromGetter(get);
       const nextItems = [...state.queueItems];
-      nextItems[index] = { ...replacement };
+      nextItems[index] = canonicalizeQueueItemRef(replacement);
       set({ queueItems: nextItems });
       const sync = userInitiated
         ? syncUserQueueMutationToServer

--- a/src/features/playback/store/queueTrackResolver.ts
+++ b/src/features/playback/store/queueTrackResolver.ts
@@ -9,6 +9,7 @@ import { trackToSong } from '@/lib/library/advancedSearchLocal';
 import { libraryIsReady } from '@/lib/library/libraryReady';
 import { NAVIDROME_PUBLIC_SHARE_SERVER_ID } from '@/lib/share/navidromePublicSharePlayback';
 import { ownedOverrideValue } from '@/lib/util/ownedEntityKey';
+import { canonicalizePlaybackTrack } from '@/features/playback/store/queueItemRef';
 
 /**
  * Queue track resolver (thin-state phase 2). Resolves `QueueItemRef`s to full
@@ -149,9 +150,10 @@ export function seedQueueResolver(serverId: string, tracks: Track[]): void {
   const canonicalId = canonicalQueueServerKey(serverId);
   const preserve = new Set<string>();
   for (const t of tracks) {
-    const key = refKey({ serverId: canonicalId, trackId: t.id });
+    const activeTrack = canonicalizePlaybackTrack(t, canonicalId);
+    const key = refKey({ serverId: canonicalId, trackId: activeTrack.id });
     preserve.add(key);
-    cacheSet(key, t, { skipCap: true });
+    cacheSet(key, activeTrack, { skipCap: true });
   }
   // Bulk queue replace: keep the whole incoming set (may exceed CACHE_CAP).
   // Single-track touch (queue navigation): no eviction — must not wipe siblings.

--- a/src/features/playback/store/resumeAction.ts
+++ b/src/features/playback/store/resumeAction.ts
@@ -37,6 +37,7 @@ import { markPlaybackActive } from '@/features/playback/store/queuePlaybackIdle'
 import { playbackReportPlaying } from '@/features/playback/store/playbackReportSession';
 import { resumeRadio } from '@/features/playback/store/radioPlayer';
 import { clearAllPlaybackScheduleTimers } from '@/features/playback/store/scheduleTimers';
+import { canonicalizePlaybackTrack } from '@/features/playback/store/queueItemRef';
 
 type SetState = (
   partial: Partial<PlayerState> | ((state: PlayerState) => Partial<PlayerState>),
@@ -168,6 +169,7 @@ export function runResume(set: SetState, get: GetState): void {
         }
       } catch { /* keep currentTrack */ }
       if (getPlayGeneration() !== gen) return;
+      trackToPlay = canonicalizePlaybackTrack(trackToPlay, coldServerId);
       if (trackToPlay !== currentTrack) set({ currentTrack: trackToPlay });
 
       const authStateCold = useAuthStore.getState();

--- a/src/features/playback/store/startupPlayQueueReconcile.test.ts
+++ b/src/features/playback/store/startupPlayQueueReconcile.test.ts
@@ -152,4 +152,33 @@ describe('reconcileStartupPlayQueues', () => {
     await expect(reconciliation).resolves.toBe('kept-local');
     expect(applyMappedQueueMock).not.toHaveBeenCalled();
   });
+
+  it('abandons a deferred old scope and lets the new scope reconcile independently', async () => {
+    let resolveA: ((value: ReturnType<typeof remote>) => void) | undefined;
+    fetchPlayQueueForServerMock.mockImplementation((serverId: string) => {
+      if (serverId === 'a') return new Promise(resolve => { resolveA = resolve; });
+      return Promise.resolve(remote(['b1', 'b2'], 'b1'));
+    });
+    const oldScope = reconcileStartupPlayQueues();
+
+    useAuthStore.setState({ libraryBrowseServerIds: ['b'] });
+    usePlayerStore.setState({
+      queueItems: [{ serverId: 'b', trackId: 'b1' }],
+      queueIndex: 0,
+      currentTrack: { id: 'b1', title: 'b1', artist: 'Artist', album: 'Album', albumId: 'album', duration: 100, serverId: 'b' },
+    });
+    const newScope = reconcileStartupPlayQueues();
+    await expect(newScope).resolves.toBe('applied');
+
+    resolveA?.(remote(['a1', 'a3'], 'a1'));
+    await expect(oldScope).resolves.toBe('kept-local');
+    expect(applyMappedQueueMock).toHaveBeenCalledTimes(1);
+    expect(applyMappedQueueMock).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ id: 'b2', serverId: 'b' })]),
+      expect.objectContaining({ current: 'b1' }),
+      'b',
+      true,
+      0,
+    );
+  });
 });

--- a/src/features/playback/store/startupPlayQueueReconcile.ts
+++ b/src/features/playback/store/startupPlayQueueReconcile.ts
@@ -26,6 +26,10 @@ type LocalQueueSnapshot = {
 
 export type StartupQueueReconcileResult = 'applied' | 'kept-local';
 
+type StartupQueueReconcileOptions = {
+  shouldAbort?: () => boolean;
+};
+
 function structuralQueueEqual(a: StructuralQueue, b: StructuralQueue): boolean {
   if (a.currentId !== b.currentId || a.trackIds.length !== b.trackIds.length) return false;
   return a.trackIds.every((id, index) => id === b.trackIds[index]);
@@ -79,14 +83,25 @@ function localSnapshotStillCurrent(snapshot: LocalQueueSnapshot): boolean {
   });
 }
 
+function selectedServerScope(): string[] {
+  return [...new Set(useAuthStore.getState().libraryBrowseServerIds.filter(Boolean))];
+}
+
+function sameServerScope(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((serverId, index) => serverId === b[index]);
+}
+
 /**
  * Preserve the persisted mixed queue unless exactly one selected server has a
  * structurally different, non-empty remote queue. Position is intentionally
  * ignored because local playback position is not persisted in the queue blob.
  */
-export async function reconcileStartupPlayQueues(): Promise<StartupQueueReconcileResult> {
-  const selectedServerIds = [...new Set(useAuthStore.getState().libraryBrowseServerIds.filter(Boolean))];
+export async function reconcileStartupPlayQueues(
+  options: StartupQueueReconcileOptions = {},
+): Promise<StartupQueueReconcileResult> {
+  const selectedServerIds = selectedServerScope();
   if (selectedServerIds.length === 0) return 'kept-local';
+  if (options.shouldAbort?.()) return 'kept-local';
 
   const snapshot = takeLocalSnapshot();
   if (snapshot.currentRadioId) return 'kept-local';
@@ -100,6 +115,8 @@ export async function reconcileStartupPlayQueues(): Promise<StartupQueueReconcil
     serverId,
     queue: await fetchPlayQueueForServer(serverId),
   })));
+  if (options.shouldAbort?.()) return 'kept-local';
+  if (!sameServerScope(selectedServerIds, selectedServerScope())) return 'kept-local';
   if (settled.some(result => result.status === 'rejected')) return 'kept-local';
   if (!localSnapshotStillCurrent(snapshot)) return 'kept-local';
 
@@ -116,6 +133,9 @@ export async function reconcileStartupPlayQueues(): Promise<StartupQueueReconcil
   if (changed.length !== 1 || changed[0].queue.songs.length === 0) return 'kept-local';
   const [{ serverId, queue }] = changed;
   const mappedTracks = queue.songs.map(song => ({ ...songToTrack(song), serverId }));
+  if (options.shouldAbort?.()) return 'kept-local';
+  if (!sameServerScope(selectedServerIds, selectedServerScope())) return 'kept-local';
+  if (!localSnapshotStillCurrent(snapshot)) return 'kept-local';
   if (representedServerIds.size > 1) {
     applyMappedQueueProjection(mappedTracks, queue, serverId);
   } else {

--- a/src/features/playback/store/timelineSessionHistory.test.ts
+++ b/src/features/playback/store/timelineSessionHistory.test.ts
@@ -8,12 +8,19 @@ import {
   isTimelineBootstrapAttempted,
   isTimelineHistoryClearedThisSession,
   markTimelineBootstrapAttempted,
+  rewriteTimelineSessionHistoryForOwners,
   TIMELINE_APPEND_DEDUPE_MS,
   TIMELINE_MERGE_DEDUPE_MS,
 } from '@/features/playback/store/timelineSessionHistory';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
 
 describe('timelineSessionHistory', () => {
   beforeEach(() => {
+    deactivateCanonicalNavidromeOwners(['s1']);
     _resetTimelineSessionHistoryForTest();
   });
 
@@ -61,5 +68,19 @@ describe('timelineSessionHistory', () => {
     expect(markTimelineBootstrapAttempted()).toBe(true);
     expect(markTimelineBootstrapAttempted()).toBe(false);
     expect(isTimelineBootstrapAttempted()).toBe(true);
+  });
+
+  it('rewrites only live history owned by a canonicalized server', () => {
+    const legacyId = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    appendTimelineSessionPlay({ serverId: 's1', trackId: legacyId, playedAtMs: 1 });
+    appendTimelineSessionPlay({ serverId: 's2', trackId: legacyId, playedAtMs: 2 });
+
+    activateCanonicalNavidromeOwners(['s1']);
+    rewriteTimelineSessionHistoryForOwners(new Set(['s1']), 's1');
+
+    expect(getTimelineSessionHistorySnapshot()).toEqual([
+      { serverId: 's1', trackId: canonicalizeNavidromeId(legacyId), playedAtMs: 1 },
+      { serverId: 's2', trackId: legacyId, playedAtMs: 2 },
+    ]);
   });
 });

--- a/src/features/playback/store/timelineSessionHistory.ts
+++ b/src/features/playback/store/timelineSessionHistory.ts
@@ -5,6 +5,7 @@ import {
 } from '@/features/playback/utils/playback/playbackServer';
 import { usePreviewStore } from '@/features/playback/store/previewStore';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
+import { canonicalizeQueueItemRef } from '@/features/playback/store/queueItemRef';
 
 export const TIMELINE_HISTORY_BOOTSTRAP_LIMIT = 50;
 export const TIMELINE_APPEND_DEDUPE_MS = 2_000;
@@ -68,6 +69,10 @@ function isDuplicateInBuffer(
 
 export function appendTimelineSessionPlay(ref: TimelinePlayedRef): void {
   if (!ref.serverId || !ref.trackId) return;
+  const canonicalRef = canonicalizeQueueItemRef(ref);
+  ref = canonicalRef.serverId === ref.serverId && canonicalRef.trackId === ref.trackId
+    ? ref
+    : { ...ref, ...canonicalRef };
   const last = sessionPlays[sessionPlays.length - 1];
   if (
     last
@@ -113,6 +118,10 @@ export function clearTimelineSessionHistory(): void {
 
 export function applyTimelineBootstrap(rowsOldestFirst: TimelinePlayedRef[]): void {
   if (historyClearedThisSession || rowsOldestFirst.length === 0) return;
+  rowsOldestFirst = rowsOldestFirst.map(row => ({
+    ...row,
+    ...canonicalizeQueueItemRef(row),
+  }));
 
   if (sessionPlays.length === 0) {
     sessionPlays = [...rowsOldestFirst];
@@ -127,6 +136,23 @@ export function applyTimelineBootstrap(rowsOldestFirst: TimelinePlayedRef[]): vo
   );
   if (deduped.length === 0) return;
   sessionPlays = [...deduped, ...sessionPlays];
+  emit();
+}
+
+export function rewriteTimelineSessionHistoryForOwners(
+  owners: ReadonlySet<string>,
+  canonicalOwner: string,
+): void {
+  let changed = false;
+  const next = sessionPlays.map(row => {
+    if (!owners.has(row.serverId)) return row;
+    const canonical = canonicalizeQueueItemRef({ ...row, serverId: canonicalOwner });
+    if (canonical.serverId === row.serverId && canonical.trackId === row.trackId) return row;
+    changed = true;
+    return { ...row, ...canonical };
+  });
+  if (!changed) return;
+  sessionPlays = next;
   emit();
 }
 

--- a/src/features/playback/utils/mixRatingFilter.test.ts
+++ b/src/features/playback/utils/mixRatingFilter.test.ts
@@ -3,6 +3,14 @@ import type { SubsonicAlbum, SubsonicSong } from '@/lib/api/subsonicTypes';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { resetPlayerStore } from '@/test/helpers/storeReset';
 
+const { getRandomSongsForServerMock } = vi.hoisted(() => ({
+  getRandomSongsForServerMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api/subsonicLibrary', () => ({
+  getRandomSongsForServer: getRandomSongsForServerMock,
+}));
+
 vi.mock('@/lib/api/subsonicRatings', () => ({
   entityUserRatingKey: ({ serverId, entityKind, entityId }: { serverId: string; entityKind: string; entityId: string }) => `${serverId}\u0001${entityKind}\u0001${entityId}`,
   putLocalEntityUserRatings: vi.fn(),
@@ -14,6 +22,7 @@ vi.mock('@/store/authStore', () => ({ useAuthStore: { getState: () => ({ activeS
 import { putLocalEntityUserRatings, resolveEntityUserRatings } from '@/lib/api/subsonicRatings';
 import {
   enrichSongsForMixRatingFilter,
+  fetchRandomMixSongsUntilFull,
   filterAlbumsByMixRatingsAcrossServers,
   filterTopArtistsForMixRatings,
   passesMixMinRatings,
@@ -36,6 +45,27 @@ beforeEach(() => {
   vi.mocked(resolveEntityUserRatings).mockReset();
   vi.mocked(resolveEntityUserRatings).mockResolvedValue(new Map());
   vi.mocked(putLocalEntityUserRatings).mockReset();
+  getRandomSongsForServerMock.mockReset().mockResolvedValue([]);
+});
+
+describe('fetchRandomMixSongsUntilFull', () => {
+  it('holds an explicit server owner across random-song batches', async () => {
+    getRandomSongsForServerMock
+      .mockResolvedValueOnce([song({ id: 'one', serverId: 'server-b' })])
+      .mockResolvedValueOnce([song({ id: 'two', serverId: 'server-b' })]);
+
+    const result = await fetchRandomMixSongsUntilFull(
+      { enabled: true, minSong: 0, minAlbum: 0, minArtist: 0 },
+      { serverId: 'server-b', targetSize: 2 },
+    );
+
+    expect(getRandomSongsForServerMock).toHaveBeenCalledTimes(2);
+    expect(getRandomSongsForServerMock.mock.calls.every(call => call[0] === 'server-b')).toBe(true);
+    expect(result.map(item => `${item.serverId}:${item.id}`)).toEqual([
+      'server-b:one',
+      'server-b:two',
+    ]);
+  });
 });
 
 describe('filterAlbumsByMixRatingsAcrossServers', () => {

--- a/src/features/playback/utils/mixRatingFilter.ts
+++ b/src/features/playback/utils/mixRatingFilter.ts
@@ -5,11 +5,12 @@ import {
   resolveEntityUserRatings,
   type EntityUserRatingRef,
 } from '@/lib/api/subsonicRatings';
-import { getRandomSongs } from '@/lib/api/subsonicLibrary';
+import { getRandomSongsForServer } from '@/lib/api/subsonicLibrary';
 import type { SubsonicAlbum, SubsonicSong } from '@/lib/api/subsonicTypes';
 import { useAuthStore } from '@/store/authStore';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { ownedOverrideValue } from '@/lib/util/ownedEntityKey';
+import { resolveIndexKey } from '@/lib/server/serverIndexKey';
 
 /** Default target list size for Random Mix; per-call override via `fetchRandomMixSongsUntilFull(c, { targetSize })`. */
 export const RANDOM_MIX_TARGET_SIZE = 50;
@@ -315,11 +316,12 @@ export async function enrichSongsForMixRatingFilter(
   ownerServerId?: string,
 ): Promise<SubsonicSong[]> {
   if (!c.enabled || (c.minArtist <= 0 && c.minAlbum <= 0)) return songs;
-  const serverId = ownerServerId ?? useAuthStore.getState().activeServerId;
-  if (!serverId) return songs;
+  const owner = ownerServerId ?? useAuthStore.getState().activeServerId;
+  if (!owner) return songs;
+  const serverId = resolveIndexKey(owner);
   const ownedSongs = songs.map(song => ({
     ...song,
-    serverId: ownerServerId ?? song.serverId ?? serverId,
+    serverId: song.serverId ?? serverId,
   }));
   const artistIds =
     c.minArtist > 0
@@ -363,19 +365,22 @@ export async function enrichSongsForMixRatingFilter(
  */
 export async function fetchRandomMixSongsUntilFull(
   c: MixMinRatingsConfig,
-  opts?: { genre?: string; timeout?: number; targetSize?: number },
+  opts?: { genre?: string; timeout?: number; targetSize?: number; serverId?: string },
 ): Promise<SubsonicSong[]> {
   const timeout = opts?.timeout ?? 15000;
   const genre = opts?.genre;
   const targetSize = opts?.targetSize ?? RANDOM_MIX_TARGET_SIZE;
+  const ownerServerId = opts?.serverId ?? useAuthStore.getState().activeServerId ?? undefined;
+  if (!ownerServerId) return [];
   const filterActive = c.enabled;
   const batchSize = batchSizeFor(targetSize, filterActive);
+  const fetchRandom = () => getRandomSongsForServer(ownerServerId, batchSize, genre, timeout);
 
   // Fast-path: no filter — one call asking for the full target, slice, done. The server-side
   // `ORDER BY random() LIMIT N` returns N distinct rows, so a single round-trip usually fills
   // the request without dup-streak gymnastics.
   if (!filterActive) {
-    const raw = await getRandomSongs(batchSize, genre, timeout);
+    const raw = await fetchRandom();
     if (raw.length >= targetSize) return raw.slice(0, targetSize);
     // Library smaller than target, or random endpoint returned fewer — fall through to the
     // batched loop below so we can top up via additional calls (deduped by id).
@@ -390,7 +395,7 @@ export async function fetchRandomMixSongsUntilFull(
   let dupStreak = 0;
 
   for (let b = 0; b < maxBatches && out.length < targetSize; b++) {
-    const raw = await getRandomSongs(batchSize, genre, timeout);
+    const raw = await fetchRandom();
     if (!raw.length) break;
 
     const novel = raw.filter(s => !seenFromApi.has(s.id));
@@ -403,7 +408,7 @@ export async function fetchRandomMixSongsUntilFull(
     dupStreak = 0;
 
     const enriched = filterActive
-      ? await enrichSongsForMixRatingFilter(novel, c)
+      ? await enrichSongsForMixRatingFilter(novel, c, ownerServerId)
       : novel;
     for (const s of enriched) {
       if (!passesMixMinRatings(s, c) || outIds.has(s.id)) continue;

--- a/src/features/playback/utils/timelineHistoryRefs.test.ts
+++ b/src/features/playback/utils/timelineHistoryRefs.test.ts
@@ -1,7 +1,23 @@
-import { describe, it, expect } from 'vitest';
+import { beforeEach, describe, it, expect } from 'vitest';
 import { bootstrapTrackFromPlaySession, timelineHistoryToQueueRefs } from '@/features/playback/utils/timelineHistoryRefs';
+import { useAuthStore } from '@/store/authStore';
 
 describe('timelineHistoryRefs', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ servers: [] });
+  });
+
+  it('centralizes queue server identity while mapping history rows', () => {
+    useAuthStore.setState({
+      servers: [{ id: 's1', name: 'One', url: 'https://music.test', username: 'u', password: 'p' }],
+    });
+    expect(timelineHistoryToQueueRefs([
+      { serverId: 's1', trackId: 't1', playedAtMs: 1 },
+    ])).toEqual([
+      { serverId: 'music.test', trackId: 't1' },
+    ]);
+  });
+
   it('maps history rows to queue refs', () => {
     expect(timelineHistoryToQueueRefs([
       { serverId: 's1', trackId: 't1', playedAtMs: 1 },

--- a/src/features/playback/utils/timelineHistoryRefs.ts
+++ b/src/features/playback/utils/timelineHistoryRefs.ts
@@ -2,17 +2,24 @@ import type { QueueItemRef } from '@/lib/media/trackTypes';
 import type { PlaySessionRecentTrack } from '@/lib/api/library';
 import type { TimelinePlayedRef } from '@/features/playback/store/timelineSessionHistory';
 import type { Track } from '@/lib/media/trackTypes';
+import {
+  canonicalizePlaybackTrack,
+  canonicalizeQueueItemRef,
+} from '@/features/playback/store/queueItemRef';
 
 export function timelineHistoryToQueueRefs(
   history: TimelinePlayedRef[],
 ): QueueItemRef[] {
-  return history.map(row => ({ serverId: row.serverId, trackId: row.trackId }));
+  return history.map(row => canonicalizeQueueItemRef({
+    serverId: row.serverId,
+    trackId: row.trackId,
+  }));
 }
 
 export function bootstrapTrackFromPlaySession(row: PlaySessionRecentTrack): Track {
   const albumId = row.albumId ?? '';
   const coverArt = row.coverArtId ?? albumId;
-  return {
+  return canonicalizePlaybackTrack({
     id: row.trackId,
     title: row.title,
     artist: row.artist ?? '',
@@ -21,5 +28,5 @@ export function bootstrapTrackFromPlaySession(row: PlaySessionRecentTrack): Trac
     coverArt,
     duration: 0,
     serverId: row.serverId,
-  };
+  }, row.serverId);
 }

--- a/src/features/playlist/store/playlistStore.ts
+++ b/src/features/playlist/store/playlistStore.ts
@@ -28,6 +28,11 @@ interface PlaylistStore {
 let playlistFetchGeneration = 0;
 let playlistMutationGeneration = 0;
 
+export function invalidatePlaylistRequestsForIdentityTransition(): void {
+  playlistFetchGeneration += 1;
+  playlistMutationGeneration += 1;
+}
+
 interface PlaylistPersistedState {
   recentIds?: string[];
   playlists?: SubsonicPlaylist[];
@@ -118,8 +123,10 @@ export const usePlaylistStore = create<PlaylistStore>()(
         }
       },
       createPlaylist: async (name: string, songIds: string[] | undefined, serverId: string) => {
+        const generation = playlistMutationGeneration;
         try {
           const playlist = { ...await apiCreatePlaylist(name, songIds, serverId), serverId };
+          if (generation !== playlistMutationGeneration) return null;
           playlistMutationGeneration += 1;
           const key = ownedEntityKey(playlist);
           set((s) => ({

--- a/src/features/randomMix/pages/RandomMix.test.tsx
+++ b/src/features/randomMix/pages/RandomMix.test.tsx
@@ -1,0 +1,74 @@
+import { act, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  fetchGenreCatalog: vi.fn(),
+  fetchRandomMixSongsUntilFull: vi.fn(),
+}));
+
+vi.mock('@/features/playback/utils/playback/genreBrowsePlayback', () => ({
+  fetchGenreCatalog: hoisted.fetchGenreCatalog,
+}));
+
+vi.mock('@/features/playback/utils/mixRatingFilter', () => ({
+  fetchRandomMixSongsUntilFull: hoisted.fetchRandomMixSongsUntilFull,
+  getMixMinRatingsConfigFromAuth: vi.fn(() => ({ enabled: false })),
+}));
+
+vi.mock('@/features/orbit', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/features/orbit')>(),
+  useOrbitSongRowBehavior: () => ({
+    orbitActive: false,
+    queueHint: null,
+    addTrackToOrbit: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/features/randomMix/components/RandomMixFiltersPanel', () => ({ default: () => null }));
+vi.mock('@/features/randomMix/components/RandomMixTrackRow', () => ({ default: () => null }));
+vi.mock('@/features/randomMix/components/RandomMixHeader', () => ({
+  default: ({ selectedGenre }: { selectedGenre: string | null }) => (
+    <div data-testid="selected-genre">{selectedGenre ?? 'all'}</div>
+  ),
+}));
+vi.mock('@/features/randomMix/components/RandomMixGenrePanel', () => ({
+  default: ({ onSelectGenre }: { onSelectGenre: (genre: string) => void }) => (
+    <button type="button" onClick={() => onSelectGenre('Rock')}>Rock</button>
+  ),
+}));
+
+import RandomMix from '@/features/randomMix/pages/RandomMix';
+import { useAuthStore } from '@/store/authStore';
+import { resetAllStores } from '@/test/helpers/storeReset';
+import { renderWithProviders } from '@/test/helpers/renderWithProviders';
+
+describe('RandomMix', () => {
+  beforeEach(() => {
+    resetAllStores();
+    hoisted.fetchGenreCatalog.mockReset().mockResolvedValue([
+      { value: 'Rock', songCount: 1, albumCount: 1 },
+    ]);
+    hoisted.fetchRandomMixSongsUntilFull.mockReset().mockResolvedValue([]);
+    useAuthStore.setState({
+      activeServerId: 'srv-a',
+      servers: [
+        { id: 'srv-a', name: 'A', url: 'https://a.test', username: 'u', password: 'p' },
+        { id: 'srv-b', name: 'B', url: 'https://b.test', username: 'u', password: 'p' },
+      ],
+    });
+  });
+
+  it('returns to the all-genres mix when the active server changes', async () => {
+    const view = renderWithProviders(<RandomMix />);
+    await waitFor(() => expect(hoisted.fetchGenreCatalog).toHaveBeenCalledWith('srv-a', true));
+
+    fireEvent.click(view.getByRole('button', { name: 'Rock' }));
+    expect(view.getByTestId('selected-genre')).toHaveTextContent('Rock');
+
+    act(() => useAuthStore.setState({ activeServerId: 'srv-b' }));
+
+    await waitFor(() => expect(view.getByTestId('selected-genre')).toHaveTextContent('all'));
+    expect(hoisted.fetchGenreCatalog).toHaveBeenCalledWith('srv-b', true);
+  });
+});

--- a/src/features/randomMix/pages/RandomMix.tsx
+++ b/src/features/randomMix/pages/RandomMix.tsx
@@ -2,7 +2,7 @@ import { queueSongStar } from '@/features/playback/store/pendingStarSync';
 import { ownedOverrideValue } from '@/lib/util/ownedEntityKey';
 import type { SubsonicSong, SubsonicGenre } from '@/lib/api/subsonicTypes';
 import { songToTrack } from '@/lib/media/songToTrack';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { usePreviewStore } from '@/features/playback/store/previewStore';
 import { useAuthStore } from '@/store/authStore';
@@ -82,19 +82,29 @@ export default function RandomMix() {
   const [genreMixLoading, setGenreMixLoading] = useState(false);
   const [genreMixComplete, setGenreMixComplete] = useState(false);
   const [genresLoading, setGenresLoading] = useState(true);
+  const songsRequestGeneration = useRef(0);
+  const genresRequestGeneration = useRef(0);
+  const genreMixRequestGeneration = useRef(0);
 
   const fetchSongs = (overrideSize?: number) => {
+    const generation = ++songsRequestGeneration.current;
     setLoading(true);
     setSongs([]);
-    fetchRandomMixSongsUntilFull(getMixMinRatingsConfigFromAuth(), { targetSize: overrideSize ?? randomMixSize })
+    fetchRandomMixSongsUntilFull(getMixMinRatingsConfigFromAuth(), {
+      serverId: activeServerId,
+      targetSize: overrideSize ?? randomMixSize,
+    })
       .then(list => {
+        if (songsRequestGeneration.current !== generation) return;
         setSongs(list);
         const st = new Set<string>();
         list.forEach(s => { if (s.starred) st.add(s.id); });
         setStarredSongs(st);
         setLoading(false);
       })
-      .catch(() => setLoading(false));
+      .catch(() => {
+        if (songsRequestGeneration.current === generation) setLoading(false);
+      });
   };
 
   useEffect(() => {
@@ -104,12 +114,21 @@ export default function RandomMix() {
   }, [contextMenuOpen]);
 
   useEffect(() => {
-    // React Compiler set-state-in-effect rule: state set from an async result resolved in this effect.
+    const genresGeneration = ++genresRequestGeneration.current;
+    genreMixRequestGeneration.current += 1;
+    queueMicrotask(() => {
+      setSelectedGenre(null);
+      setGenreMixLoading(false);
+      setGenreMixComplete(false);
+      setGenreMixSongs([]);
+    });
+    // State changes happen through async request lifecycle helpers started here.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchSongs();
     setGenresLoading(true);
     void fetchGenreCatalog(activeServerId, indexEnabled)
       .then(data => {
+        if (genresRequestGeneration.current !== genresGeneration) return;
         setServerGenres(data);
         const audiobookLower = AUDIOBOOK_GENRES.map(g => g.toLowerCase());
         const available = data
@@ -120,11 +139,14 @@ export default function RandomMix() {
         setDisplayedGenres(available.slice(0, 20));
       })
       .catch(() => {
+        if (genresRequestGeneration.current !== genresGeneration) return;
         setServerGenres([]);
         setAllAvailableGenres([]);
         setDisplayedGenres([]);
       })
-      .finally(() => setGenresLoading(false));
+      .finally(() => {
+        if (genresRequestGeneration.current === genresGeneration) setGenresLoading(false);
+      });
     // fetchSongs is a local helper recreated each render; the mix reload is keyed
     // on the library filter / server / index, not on the function identity.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -157,17 +179,21 @@ export default function RandomMix() {
   };
 
   const loadGenreMix = async (genre: string, overrideSize?: number) => {
+    const generation = ++genreMixRequestGeneration.current;
     setGenreMixLoading(true);
     setGenreMixComplete(false);
     setGenreMixSongs([]);
     try {
       const list = await fetchRandomMixSongsUntilFull(getMixMinRatingsConfigFromAuth(), {
+        serverId: activeServerId,
         genre,
         timeout: 45000,
         targetSize: overrideSize ?? randomMixSize,
       });
+      if (genreMixRequestGeneration.current !== generation) return;
       setGenreMixSongs(list);
     } catch { /* ignore: best-effort */ }
+    if (genreMixRequestGeneration.current !== generation) return;
     setGenreMixLoading(false);
     setGenreMixComplete(true);
   };

--- a/src/generated/bindings.ts
+++ b/src/generated/bindings.ts
@@ -73,6 +73,10 @@ export const commands = {
 	libraryResolveEntitySources: (request: LibraryResolveEntitySourcesRequest) => typedError<LibraryEntitySourceDto[], string>(__TAURI_INVOKE("library_resolve_entity_sources", { request })),
 	libraryResolveAlbumOverlay: (request: LibraryResolveAlbumOverlayRequest) => typedError<LibraryAlbumOverlayResolutionDto[], string>(__TAURI_INVOKE("library_resolve_album_overlay", { request })),
 	librarySyncBindSession: (serverId: string, baseUrl: string, username: string, password: string, libraryScope: string | null) => typedError<null, string>(__TAURI_INVOKE("library_sync_bind_session", { serverId, baseUrl, username, password, libraryScope })),
+	libraryIdentityTransitionStatus: (serverId: string) => typedError<IdentityTransitionDto, string>(__TAURI_INVOKE("library_identity_transition_status", { serverId })),
+	libraryIdentityTransitionAck: (serverId: string) => typedError<null, string>(__TAURI_INVOKE("library_identity_transition_ack", { serverId })),
+	libraryIdentityTransitionProbe: (serverId: string, candidates: IdentityProbeCandidateDto[]) => typedError<IdentityTransitionDto, string>(__TAURI_INVOKE("library_identity_transition_probe", { serverId, candidates })),
+	libraryIdentityTransitionRunNativeMigration: (serverId: string) => typedError<IdentityTransitionDto, string>(__TAURI_INVOKE("library_identity_transition_run_native_migration", { serverId })),
 	librarySyncClearSession: (serverId: string) => typedError<null, string>(__TAURI_INVOKE("library_sync_clear_session", { serverId })),
 	librarySetPlaybackHint: (hint: string) => typedError<null, string>(__TAURI_INVOKE("library_set_playback_hint", { hint })),
 	libraryGetPlaybackHint: () => typedError<string, string>(__TAURI_INVOKE("library_get_playback_hint")),
@@ -1051,6 +1055,20 @@ export type IcyMetadata = {
 	icy_url: string | null,
 	/**  Value of the `icy-description` response header. */
 	icy_description: string | null,
+};
+
+export type IdentityProbeCandidateDto = {
+	entityKind: string,
+	id: string,
+};
+
+export type IdentityTransitionDto = {
+	serverId: string,
+	state: string,
+	canonicalVersion: number,
+	probeOldId: string | null,
+	probeNewId: string | null,
+	lastError: string | null,
 };
 
 export type ImportedThemeAsset = {

--- a/src/lib/api/analysis.ts
+++ b/src/lib/api/analysis.ts
@@ -49,6 +49,12 @@ export interface AnalysisDeleteServerReportDto {
   loudness: number;
 }
 
+export async function analysisClearServerCache(serverId: string): Promise<void> {
+  const indexKey = serverIndexKeyForId(serverId);
+  const res = await commands.analysisDeleteAllForServer(indexKey);
+  if (res.status === 'error') throw new Error(res.error);
+}
+
 function serverIndexKeyForId(serverId: string): string {
   const server = useAuthStore.getState().servers.find(s => s.id === serverId);
   if (!server) return serverId;

--- a/src/lib/api/library/sync.ts
+++ b/src/lib/api/library/sync.ts
@@ -15,6 +15,29 @@ import type {
   FactInputDto,
 } from './dto';
 
+export interface IdentityTransitionDto {
+  serverId: string;
+  state:
+    | 'unseen'
+    | 'awaiting_supplemental_probe'
+    | 'no_legacy_ids'
+    | 'legacy'
+    | 'retryable'
+    | 'transition_detected'
+    | 'pending_frontend'
+    | 'ready'
+    | 'blocked';
+  canonicalVersion: number;
+  probeOldId: string | null;
+  probeNewId: string | null;
+  lastError: string | null;
+}
+
+export interface IdentityProbeCandidateDto {
+  entityKind: 'album' | 'track';
+  id: string;
+}
+
 export async function librarySyncBindSession(args: {
   serverId: string;
   baseUrl: string;
@@ -37,6 +60,40 @@ export async function librarySyncClearSession(serverId: string): Promise<void> {
   const indexKey = serverIndexKeyForId(serverId);
   const res = await commands.librarySyncClearSession(indexKey);
   if (res.status === 'error') throw new Error(res.error);
+}
+
+export async function libraryIdentityTransitionStatus(
+  serverId: string,
+): Promise<IdentityTransitionDto> {
+  const indexKey = serverIndexKeyForId(serverId);
+  const res = await commands.libraryIdentityTransitionStatus(indexKey);
+  if (res.status === 'error') throw new Error(res.error);
+  return res.data as IdentityTransitionDto;
+}
+
+export async function libraryIdentityTransitionAck(serverId: string): Promise<void> {
+  const indexKey = serverIndexKeyForId(serverId);
+  const res = await commands.libraryIdentityTransitionAck(indexKey);
+  if (res.status === 'error') throw new Error(res.error);
+}
+
+export async function libraryIdentityTransitionProbe(
+  serverId: string,
+  candidates: IdentityProbeCandidateDto[],
+): Promise<IdentityTransitionDto> {
+  const indexKey = serverIndexKeyForId(serverId);
+  const res = await commands.libraryIdentityTransitionProbe(indexKey, candidates);
+  if (res.status === 'error') throw new Error(res.error);
+  return res.data as IdentityTransitionDto;
+}
+
+export async function libraryIdentityTransitionRunNativeMigration(
+  serverId: string,
+): Promise<IdentityTransitionDto> {
+  const indexKey = serverIndexKeyForId(serverId);
+  const res = await commands.libraryIdentityTransitionRunNativeMigration(indexKey);
+  if (res.status === 'error') throw new Error(res.error);
+  return res.data as IdentityTransitionDto;
 }
 
 export async function libraryGetPlaybackHint(): Promise<PlaybackHint> {

--- a/src/lib/api/subsonic.async.test.ts
+++ b/src/lib/api/subsonic.async.test.ts
@@ -116,7 +116,7 @@ describe('getRandomSongs — pass-through behaviour', () => {
     expect(songs).toEqual([]);
   });
 
-  it('passes a song-array through unchanged', async () => {
+  it('stamps a song-array with the active server owner', async () => {
     vi.mocked(axios.get).mockResolvedValue(
       okResponse({
         randomSongs: {
@@ -130,6 +130,7 @@ describe('getRandomSongs — pass-through behaviour', () => {
     const songs = await getRandomSongs();
     expect(songs).toHaveLength(2);
     expect(songs.map(s => s.id)).toEqual(['a', 'b']);
+    expect(songs.every(s => s.serverId === 'music.example.com')).toBe(true);
   });
 
   it('forwards a custom size to the query params', async () => {

--- a/src/lib/api/subsonicLibrary.ts
+++ b/src/lib/api/subsonicLibrary.ts
@@ -217,10 +217,14 @@ export function similarSongsRequestCount(desired: number, serverId?: string): nu
 }
 
 export async function getRandomSongs(size = 50, genre?: string, timeout = 15000): Promise<SubsonicSong[]> {
+  const ownerServerId = useAuthStore.getState().activeServerId;
   const params: Record<string, string | number> = { size, _t: Date.now(), ...libraryFilterParams() };
   if (genre) params.genre = genre;
   const data = await api<{ randomSongs: { song: SubsonicSong[] } }>('getRandomSongs.view', params, timeout);
-  return data.randomSongs?.song ?? [];
+  const songs = data.randomSongs?.song ?? [];
+  if (!ownerServerId) return songs;
+  const ownerServerKey = resolveIndexKey(ownerServerId);
+  return songs.map(song => ({ ...song, serverId: ownerServerKey }));
 }
 
 export async function getRandomSongsForServer(
@@ -268,6 +272,7 @@ export async function getRandomSongsFiltered(
   filters: RandomSongsFilters,
   timeout = 15000,
 ): Promise<SubsonicSong[]> {
+  const ownerServerId = useAuthStore.getState().activeServerId;
   const params: Record<string, string | number> = {
     size: filters.size ?? 50,
     _t: Date.now(),
@@ -277,7 +282,10 @@ export async function getRandomSongsFiltered(
   if (typeof filters.fromYear === 'number') params.fromYear = filters.fromYear;
   if (typeof filters.toYear === 'number') params.toYear = filters.toYear;
   const data = await api<{ randomSongs: { song: SubsonicSong[] } }>('getRandomSongs.view', params, timeout);
-  return data.randomSongs?.song ?? [];
+  const songs = data.randomSongs?.song ?? [];
+  if (!ownerServerId) return songs;
+  const ownerServerKey = resolveIndexKey(ownerServerId);
+  return songs.map(song => ({ ...song, serverId: ownerServerKey }));
 }
 
 export async function getAlbumListForServer(

--- a/src/lib/library/librarySession.test.ts
+++ b/src/lib/library/librarySession.test.ts
@@ -151,6 +151,31 @@ describe('resumeInitialSyncIfIncomplete', () => {
     expect(passwords).toEqual(['password', 'new-password']);
   });
 
+  it('completes pending frontend identity recovery before an offline reachability result', async () => {
+    sessionMocks.ensureConnectUrlResolved.mockResolvedValue({
+      ok: false,
+      endpoint: null,
+      ping: { ok: false },
+    });
+    const status = vi.fn(() => ({
+      serverId: 'music.test/rest',
+      state: 'pending_frontend',
+      canonicalVersion: 1,
+      probeOldId: null,
+      probeNewId: null,
+      lastError: null,
+    }));
+    const ack = vi.fn(() => undefined);
+    onInvoke('library_identity_transition_status', status);
+    onInvoke('analysis_delete_all_for_server', () => undefined);
+    onInvoke('library_identity_transition_ack', ack);
+
+    await expect(bootstrapIndexedServer(server)).resolves.toBe('offline');
+
+    expect(status).toHaveBeenCalled();
+    expect(ack).toHaveBeenCalledWith(expect.objectContaining({ serverId: 'music.test/rest' }));
+  });
+
   it('resumes when initial sync was interrupted mid-run', async () => {
     onInvoke('library_get_status', () => status({ syncPhase: 'initial_sync' }));
     const start = mockQueuedStart();

--- a/src/lib/library/librarySession.test.ts
+++ b/src/lib/library/librarySession.test.ts
@@ -88,6 +88,14 @@ describe('resumeInitialSyncIfIncomplete', () => {
     sessionMocks.syncAllServerHttpContexts.mockReset().mockResolvedValue(undefined);
     sessionMocks.libraryCoverClearFetchFailures.mockReset().mockResolvedValue(0);
     sessionMocks.libraryCoverBackfillRunFullPass.mockReset().mockResolvedValue(undefined);
+    onInvoke('library_identity_transition_status', () => ({
+      serverId: 'music.test/rest',
+      state: 'ready',
+      canonicalVersion: 1,
+      probeOldId: null,
+      probeNewId: null,
+      lastError: null,
+    }));
   });
 
   it('single-flights concurrent URL-key bootstraps and resumes the stranded sync once', async () => {

--- a/src/lib/library/librarySession.ts
+++ b/src/lib/library/librarySession.ts
@@ -22,7 +22,10 @@ import {
 } from '@/lib/api/coverCache';
 import { libraryDevEnabled, logLibraryStatus, logLibrarySync, timed } from './libraryDevLog';
 import { publishServerConnectionStatus } from '@/lib/network/serverReachability';
-import { reconcileCanonicalEntityIds } from '@/utils/server/reconcileCanonicalEntityIds';
+import {
+  reconcileCanonicalEntityIds,
+  restoreCanonicalEntityIdsFromLocalState,
+} from '@/utils/server/reconcileCanonicalEntityIds';
 
 export type BindServerResult = 'bound' | 'offline' | 'error';
 
@@ -92,6 +95,11 @@ async function bindIndexedServerOnce(
   // markers so covers that failed during a registry gap re-download. Best-effort
   // and independent of bind — keep it off the critical path.
   void retryGatedServerCovers(server);
+
+  // A previous launch may have completed the native rewrite and crashed before
+  // frontend persistence was acknowledged. That recovery is local-only and must
+  // finish even when the server is currently unreachable.
+  await restoreCanonicalEntityIdsFromLocalState(server, serverIndexKey);
 
   // Dual-address: resolve the connect URL once (LAN-first, sticky cached) and
   // hand that to the Rust bind-session command — Rust then sees the reachable
@@ -188,23 +196,15 @@ export async function bootstrapIndexedServer(server: ServerProfile): Promise<Bin
   return 'bound';
 }
 
-/** Bind all indexed servers, then queue initial syncs one server at a time. */
-export async function bootstrapAllIndexedServers(): Promise<Record<string, BindServerResult>> {
+function primaryIndexedServers(): ServerProfile[] {
   const lib = useLibraryIndexStore.getState();
-  if (!lib.masterEnabled) return {};
+  if (!lib.masterEnabled) return [];
   const auth = useAuthStore.getState();
-  // Authoritatively (re)populate the native gate-header registry for every saved
-  // server before any bind/probe runs. The persist-rehydrate sync fires very
-  // early and is best-effort; this runs once React has mounted and the Tauri IPC
-  // bridge is ready, so a gated server's headers are present for the reachability
-  // probe, stream, cover and prefetch paths that resolve them from the registry.
-  await syncAllServerHttpContexts(auth.servers).catch(() => {});
   const active = auth.activeServerId
     ? auth.servers.find(s => s.id === auth.activeServerId) ?? null
     : null;
-  const indexed = auth.servers.filter(s => lib.isIndexEnabled(s.id));
   const primaryByKey = new Map<string, ServerProfile>();
-  for (const server of indexed) {
+  for (const server of auth.servers.filter(s => lib.isIndexEnabled(s.id))) {
     const key = serverIndexKeyForProfile(server);
     if (!primaryByKey.has(key)) primaryByKey.set(key, server);
   }
@@ -212,18 +212,45 @@ export async function bootstrapAllIndexedServers(): Promise<Record<string, BindS
     const key = serverIndexKeyForProfile(active);
     if (primaryByKey.has(key)) primaryByKey.set(key, active);
   }
+  return [...primaryByKey.values()];
+}
+
+/** Bind all indexed sessions, including canonical-ID reconciliation, without waiting for initial sync. */
+export async function bindAllIndexedServers(): Promise<Record<string, BindServerResult>> {
+  const servers = primaryIndexedServers();
+  if (servers.length === 0) return {};
+  const auth = useAuthStore.getState();
+  // Authoritatively (re)populate the native gate-header registry for every saved
+  // server before any bind/probe runs. The persist-rehydrate sync fires very
+  // early and is best-effort; this runs once React has mounted and the Tauri IPC
+  // bridge is ready, so a gated server's headers are present for the reachability
+  // probe, stream, cover and prefetch paths that resolve them from the registry.
+  await syncAllServerHttpContexts(auth.servers).catch(() => {});
   const results: Record<string, BindServerResult> = {};
-  for (const server of primaryByKey.values()) {
+  for (const server of servers) {
     const key = serverIndexKeyForProfile(server);
     results[key] = await bindIndexedServer(server);
   }
-  for (const server of primaryByKey.values()) {
+  return results;
+}
+
+/** Resume or start initial syncs for sessions that are already bound. */
+export async function startInitialSyncsForBoundServers(
+  results: Record<string, BindServerResult>,
+): Promise<void> {
+  for (const server of primaryIndexedServers()) {
     const key = serverIndexKeyForProfile(server);
     if (results[key] === 'bound') {
       await resumeInitialSyncIfIncomplete(key);
       await queueInitialSyncIfNeeded(key);
     }
   }
+}
+
+/** Bind all indexed servers, then queue initial syncs one server at a time. */
+export async function bootstrapAllIndexedServers(): Promise<Record<string, BindServerResult>> {
+  const results = await bindAllIndexedServers();
+  await startInitialSyncsForBoundServers(results);
   return results;
 }
 

--- a/src/lib/library/librarySession.ts
+++ b/src/lib/library/librarySession.ts
@@ -22,6 +22,7 @@ import {
 } from '@/lib/api/coverCache';
 import { libraryDevEnabled, logLibraryStatus, logLibrarySync, timed } from './libraryDevLog';
 import { publishServerConnectionStatus } from '@/lib/network/serverReachability';
+import { reconcileCanonicalEntityIds } from '@/utils/server/reconcileCanonicalEntityIds';
 
 export type BindServerResult = 'bound' | 'offline' | 'error';
 
@@ -109,6 +110,7 @@ async function bindIndexedServerOnce(
       username: server.username,
       password: server.password,
     });
+    await reconcileCanonicalEntityIds(server, serverIndexKey);
     if (libraryDevEnabled()) {
       const { result: status, ms } = await timed(() => libraryGetStatus(serverIndexKey));
       logLibrarySync({

--- a/src/lib/server/navidromeCanonicalIds.ts
+++ b/src/lib/server/navidromeCanonicalIds.ts
@@ -1,0 +1,55 @@
+import md5 from 'md5';
+
+const BASE62 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const MAX_U128 = (1n << 128n) - 1n;
+const confirmedOwners = new Set<string>();
+
+export function canonicalizeNavidromeId(value: string): string {
+  if (value.length === 22) {
+    let parsed = 0n;
+    for (const character of value) {
+      const digit = BASE62.indexOf(character);
+      if (digit < 0) return value;
+      parsed = parsed * 62n + BigInt(digit);
+      if (parsed > MAX_U128) return encodeCanonicalHex(md5(value));
+    }
+    return value;
+  }
+  if (/^[0-9a-fA-F]{32}$/.test(value)) return encodeCanonicalHex(value);
+  if (/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(value)) {
+    return encodeCanonicalHex(value.replace(/-/g, ''));
+  }
+  return value;
+}
+
+function encodeCanonicalHex(hex: string): string {
+  let value = BigInt(`0x${hex}`);
+  const encoded = Array<string>(22).fill('0');
+  for (let index = encoded.length - 1; index >= 0 && value > 0n; index -= 1) {
+    encoded[index] = BASE62[Number(value % 62n)];
+    value /= 62n;
+  }
+  return encoded.join('');
+}
+
+export function activateCanonicalNavidromeOwners(owners: Iterable<string>): void {
+  for (const owner of owners) {
+    if (owner) confirmedOwners.add(owner);
+  }
+}
+
+export function deactivateCanonicalNavidromeOwners(owners: Iterable<string>): void {
+  for (const owner of owners) confirmedOwners.delete(owner);
+}
+
+export function canonicalizeConfirmedNavidromeId(owner: string, value: string): string {
+  return confirmedOwners.has(owner) ? canonicalizeNavidromeId(value) : value;
+}
+
+export function canonicalizeConfirmedOwnedKey(key: string): string {
+  const owner = [...confirmedOwners]
+    .sort((a, b) => b.length - a.length)
+    .find(candidate => key.startsWith(`${candidate}:`));
+  if (!owner) return key;
+  return `${owner}:${canonicalizeNavidromeId(key.slice(owner.length + 1))}`;
+}

--- a/src/lib/server/navidromeCanonicalIds.ts
+++ b/src/lib/server/navidromeCanonicalIds.ts
@@ -3,6 +3,8 @@ import md5 from 'md5';
 const BASE62 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const MAX_U128 = (1n << 128n) - 1n;
 const confirmedOwners = new Set<string>();
+const identityGenerationByOwner = new Map<string, number>();
+let globalIdentityGeneration = 0;
 
 export function canonicalizeNavidromeId(value: string): string {
   if (value.length === 22) {
@@ -33,13 +35,41 @@ function encodeCanonicalHex(hex: string): string {
 }
 
 export function activateCanonicalNavidromeOwners(owners: Iterable<string>): void {
+  const activated: string[] = [];
   for (const owner of owners) {
-    if (owner) confirmedOwners.add(owner);
+    if (!owner || confirmedOwners.has(owner)) continue;
+    confirmedOwners.add(owner);
+    activated.push(owner);
+  }
+  if (activated.length > 0) {
+    globalIdentityGeneration += 1;
+    for (const owner of activated) {
+      identityGenerationByOwner.set(owner, (identityGenerationByOwner.get(owner) ?? 0) + 1);
+    }
   }
 }
 
 export function deactivateCanonicalNavidromeOwners(owners: Iterable<string>): void {
-  for (const owner of owners) confirmedOwners.delete(owner);
+  const deactivated: string[] = [];
+  for (const owner of owners) {
+    if (!confirmedOwners.delete(owner)) continue;
+    deactivated.push(owner);
+  }
+  if (deactivated.length > 0) {
+    globalIdentityGeneration += 1;
+    for (const owner of deactivated) {
+      identityGenerationByOwner.set(owner, (identityGenerationByOwner.get(owner) ?? 0) + 1);
+    }
+  }
+}
+
+/** Changes whenever canonical identity semantics change for this owner. */
+export function canonicalIdentityGeneration(owner?: string): number {
+  return owner ? identityGenerationByOwner.get(owner) ?? 0 : globalIdentityGeneration;
+}
+
+export function canonicalIdentityGenerationChanged(owner: string, generation: number): boolean {
+  return canonicalIdentityGeneration(owner) !== generation;
 }
 
 export function canonicalizeConfirmedNavidromeId(owner: string, value: string): string {

--- a/src/localPlaybackInvalidation.test.ts
+++ b/src/localPlaybackInvalidation.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { emitTauriEvent, tauriMockListenerCount } from '@/test/mocks/tauri';
+import { useAuthStore } from '@/store/authStore';
+import { useLocalPlaybackStore } from '@/store/localPlaybackStore';
+
+const libraryGetTrackMock = vi.fn();
+const deleteMediaFileMock = vi.fn(async (_args: { localPath: string; mediaDir: string | null }) => undefined);
+
+vi.mock('@/lib/api/library', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/api/library')>()),
+  libraryGetTrack: (serverId: string, trackId: string) => libraryGetTrackMock(serverId, trackId),
+}));
+
+vi.mock('@/lib/api/syncfs', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/api/syncfs')>()),
+  deleteMediaFile: (args: { localPath: string; mediaDir: string | null }) => deleteMediaFileMock(args),
+}));
+
+vi.mock('@/features/offline/utils/legacyOfflineFileMigration', () => ({
+  runLegacyOfflineFileMigration: vi.fn(async () => undefined),
+}));
+
+vi.mock('@/features/offline/utils/libraryTierReconcile', () => ({
+  reconcileLibraryTierForServer: vi.fn(async () => undefined),
+}));
+
+import {
+  initLocalPlaybackInvalidation,
+  pauseAndDrainLocalPlaybackInvalidation,
+  resumeLocalPlaybackInvalidation,
+} from './localPlaybackInvalidation';
+
+describe('local playback invalidation', () => {
+  beforeEach(() => {
+    libraryGetTrackMock.mockReset();
+    deleteMediaFileMock.mockClear();
+    useAuthStore.setState({
+      servers: [{ id: 'srv', name: 'Server', url: 'https://music.test', username: 'u', password: 'p' }],
+    });
+    useLocalPlaybackStore.setState({
+      entries: {
+        'music.test:legacy-track': {
+          serverIndexKey: 'music.test',
+          trackId: 'legacy-track',
+          localPath: '/media/legacy.flac',
+          layoutFingerprint: 'old',
+          sizeBytes: 1,
+          tier: 'library',
+          cachedAt: 1,
+          suffix: 'flac',
+        },
+      },
+    });
+  });
+
+  it('ignores failed sync-idle events used to start identity migration', async () => {
+    const cleanup = initLocalPlaybackInvalidation();
+    await vi.waitFor(() => expect(tauriMockListenerCount('library:sync-idle')).toBe(1));
+
+    emitTauriEvent('library:sync-idle', {
+      serverId: 'music.test', libraryScope: 'all', kind: 'delta_sync', ok: false,
+      error: 'identity transition: migration required',
+    });
+    await Promise.resolve();
+
+    expect(libraryGetTrackMock).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('does not remove an entry when migration pauses a stale lookup', async () => {
+    let resolveTrack!: (value: null) => void;
+    libraryGetTrackMock.mockImplementation(() => new Promise(resolve => { resolveTrack = resolve; }));
+    const cleanup = initLocalPlaybackInvalidation();
+    await vi.waitFor(() => expect(tauriMockListenerCount('library:sync-idle')).toBe(1));
+    emitTauriEvent('library:sync-idle', {
+      serverId: 'music.test', libraryScope: 'all', kind: 'delta_sync', ok: true,
+    });
+    await vi.waitFor(() => expect(libraryGetTrackMock).toHaveBeenCalled());
+
+    const paused = pauseAndDrainLocalPlaybackInvalidation();
+    resolveTrack(null);
+    await paused;
+
+    expect(deleteMediaFileMock).not.toHaveBeenCalled();
+    expect(useLocalPlaybackStore.getState().entries['music.test:legacy-track']).toBeDefined();
+    resumeLocalPlaybackInvalidation();
+    cleanup();
+  });
+
+  it('removes the index row when migration pauses an in-flight delete', async () => {
+    let resolveDelete!: () => void;
+    libraryGetTrackMock.mockResolvedValue(null);
+    deleteMediaFileMock.mockImplementationOnce(() => new Promise<undefined>(resolve => {
+      resolveDelete = () => resolve(undefined);
+    }));
+    const cleanup = initLocalPlaybackInvalidation();
+    await vi.waitFor(() => expect(tauriMockListenerCount('library:sync-idle')).toBe(1));
+    emitTauriEvent('library:sync-idle', {
+      serverId: 'music.test', libraryScope: 'all', kind: 'delta_sync', ok: true,
+    });
+    await vi.waitFor(() => expect(deleteMediaFileMock).toHaveBeenCalled());
+
+    const paused = pauseAndDrainLocalPlaybackInvalidation();
+    resolveDelete();
+    await paused;
+
+    expect(useLocalPlaybackStore.getState().entries['music.test:legacy-track']).toBeUndefined();
+    resumeLocalPlaybackInvalidation();
+    cleanup();
+  });
+});

--- a/src/localPlaybackInvalidation.ts
+++ b/src/localPlaybackInvalidation.ts
@@ -9,8 +9,16 @@ import { runLegacyOfflineFileMigration } from '@/features/offline/utils/legacyOf
 import { reconcileLibraryTierForServer } from '@/features/offline/utils/libraryTierReconcile';
 import { resolveServerIdForIndexKey } from '@/lib/server/serverLookup';
 import { serverIndexKeyFromUrl } from '@/lib/server/serverIndexKey';
+import type { LibrarySyncIdlePayload } from '@/lib/api/library';
 
-async function invalidateEntriesForLibraryServer(libraryServerId: string): Promise<void> {
+let invalidationPauseDepth = 0;
+let invalidationLifecycle = 0;
+const invalidationRuns = new Set<Promise<void>>();
+
+async function invalidateEntriesForLibraryServer(
+  libraryServerId: string,
+  isCurrent: () => boolean,
+): Promise<void> {
   const store = useLocalPlaybackStore.getState();
   const mediaDir = getMediaDir();
   const targets = Object.values(store.entries).filter(
@@ -20,17 +28,27 @@ async function invalidateEntriesForLibraryServer(libraryServerId: string): Promi
   );
 
   for (const entry of targets) {
+    if (!isCurrent()) return;
     const track = await libraryGetTrack(libraryServerId, entry.trackId).catch(() => null);
+    if (!isCurrent()) return;
     if (!track) {
       await deleteMediaFile({ localPath: entry.localPath, mediaDir }).catch(() => {});
-      store.removeEntry(entry.trackId, entry.serverIndexKey, 'sync-track-removed');
+      const current = store.getEntry(entry.trackId, entry.serverIndexKey);
+      if (current?.localPath === entry.localPath) {
+        store.removeEntry(current.trackId, current.serverIndexKey, 'sync-track-removed');
+      }
+      if (!isCurrent()) return;
       continue;
     }
     if (!entry.layoutFingerprint) continue;
     const nextFp = layoutFingerprintFromLibraryTrack(track, entry.suffix);
     if (nextFp !== entry.layoutFingerprint) {
       await deleteMediaFile({ localPath: entry.localPath, mediaDir }).catch(() => {});
-      store.removeEntry(entry.trackId, entry.serverIndexKey, 'sync-layout-changed');
+      const current = store.getEntry(entry.trackId, entry.serverIndexKey);
+      if (current?.localPath === entry.localPath) {
+        store.removeEntry(current.trackId, current.serverIndexKey, 'sync-layout-changed');
+      }
+      if (!isCurrent()) return;
     }
   }
 }
@@ -43,22 +61,49 @@ function serverIndexKeyForLibraryId(libraryServerId: string): string | undefined
 
 /** Drop stale local files after library sync; relocate legacy offline bytes when index is ready. */
 export function initLocalPlaybackInvalidation(): () => void {
+  let disposed = false;
   let unlisten: (() => void) | null = null;
-  void listen<{ serverId?: string }>('library:sync-idle', ({ payload }) => {
+  void listen<LibrarySyncIdlePayload>('library:sync-idle', ({ payload }) => {
+    if (disposed || invalidationPauseDepth > 0 || !payload.ok) return;
     const scopeId = payload?.serverId?.trim();
     if (!scopeId) return;
-    void (async () => {
+    const lifecycle = invalidationLifecycle;
+    const isCurrent = () => (
+      !disposed
+      && invalidationPauseDepth === 0
+      && invalidationLifecycle === lifecycle
+    );
+    const run = (async () => {
       const profileId = resolveServerIdForIndexKey(scopeId) || scopeId;
       const indexKey = serverIndexKeyForLibraryId(profileId);
       await runLegacyOfflineFileMigration(indexKey);
+      if (!isCurrent()) return;
       await reconcileLibraryTierForServer(profileId);
-      await invalidateEntriesForLibraryServer(profileId);
+      if (!isCurrent()) return;
+      await invalidateEntriesForLibraryServer(profileId, isCurrent);
     })();
+    const tracked = run.catch(() => {});
+    invalidationRuns.add(tracked);
+    void tracked.finally(() => invalidationRuns.delete(tracked));
   }).then(fn => {
-    unlisten = fn;
+    if (disposed) fn();
+    else unlisten = fn;
   });
   return () => {
+    disposed = true;
     unlisten?.();
     unlisten = null;
   };
+}
+
+export async function pauseAndDrainLocalPlaybackInvalidation(): Promise<void> {
+  invalidationPauseDepth += 1;
+  if (invalidationPauseDepth > 1) return;
+  invalidationLifecycle += 1;
+  await Promise.allSettled([...invalidationRuns]);
+}
+
+export function resumeLocalPlaybackInvalidation(): void {
+  if (invalidationPauseDepth === 0) return;
+  invalidationPauseDepth -= 1;
 }

--- a/src/store/authMusicLibraryActions.test.ts
+++ b/src/store/authMusicLibraryActions.test.ts
@@ -2,6 +2,14 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { useAuthStore } from '@/store/authStore';
 import { resetAuthStore } from '@/test/helpers/storeReset';
 import { flushMusicLibraryFilterVersionBumpForTests } from '@/store/musicLibraryFilterNotify';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
+
+const LEGACY_FOLDER = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const CANONICAL_FOLDER = canonicalizeNavidromeId(LEGACY_FOLDER);
 
 function setUpActiveServer(): string {
   const id = useAuthStore.getState().addServer({
@@ -134,5 +142,25 @@ describe('Library browse scope', () => {
     expect(useAuthStore.getState().libraryBrowseSelectionByServer[serverId]).toEqual(['two']);
     useAuthStore.getState().setLibraryBrowseSelectionForServer(serverId, ['two', 'one']);
     expect(useAuthStore.getState().libraryBrowseSelectionByServer[serverId]).toEqual([]);
+  });
+
+  it('canonicalizes stale folder selection and filter callbacks after owner activation', () => {
+    const serverId = setUpActiveServer();
+    activateCanonicalNavidromeOwners([serverId, 'music.example.com']);
+    useAuthStore.getState().setMusicFoldersForServer(serverId, [
+      { id: LEGACY_FOLDER, name: 'Music' },
+      { id: 'other', name: 'Other' },
+    ]);
+
+    useAuthStore.getState().setLibraryBrowseSelectionForServer(serverId, [LEGACY_FOLDER]);
+    expect(useAuthStore.getState().libraryBrowseSelectionByServer[serverId]).toEqual([CANONICAL_FOLDER]);
+
+    useAuthStore.getState().setMusicLibraryFilter(LEGACY_FOLDER);
+    expect(useAuthStore.getState().musicLibraryFilterByServer[serverId]).toBe(CANONICAL_FOLDER);
+    expect(useAuthStore.getState().musicLibrarySelectionByServer[serverId]).toEqual([CANONICAL_FOLDER]);
+
+    useAuthStore.getState().setMusicLibrarySelection([LEGACY_FOLDER]);
+    expect(useAuthStore.getState().musicLibrarySelectionByServer[serverId]).toEqual([CANONICAL_FOLDER]);
+    deactivateCanonicalNavidromeOwners([serverId, 'music.example.com']);
   });
 });

--- a/src/store/authMusicLibraryActions.ts
+++ b/src/store/authMusicLibraryActions.ts
@@ -6,6 +6,7 @@ import {
 } from './musicLibraryFilterNotify';
 import { deriveLibraryBrowseServerIdsWithFallback } from '@/lib/library/libraryBrowseScope';
 import { emitMultiServerDebug } from '@/lib/library/multiServerDebug';
+import { canonicalizeConfirmedNavidromeId } from '@/lib/server/navidromeCanonicalIds';
 
 type SetState = (
   partial: Partial<AuthState> | ((state: AuthState) => Partial<AuthState>),
@@ -37,6 +38,17 @@ function collapseServerSelection(folders: MusicFolder[], libraryIds: string[]): 
   }
   const selected = new Set(libraryIds);
   return folders.every(folder => selected.has(folder.id)) ? [] : libraryIds;
+}
+
+function canonicalizeMusicFolders(serverId: string, folders: MusicFolder[]): MusicFolder[] {
+  return folders.map(folder => ({
+    ...folder,
+    id: canonicalizeConfirmedNavidromeId(serverId, folder.id),
+  }));
+}
+
+function canonicalizeFolderIds(serverId: string, ids: string[]): string[] {
+  return ids.map(id => canonicalizeConfirmedNavidromeId(serverId, id));
 }
 
 function deferMusicLibraryCatalogReload(get: GetState, set: SetState, serverId: string): void {
@@ -77,11 +89,12 @@ export function createMusicLibraryActions(set: SetState, get: GetState): Pick<
   return {
     setMusicFolders: (folders) => {
       const sid = get().activeServerId;
-      const folderIds = new Set(folders.map(x => x.id));
       if (!sid) {
         set({ musicFolders: folders });
         return;
       }
+      folders = canonicalizeMusicFolders(sid, folders);
+      const folderIds = new Set(folders.map(x => x.id));
 
       const s = get();
       const updates: Partial<AuthState> = {
@@ -133,6 +146,7 @@ export function createMusicLibraryActions(set: SetState, get: GetState): Pick<
         });
         return;
       }
+      folders = canonicalizeMusicFolders(serverId, folders);
       const previousFolders = s.musicFoldersByServer[serverId] ?? [];
       const foldersChanged = folders.length !== previousFolders.length
         || folders.some((folder, index) => {
@@ -268,6 +282,7 @@ export function createMusicLibraryActions(set: SetState, get: GetState): Pick<
         });
         return;
       }
+      libraryIds = canonicalizeFolderIds(serverId, libraryIds);
       const folders = s.musicFoldersByServer[serverId] ?? [];
       const knownFolderIds = new Set(folders.map(folder => folder.id));
       const unique = [...new Set(libraryIds)].filter(id => folders.length === 0 || knownFolderIds.has(id));
@@ -303,6 +318,9 @@ export function createMusicLibraryActions(set: SetState, get: GetState): Pick<
     setMusicLibraryFilter: (folderId) => {
       const sid = get().activeServerId;
       if (!sid) return;
+      folderId = folderId === 'all'
+        ? folderId
+        : canonicalizeConfirmedNavidromeId(sid, folderId);
       // Selection readers prefer the ordered selection over the legacy field, so
       // a legacy-only write would be a no-op once a selection exists. Keep both
       // in sync: 'all' clears the selection (browse all), a folder id becomes a
@@ -321,6 +339,7 @@ export function createMusicLibraryActions(set: SetState, get: GetState): Pick<
     setMusicLibrarySelection: (libraryIds) => {
       const sid = get().activeServerId;
       if (!sid) return;
+      libraryIds = canonicalizeFolderIds(sid, libraryIds);
       const selection = collapseFullSelection(get(), libraryIds);
       set(s => ({
         musicLibrarySelectionByServer: {

--- a/src/store/authServerProfileActions.ts
+++ b/src/store/authServerProfileActions.ts
@@ -6,12 +6,13 @@ import {
   invalidatePlaybackPreloads,
 } from './playbackEngineBridge';
 import { resolveServerIdForIndexKey } from '@/lib/server/serverLookup';
-import { serverProfileBaseUrl } from '@/lib/server/serverBaseUrl';
+import { serverIndexKeyForProfile, serverProfileBaseUrl } from '@/lib/server/serverBaseUrl';
 import { deriveLibraryBrowseServerIdsWithFallback } from '@/lib/library/libraryBrowseScope';
 import {
   emitMultiServerDebug,
   summarizeMultiServerProfiles,
 } from '@/lib/library/multiServerDebug';
+import { deactivateCanonicalNavidromeOwners } from '@/lib/server/navidromeCanonicalIds';
 
 type SetState = (
   partial: Partial<AuthState> | ((state: AuthState) => Partial<AuthState>),
@@ -97,6 +98,8 @@ export function createServerProfileActions(set: SetState, get: GetState): Pick<
 
     updateServer: (id, data) => {
       let addressesChanged = false;
+      const previous = get().servers.find(server => server.id === id);
+      const previousIndexKey = previous ? serverIndexKeyForProfile(previous) : null;
       set(s => {
         const prev = s.servers.find(srv => srv.id === id);
         const servers = s.servers.map(srv => srv.id === id ? { ...srv, ...data } : srv);
@@ -131,11 +134,16 @@ export function createServerProfileActions(set: SetState, get: GetState): Pick<
           subsonicServerIdentityByServer,
         };
       });
-      if (addressesChanged) void invalidatePlaybackPreloads().catch(() => {});
+      if (addressesChanged) {
+        deactivateCanonicalNavidromeOwners([id, previousIndexKey ?? '']);
+        void invalidatePlaybackPreloads().catch(() => {});
+      }
     },
 
     removeServer: (id) => {
       const serversBeforeRemoval = get().servers;
+      const removed = serversBeforeRemoval.find(server => server.id === id);
+      const removedIndexKey = removed ? serverIndexKeyForProfile(removed) : null;
       // queueServerId is the canonical index key (B1); resolve the
       // canonical id back to a server UUID before comparing so a profile
       // delete still clears the matching queue binding.
@@ -193,6 +201,12 @@ export function createServerProfileActions(set: SetState, get: GetState): Pick<
       if (serverAddressSetsChanged(serversBeforeRemoval, get().servers)) {
         void invalidatePlaybackPreloads().catch(() => {});
       }
+      deactivateCanonicalNavidromeOwners([
+        id,
+        removedIndexKey && !get().servers.some(
+          server => serverIndexKeyForProfile(server) === removedIndexKey,
+        ) ? removedIndexKey : '',
+      ]);
     },
 
     setServers: (servers) => {

--- a/src/store/localPlaybackStore.ts
+++ b/src/store/localPlaybackStore.ts
@@ -18,6 +18,7 @@ import {
   reconcileEphemeralCache,
 } from '@/lib/cache/ephemeralTierReconcile';
 import { canonicalQueueServerKey } from '@/lib/server/serverIndexKey';
+import { canonicalizeConfirmedNavidromeId } from '@/lib/server/navidromeCanonicalIds';
 
 export type LocalPlaybackTier = 'ephemeral' | 'library' | 'favorite-auto';
 
@@ -121,29 +122,51 @@ export const useLocalPlaybackStore = create<LocalPlaybackState>()(
       entries: {},
 
       getEntry: (trackId, serverIndexKey) =>
-        get().entries[localPlaybackEntryKey(serverIndexKey, trackId)] ?? null,
+        get().entries[localPlaybackEntryKey(
+          serverIndexKey,
+          canonicalizeConfirmedNavidromeId(serverIndexKey, trackId),
+        )] ?? null,
 
       getLocalUrl: (trackId, serverIndexKey, tier) => {
-        const e = get().entries[localPlaybackEntryKey(serverIndexKey, trackId)];
+        const e = get().entries[localPlaybackEntryKey(
+          serverIndexKey,
+          canonicalizeConfirmedNavidromeId(serverIndexKey, trackId),
+        )];
         if (!e?.localPath) return null;
         if (tier && e.tier !== tier) return null;
         return `psysonic-local://${e.localPath}`;
       },
 
       hasLocalBytes: (trackId, serverIndexKey) =>
-        !!get().entries[localPlaybackEntryKey(serverIndexKey, trackId)]?.localPath,
+        !!get().entries[localPlaybackEntryKey(
+          serverIndexKey,
+          canonicalizeConfirmedNavidromeId(serverIndexKey, trackId),
+        )]?.localPath,
 
       isPinned: (trackId, serverIndexKey) =>
-        get().entries[localPlaybackEntryKey(serverIndexKey, trackId)]?.tier === 'library',
+        get().entries[localPlaybackEntryKey(
+          serverIndexKey,
+          canonicalizeConfirmedNavidromeId(serverIndexKey, trackId),
+        )]?.tier === 'library',
 
       upsertEntry: (entry) => {
         const now = Date.now();
-        const key = localPlaybackEntryKey(entry.serverIndexKey, entry.trackId);
+        const trackId = canonicalizeConfirmedNavidromeId(entry.serverIndexKey, entry.trackId);
+        const pinSource = entry.pinSource ? {
+          ...entry.pinSource,
+          sourceId: canonicalizeConfirmedNavidromeId(
+            entry.serverIndexKey,
+            entry.pinSource.sourceId,
+          ),
+        } : undefined;
+        const key = localPlaybackEntryKey(entry.serverIndexKey, trackId);
         set(s => ({
           entries: {
             ...s.entries,
             [key]: {
               ...entry,
+              trackId,
+              pinSource,
               cachedAt: entry.cachedAt ?? now,
               lastPlayedAt: entry.lastPlayedAt ?? (entry.tier === 'ephemeral' ? now : entry.lastPlayedAt),
             },
@@ -152,6 +175,7 @@ export const useLocalPlaybackStore = create<LocalPlaybackState>()(
       },
 
       touchPlayed: (trackId, serverIndexKey) => {
+        trackId = canonicalizeConfirmedNavidromeId(serverIndexKey, trackId);
         const key = localPlaybackEntryKey(serverIndexKey, trackId);
         set(s => {
           const e = s.entries[key];
@@ -166,6 +190,7 @@ export const useLocalPlaybackStore = create<LocalPlaybackState>()(
       },
 
       removeEntry: (trackId, serverIndexKey, reason = 'explicit-remove') => {
+        trackId = canonicalizeConfirmedNavidromeId(serverIndexKey, trackId);
         const key = localPlaybackEntryKey(serverIndexKey, trackId);
         set(s => {
           const next = { ...s.entries };

--- a/src/store/migrationCoordinator.test.ts
+++ b/src/store/migrationCoordinator.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMigrationStore } from './migrationStore';
+import {
+  blockingMigrationStatus,
+  enqueueBlockingMigration,
+  resetBlockingMigrationCoordinatorForTests,
+  retryCurrentBlockingMigration,
+} from './migrationCoordinator';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(res => { resolve = res; });
+  return { promise, resolve };
+}
+
+describe('migrationCoordinator', () => {
+  beforeEach(() => {
+    resetBlockingMigrationCoordinatorForTests();
+    useMigrationStore.setState({
+      phase: 'completed',
+      step: null,
+      needsMigration: false,
+      lastError: null,
+      blockingRevision: 0,
+    });
+  });
+
+  it('serializes ordinary and canonical jobs without publishing idle or completed between them', async () => {
+    const ordinary = deferred();
+    const canonical = deferred();
+    const phases: string[] = [];
+    const unsubscribe = useMigrationStore.subscribe(state => phases.push(state.phase));
+
+    const ordinaryRun = enqueueBlockingMigration({
+      id: 'ordinary-migrations',
+      step: 'serverIndex',
+      initialPhase: 'running',
+      retry: vi.fn(),
+      run: async () => ordinary.promise,
+    });
+    const canonicalRun = enqueueBlockingMigration({
+      id: 'canonical-ids:a.test',
+      step: 'canonicalIds',
+      initialPhase: 'inspecting',
+      retry: vi.fn(),
+      run: async context => {
+        context.setView({ phase: 'running', needsMigration: true });
+        await canonical.promise;
+      },
+    });
+
+    await vi.waitFor(() => expect(useMigrationStore.getState().step).toBe('serverIndex'));
+    ordinary.resolve();
+    await vi.waitFor(() => expect(useMigrationStore.getState().step).toBe('canonicalIds'));
+    expect(useMigrationStore.getState().phase).toBe('running');
+    expect(phases.slice(phases.indexOf('running'))).not.toContain('idle');
+    expect(phases.slice(phases.indexOf('running'))).not.toContain('completed');
+
+    canonical.resolve();
+    await Promise.all([ordinaryRun, canonicalRun]);
+    expect(useMigrationStore.getState()).toMatchObject({
+      phase: 'completed',
+      step: null,
+      needsMigration: false,
+    });
+    unsubscribe();
+  });
+
+  it('keeps non-blocking inspection invisible until it enters a blocking phase', async () => {
+    const inspection = deferred();
+    const run = enqueueBlockingMigration({
+      id: 'canonical-ids:a.test',
+      step: 'canonicalIds',
+      initialPhase: 'idle',
+      retry: vi.fn(),
+      run: async () => inspection.promise,
+    });
+
+    await vi.waitFor(() => expect(blockingMigrationStatus('canonical-ids:a.test')).toBe('active'));
+    expect(useMigrationStore.getState()).toMatchObject({
+      phase: 'completed',
+      blockingRevision: 0,
+    });
+
+    inspection.resolve();
+    await run;
+    expect(useMigrationStore.getState()).toMatchObject({
+      phase: 'completed',
+      blockingRevision: 0,
+    });
+  });
+
+  it('stops after the first failure, retries that owner, then resumes queued jobs', async () => {
+    let firstAttempts = 0;
+    let secondAttempts = 0;
+    const enqueueFirst = (): Promise<void> => enqueueBlockingMigration({
+      id: 'canonical-ids:a.test',
+      step: 'canonicalIds',
+      retry: () => { void enqueueFirst().catch(() => {}); },
+      run: async context => {
+        context.setView({ phase: 'running', needsMigration: true });
+        firstAttempts += 1;
+        if (firstAttempts === 1) throw new Error('server A unresolved');
+      },
+    });
+
+    const first = enqueueFirst();
+    const second = enqueueBlockingMigration({
+      id: 'canonical-ids:b.test',
+      step: 'canonicalIds',
+      retry: vi.fn(),
+      run: async context => {
+        context.setView({ phase: 'running', needsMigration: true });
+        secondAttempts += 1;
+      },
+    });
+
+    await expect(first).rejects.toThrow('server A unresolved');
+    expect(secondAttempts).toBe(0);
+    expect(blockingMigrationStatus('canonical-ids:b.test')).toBe('queued');
+    expect(useMigrationStore.getState()).toMatchObject({
+      phase: 'error',
+      step: 'canonicalIds',
+      lastError: 'server A unresolved',
+    });
+    expect(blockingMigrationStatus('canonical-ids:a.test')).toBe('failed');
+
+    retryCurrentBlockingMigration();
+    await vi.waitFor(() => expect(firstAttempts).toBe(2));
+    await second;
+    expect(secondAttempts).toBe(1);
+    await vi.waitFor(() => expect(useMigrationStore.getState().phase).toBe('completed'));
+  });
+});

--- a/src/store/migrationCoordinator.ts
+++ b/src/store/migrationCoordinator.ts
@@ -1,0 +1,233 @@
+import {
+  useMigrationStore,
+  type MigrationPhase,
+  type MigrationStep,
+} from './migrationStore';
+
+type ActiveMigrationPhase = Exclude<MigrationPhase, 'completed' | 'error'>;
+
+interface MigrationView {
+  phase: ActiveMigrationPhase;
+  step: MigrationStep | null;
+  needsMigration: boolean;
+}
+
+export interface BlockingMigrationContext {
+  setView: (view: Partial<MigrationView>) => void;
+  setRetry: (retry: () => void) => void;
+}
+
+interface BlockingMigrationJob<T> {
+  id: string;
+  initialView: MigrationView;
+  retry: () => void;
+  run: (context: BlockingMigrationContext) => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+}
+
+interface ActiveJob {
+  id: string;
+  view: MigrationView;
+  retry: () => void;
+}
+
+interface MigrationFailure {
+  id: string;
+  step: MigrationStep | null;
+  error: string;
+  retry: () => void;
+}
+
+type BlockingMigrationStatus = 'queued' | 'active' | 'failed';
+
+const queue: BlockingMigrationJob<unknown>[] = [];
+const pendingById = new Map<string, Promise<unknown>>();
+let failure: MigrationFailure | null = null;
+let activeJob: ActiveJob | null = null;
+let draining = false;
+let blockingBatchActive = false;
+let retryingJobId: string | null = null;
+
+function isBlockingPhase(phase: ActiveMigrationPhase): boolean {
+  return phase === 'inspecting' || phase === 'running';
+}
+
+type PublishedMigrationState = Partial<Pick<
+  ReturnType<typeof useMigrationStore.getState>,
+  'phase' | 'step' | 'needsMigration' | 'lastError'
+>>;
+
+function publishState(state: PublishedMigrationState): void {
+  useMigrationStore.setState(current => ({
+    ...state,
+    ...(state.phase && state.phase !== 'completed' && current.phase === 'completed'
+      ? { blockingRevision: current.blockingRevision + 1 }
+      : {}),
+  }));
+}
+
+function publishAggregateState(): void {
+  const queuedBlocking = queue.find(job => isBlockingPhase(job.initialView.phase));
+  if (activeJob && isBlockingPhase(activeJob.view.phase)) {
+    publishState({
+      ...activeJob.view,
+      lastError: null,
+    });
+    return;
+  }
+  if (failure) {
+    publishState({
+      phase: 'error',
+      step: failure.step,
+      needsMigration: true,
+      lastError: failure.error,
+    });
+    return;
+  }
+  if (queuedBlocking) {
+    publishState({
+      ...queuedBlocking.initialView,
+      lastError: null,
+    });
+    return;
+  }
+  if (blockingBatchActive && (activeJob || queue.length > 0)) {
+    const next = activeJob?.view ?? queue[0]?.initialView;
+    publishState({
+      phase: 'inspecting',
+      step: next?.step ?? null,
+      needsMigration: true,
+      lastError: null,
+    });
+    return;
+  }
+  // Non-blocking inspection jobs stay invisible until they explicitly enter
+  // a blocking phase through context.setView(). Publishing their idle view
+  // would revoke startup readiness and make bind-time identity inspection loop.
+  if (activeJob || queue.length > 0) return;
+
+  blockingBatchActive = false;
+  publishState({
+    phase: 'completed',
+    step: null,
+    needsMigration: false,
+    lastError: null,
+  });
+}
+
+async function drainQueue(): Promise<void> {
+  if (draining) return;
+  draining = true;
+  try {
+    while (queue.length > 0 && !failure) {
+      const job = queue.shift()!;
+      activeJob = {
+        id: job.id,
+        view: job.initialView,
+        retry: job.retry,
+      };
+      if (isBlockingPhase(activeJob.view.phase)) blockingBatchActive = true;
+      publishAggregateState();
+
+      const context: BlockingMigrationContext = {
+        setView: view => {
+          if (!activeJob || activeJob.id !== job.id) return;
+          activeJob.view = { ...activeJob.view, ...view };
+          if (isBlockingPhase(activeJob.view.phase)) blockingBatchActive = true;
+          publishAggregateState();
+        },
+        setRetry: retry => {
+          if (!activeJob || activeJob.id !== job.id) return;
+          activeJob.retry = retry;
+        },
+      };
+
+      try {
+        const result = await job.run(context);
+        job.resolve(result);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        failure = {
+          id: job.id,
+          step: activeJob.view.step,
+          error: message,
+          retry: activeJob.retry,
+        };
+        blockingBatchActive = true;
+        job.reject(error);
+      } finally {
+        pendingById.delete(job.id);
+        activeJob = null;
+        publishAggregateState();
+      }
+    }
+  } finally {
+    draining = false;
+    publishAggregateState();
+  }
+}
+
+export function enqueueBlockingMigration<T>(options: {
+  id: string;
+  step: MigrationStep | null;
+  initialPhase?: ActiveMigrationPhase;
+  retry: () => void;
+  run: (context: BlockingMigrationContext) => Promise<T>;
+}): Promise<T> {
+  const existing = pendingById.get(options.id);
+  if (existing) return existing as Promise<T>;
+
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  pendingById.set(options.id, promise);
+  const job: BlockingMigrationJob<unknown> = {
+    id: options.id,
+    initialView: {
+      phase: options.initialPhase ?? 'idle',
+      step: options.step,
+      needsMigration: false,
+    },
+    retry: options.retry,
+    run: options.run,
+    resolve: resolve as (value: unknown) => void,
+    reject,
+  };
+  if (retryingJobId === options.id) queue.unshift(job);
+  else queue.push(job);
+  publishAggregateState();
+  if (!failure) void drainQueue();
+  return promise;
+}
+
+export function retryCurrentBlockingMigration(): void {
+  const failed = failure;
+  if (!failed) return;
+  failure = null;
+  retryingJobId = failed.id;
+  failed.retry();
+  retryingJobId = null;
+  publishAggregateState();
+  void drainQueue();
+}
+
+export function blockingMigrationStatus(id: string): BlockingMigrationStatus | null {
+  if (activeJob?.id === id) return 'active';
+  if (queue.some(job => job.id === id)) return 'queued';
+  if (failure?.id === id) return 'failed';
+  return null;
+}
+
+export function resetBlockingMigrationCoordinatorForTests(): void {
+  queue.length = 0;
+  pendingById.clear();
+  failure = null;
+  activeJob = null;
+  draining = false;
+  blockingBatchActive = false;
+  retryingJobId = null;
+}

--- a/src/store/migrationStore.ts
+++ b/src/store/migrationStore.ts
@@ -21,6 +21,7 @@ interface MigrationState {
   scopeBrowseProjectionInspect: ScopeBrowseProjectionInspectDto | null;
   scopeBrowseProjectionProgress: GenreTagsProgressEvent | null;
   lastError: string | null;
+  blockingRevision: number;
   setPhase: (phase: MigrationPhase) => void;
   setStep: (step: MigrationStep | null) => void;
   setNeedsMigration: (needsMigration: boolean) => void;
@@ -44,6 +45,7 @@ export const useMigrationStore = create<MigrationState>(set => ({
   scopeBrowseProjectionInspect: null,
   scopeBrowseProjectionProgress: null,
   lastError: null,
+  blockingRevision: 0,
   setPhase: phase => set({ phase }),
   setStep: step => set({ step }),
   setNeedsMigration: needsMigration => set({ needsMigration }),

--- a/src/store/migrationStore.ts
+++ b/src/store/migrationStore.ts
@@ -3,7 +3,7 @@ import type { GenreTagsInspectDto, ScopeBrowseProjectionInspectDto } from '@/lib
 import type { MigrationInspectReport, MigrationProgressEvent } from '@/lib/api/migration';
 
 export type MigrationPhase = 'idle' | 'inspecting' | 'running' | 'completed' | 'error';
-export type MigrationStep = 'serverIndex' | 'genreTags' | 'scopeBrowseProjection';
+export type MigrationStep = 'serverIndex' | 'genreTags' | 'scopeBrowseProjection' | 'canonicalIds';
 
 export interface GenreTagsProgressEvent {
   done: number;

--- a/src/utils/server/reconcileCanonicalEntityIds.test.ts
+++ b/src/utils/server/reconcileCanonicalEntityIds.test.ts
@@ -1,0 +1,500 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/api/library', () => ({
+  libraryIdentityTransitionStatus: vi.fn(),
+  libraryIdentityTransitionProbe: vi.fn(),
+  libraryIdentityTransitionRunNativeMigration: vi.fn(),
+  libraryIdentityTransitionAck: vi.fn(),
+}));
+
+vi.mock('@/lib/api/analysis', () => ({
+  analysisClearServerCache: vi.fn(),
+}));
+
+vi.mock('@/features/lyrics/utils/lyricsPersistentCache', () => ({
+  clearLyricsCache: vi.fn(),
+}));
+
+import {
+  libraryIdentityTransitionAck,
+  libraryIdentityTransitionProbe,
+  libraryIdentityTransitionRunNativeMigration,
+  libraryIdentityTransitionStatus,
+} from '@/lib/api/library';
+import { analysisClearServerCache } from '@/lib/api/analysis';
+import { clearLyricsCache } from '@/features/lyrics/utils/lyricsPersistentCache';
+import { useAuthStore } from '@/store/authStore';
+import { useLocalPlaybackStore } from '@/store/localPlaybackStore';
+import { useOfflineStore } from '@/features/offline';
+import { usePlayerStore } from '@/features/playback/store/playerStore';
+import { useDeviceSyncStore } from '@/features/deviceSync';
+import { usePlaylistFolderStore, usePlaylistStore } from '@/features/playlist';
+import { useMigrationStore } from '@/store/migrationStore';
+import { usePlaylistMembershipStore } from '@/store/playlistMembershipStore';
+import { persistShuffleModeSnapshot } from '@/features/playback/store/shuffleModeStorage';
+import {
+  canonicalizeNavidromeId,
+  reconcileCanonicalEntityIds,
+} from './reconcileCanonicalEntityIds';
+import { canonicalizeConfirmedNavidromeId } from '@/lib/server/navidromeCanonicalIds';
+
+const OLD_TRACK = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+const NEW_TRACK = '6VHl3uR4kss6sUPKA8Cwnk';
+const OLD_ALBUM = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const NEW_ALBUM = '7rke2SAWaicSeSYzkhww6R';
+const PROFILE_ID = 'profile-1';
+const INDEX_KEY = 'music.test';
+
+describe('canonical Navidrome IDs', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  beforeEach(async () => {
+    localStorage.clear();
+    vi.mocked(libraryIdentityTransitionStatus).mockReset();
+    vi.mocked(libraryIdentityTransitionAck).mockReset();
+    vi.mocked(libraryIdentityTransitionProbe).mockReset();
+    vi.mocked(libraryIdentityTransitionRunNativeMigration).mockReset();
+    vi.mocked(analysisClearServerCache).mockReset();
+    vi.mocked(clearLyricsCache).mockReset();
+    await Promise.all([
+      useAuthStore.persist.rehydrate(),
+      usePlayerStore.persist.rehydrate(),
+      useLocalPlaybackStore.persist.rehydrate(),
+      useOfflineStore.persist.rehydrate(),
+      useDeviceSyncStore.persist.rehydrate(),
+      usePlaylistStore.persist.rehydrate(),
+      usePlaylistFolderStore.persist.rehydrate(),
+    ]);
+    usePlayerStore.setState({ currentTrack: null, queueServerId: null, queueItems: [] });
+    useLocalPlaybackStore.setState({ entries: {} });
+    useOfflineStore.setState({ albums: {} });
+    useDeviceSyncStore.setState({ sources: [], legacySources: [] });
+    usePlaylistStore.setState({ playlists: [], recentIds: [], lastModified: {} });
+    usePlaylistFolderStore.setState({ byServer: {} });
+    usePlaylistMembershipStore.setState({ songIdsByCacheKey: {}, revision: 0 });
+    useAuthStore.setState({
+      skipStarManualSkipCountsByKey: {},
+      musicFolders: [],
+      musicFoldersByServer: {},
+      libraryBrowseSelectionByServer: {},
+      musicLibraryFilterByServer: {},
+      musicLibrarySelectionByServer: {},
+    });
+    useMigrationStore.setState({
+      phase: 'completed',
+      step: null,
+      needsMigration: false,
+      lastError: null,
+    });
+  });
+
+  it('matches Navidrome upstream migration vectors', () => {
+    expect(canonicalizeNavidromeId('5cLJPkLA5DK2BADhoeotPk')).toBe('5cLJPkLA5DK2BADhoeotPk');
+    expect(canonicalizeNavidromeId('zzzzzzzzzzzzzzzzzzzzzz')).toBe('3LyqmwQBm5IRqlVjNYASwb');
+    expect(canonicalizeNavidromeId(OLD_TRACK)).toBe(NEW_TRACK);
+    expect(canonicalizeNavidromeId(OLD_ALBUM)).toBe(NEW_ALBUM);
+    expect(canonicalizeNavidromeId('!!!!!!!!!!!!!!!!!!!!!!')).toBe('!!!!!!!!!!!!!!!!!!!!!!');
+  });
+
+  it('rewrites persisted state before acknowledging the native transition', async () => {
+    vi.mocked(libraryIdentityTransitionStatus).mockResolvedValue({
+      serverId: INDEX_KEY,
+      state: 'transition_detected',
+      canonicalVersion: 1,
+      probeOldId: OLD_TRACK,
+      probeNewId: NEW_TRACK,
+      lastError: null,
+    });
+    vi.mocked(libraryIdentityTransitionRunNativeMigration).mockResolvedValue({
+      serverId: INDEX_KEY,
+      state: 'pending_frontend',
+      canonicalVersion: 1,
+      probeOldId: OLD_TRACK,
+      probeNewId: NEW_TRACK,
+      lastError: null,
+    });
+    vi.mocked(libraryIdentityTransitionAck).mockResolvedValue();
+    vi.mocked(analysisClearServerCache).mockResolvedValue();
+    vi.mocked(clearLyricsCache).mockResolvedValue();
+    const server = {
+      id: PROFILE_ID,
+      name: 'Navidrome',
+      url: 'https://music.test',
+      username: 'user',
+      password: 'password',
+    };
+
+    usePlayerStore.setState({
+      queueServerId: INDEX_KEY,
+      currentTrack: {
+        id: OLD_TRACK,
+        title: 'Track',
+        artist: 'Artist',
+        album: 'Album',
+        albumId: OLD_ALBUM,
+        duration: 120,
+        serverId: PROFILE_ID,
+      },
+      queueItems: [
+        { serverId: INDEX_KEY, trackId: OLD_TRACK },
+        { serverId: 'other.test', trackId: OLD_TRACK },
+      ],
+    });
+    useLocalPlaybackStore.setState({
+      entries: {
+        [`${INDEX_KEY}:${OLD_TRACK}`]: {
+          serverIndexKey: INDEX_KEY,
+          trackId: OLD_TRACK,
+          localPath: '/music/track.flac',
+          layoutFingerprint: 'layout',
+          sizeBytes: 10,
+          tier: 'library',
+          cachedAt: 1,
+          pinSource: { kind: 'album', sourceId: OLD_ALBUM },
+          suffix: 'flac',
+        },
+      },
+    });
+    useOfflineStore.setState({
+      albums: {
+        [`${INDEX_KEY}:${OLD_ALBUM}`]: {
+          id: OLD_ALBUM,
+          serverId: INDEX_KEY,
+          name: 'Album',
+          artist: 'Artist',
+          trackIds: [OLD_TRACK],
+        },
+      },
+    });
+    useAuthStore.setState({
+      skipStarManualSkipCountsByKey: {
+        [`${PROFILE_ID}\u001f${OLD_TRACK}`]: 2,
+      },
+      activeServerId: PROFILE_ID,
+      musicFolders: [{ id: OLD_ALBUM, name: 'Library' }],
+      musicFoldersByServer: { [PROFILE_ID]: [{ id: OLD_ALBUM, name: 'Library' }] },
+      libraryBrowseSelectionByServer: { [PROFILE_ID]: [OLD_ALBUM] },
+      musicLibraryFilterByServer: { [PROFILE_ID]: OLD_ALBUM },
+      musicLibrarySelectionByServer: { [PROFILE_ID]: [OLD_ALBUM] },
+    });
+    useDeviceSyncStore.setState({
+      sources: [{ type: 'album', id: OLD_ALBUM, name: 'Album', serverIndexKey: INDEX_KEY }],
+    });
+    usePlaylistStore.setState({
+      playlists: [{
+        id: OLD_ALBUM,
+        serverId: PROFILE_ID,
+        name: 'Playlist',
+        songCount: 1,
+        duration: 120,
+        created: '2026-01-01',
+        changed: '2026-01-01',
+      }],
+      recentIds: [`${PROFILE_ID}:${OLD_ALBUM}`],
+      lastModified: { [`${PROFILE_ID}:${OLD_ALBUM}`]: 10 },
+    });
+    usePlaylistFolderStore.setState({
+      byServer: {
+        [PROFILE_ID]: { folders: [], assignments: { [OLD_ALBUM]: 'folder-1' } },
+      },
+    });
+    usePlaylistMembershipStore.getState().setPlaylistSongIds(OLD_ALBUM, [OLD_TRACK], PROFILE_ID);
+
+    await reconcileCanonicalEntityIds(server, INDEX_KEY);
+
+    expect(usePlayerStore.getState().currentTrack?.id).toBe(NEW_TRACK);
+    expect(usePlayerStore.getState().queueItems).toEqual([
+      { serverId: INDEX_KEY, trackId: NEW_TRACK },
+      { serverId: 'other.test', trackId: OLD_TRACK },
+    ]);
+    const local = useLocalPlaybackStore.getState().entries[`${INDEX_KEY}:${NEW_TRACK}`];
+    expect(local).toMatchObject({
+      trackId: NEW_TRACK,
+      localPath: '/music/track.flac',
+      pinSource: { sourceId: NEW_ALBUM },
+    });
+    expect(useOfflineStore.getState().albums[`${INDEX_KEY}:${NEW_ALBUM}`]?.trackIds).toEqual([NEW_TRACK]);
+    expect(useAuthStore.getState().skipStarManualSkipCountsByKey).toEqual({});
+    expect(useAuthStore.getState().musicFolders[0]?.id).toBe(NEW_ALBUM);
+    expect(useAuthStore.getState().musicFoldersByServer[PROFILE_ID]?.[0]?.id).toBe(NEW_ALBUM);
+    expect(useAuthStore.getState().libraryBrowseSelectionByServer[PROFILE_ID]).toEqual([NEW_ALBUM]);
+    expect(useAuthStore.getState().musicLibraryFilterByServer[PROFILE_ID]).toBe(NEW_ALBUM);
+    expect(useAuthStore.getState().musicLibrarySelectionByServer[PROFILE_ID]).toEqual([NEW_ALBUM]);
+    expect(useDeviceSyncStore.getState().sources[0]?.id).toBe(NEW_ALBUM);
+    expect(usePlaylistStore.getState()).toMatchObject({
+      playlists: [],
+      recentIds: [],
+      lastModified: {},
+    });
+    expect(usePlaylistFolderStore.getState().byServer[PROFILE_ID]?.assignments).toEqual({
+      [NEW_ALBUM]: 'folder-1',
+    });
+    expect(usePlaylistMembershipStore.getState().songIdsByCacheKey).toEqual({});
+    expect(analysisClearServerCache).toHaveBeenCalledWith(INDEX_KEY);
+    expect(clearLyricsCache).toHaveBeenCalledTimes(1);
+    expect(libraryIdentityTransitionRunNativeMigration).toHaveBeenCalledWith(INDEX_KEY);
+    expect(libraryIdentityTransitionAck).toHaveBeenCalledWith(INDEX_KEY);
+    expect(useMigrationStore.getState()).toMatchObject({
+      phase: 'completed',
+      step: null,
+      needsMigration: false,
+    });
+  });
+
+  it('does not acknowledge when a durable cache migration fails', async () => {
+    vi.mocked(libraryIdentityTransitionStatus).mockResolvedValue({
+      serverId: INDEX_KEY,
+      state: 'pending_frontend',
+      canonicalVersion: 1,
+      probeOldId: OLD_TRACK,
+      probeNewId: NEW_TRACK,
+      lastError: null,
+    });
+    vi.mocked(analysisClearServerCache).mockRejectedValue(new Error('analysis locked'));
+
+    await expect(reconcileCanonicalEntityIds({
+      id: PROFILE_ID,
+      name: 'Navidrome',
+      url: 'https://music.test',
+      username: 'user',
+      password: 'password',
+    }, INDEX_KEY)).rejects.toThrow('analysis locked');
+    expect(libraryIdentityTransitionAck).not.toHaveBeenCalled();
+  });
+
+  it('does not acknowledge when current-track persistence fails', async () => {
+    vi.mocked(libraryIdentityTransitionStatus).mockResolvedValue({
+      serverId: INDEX_KEY,
+      state: 'pending_frontend',
+      canonicalVersion: 1,
+      probeOldId: OLD_TRACK,
+      probeNewId: NEW_TRACK,
+      lastError: null,
+    });
+    vi.mocked(analysisClearServerCache).mockResolvedValue();
+    vi.mocked(clearLyricsCache).mockResolvedValue();
+    usePlayerStore.setState({
+      queueServerId: INDEX_KEY,
+      currentTrack: {
+        id: OLD_TRACK,
+        title: 'Track',
+        artist: 'Artist',
+        album: 'Album',
+        albumId: OLD_ALBUM,
+        duration: 120,
+        serverId: PROFILE_ID,
+      },
+      queueItems: [{ serverId: INDEX_KEY, trackId: OLD_TRACK }],
+    });
+    const originalSetItem = window.localStorage.setItem.bind(window.localStorage);
+    const setItem = vi.spyOn(window.localStorage, 'setItem').mockImplementation((key, value) => {
+      if (key === 'psysonic-player') throw new DOMException('quota', 'QuotaExceededError');
+      return originalSetItem(key, value);
+    });
+
+    await expect(reconcileCanonicalEntityIds({
+      id: PROFILE_ID,
+      name: 'Navidrome',
+      url: 'https://music.test',
+      username: 'user',
+      password: 'password',
+    }, INDEX_KEY)).rejects.toThrow('psysonic-player.currentTrack');
+
+    setItem.mockRestore();
+    expect(libraryIdentityTransitionAck).not.toHaveBeenCalled();
+    expect(useMigrationStore.getState().phase).toBe('error');
+  });
+
+  it('does not acknowledge when shuffle persistence fails', async () => {
+    vi.mocked(libraryIdentityTransitionStatus).mockResolvedValue({
+      serverId: INDEX_KEY,
+      state: 'pending_frontend',
+      canonicalVersion: 1,
+      probeOldId: OLD_TRACK,
+      probeNewId: NEW_TRACK,
+      lastError: null,
+    });
+    vi.mocked(analysisClearServerCache).mockResolvedValue();
+    vi.mocked(clearLyricsCache).mockResolvedValue();
+    persistShuffleModeSnapshot({
+      enabled: true,
+      originalOrder: [JSON.stringify([INDEX_KEY, OLD_TRACK])],
+    });
+    const originalSetItem = window.localStorage.setItem.bind(window.localStorage);
+    const setItem = vi.spyOn(window.localStorage, 'setItem').mockImplementation((key, value) => {
+      if (key === 'psysonic_shuffle_mode') throw new DOMException('quota', 'QuotaExceededError');
+      return originalSetItem(key, value);
+    });
+
+    await expect(reconcileCanonicalEntityIds({
+      id: PROFILE_ID,
+      name: 'Navidrome',
+      url: 'https://music.test',
+      username: 'user',
+      password: 'password',
+    }, INDEX_KEY)).rejects.toThrow('shuffle state');
+
+    setItem.mockRestore();
+    expect(libraryIdentityTransitionAck).not.toHaveBeenCalled();
+  });
+
+  it('probes frontend-only legacy IDs when the native library has no candidate', async () => {
+    vi.mocked(libraryIdentityTransitionStatus).mockResolvedValue({
+      serverId: INDEX_KEY,
+      state: 'awaiting_supplemental_probe',
+      canonicalVersion: 1,
+      probeOldId: null,
+      probeNewId: null,
+      lastError: null,
+    });
+    vi.mocked(libraryIdentityTransitionProbe).mockResolvedValue({
+      serverId: INDEX_KEY,
+      state: 'transition_detected',
+      canonicalVersion: 1,
+      probeOldId: OLD_TRACK,
+      probeNewId: NEW_TRACK,
+      lastError: null,
+    });
+    vi.mocked(libraryIdentityTransitionRunNativeMigration).mockResolvedValue({
+      serverId: INDEX_KEY,
+      state: 'pending_frontend',
+      canonicalVersion: 1,
+      probeOldId: OLD_TRACK,
+      probeNewId: NEW_TRACK,
+      lastError: null,
+    });
+    vi.mocked(analysisClearServerCache).mockResolvedValue();
+    vi.mocked(clearLyricsCache).mockResolvedValue();
+    vi.mocked(libraryIdentityTransitionAck).mockResolvedValue();
+    usePlayerStore.setState({
+      queueServerId: INDEX_KEY,
+      currentTrack: null,
+      queueItems: [{ serverId: INDEX_KEY, trackId: OLD_TRACK }],
+    });
+
+    await reconcileCanonicalEntityIds({
+      id: PROFILE_ID,
+      name: 'Navidrome',
+      url: 'https://music.test',
+      username: 'user',
+      password: 'password',
+    }, INDEX_KEY);
+
+    expect(libraryIdentityTransitionProbe).toHaveBeenCalledWith(INDEX_KEY, [
+      { entityKind: 'track', id: OLD_TRACK },
+    ]);
+    expect(usePlayerStore.getState().queueItems[0]?.trackId).toBe(NEW_TRACK);
+    expect(libraryIdentityTransitionAck).toHaveBeenCalledWith(INDEX_KEY);
+  });
+
+  it('records an empty frontend inventory without permanently completing detection', async () => {
+    vi.mocked(libraryIdentityTransitionStatus).mockResolvedValue({
+      serverId: INDEX_KEY,
+      state: 'awaiting_supplemental_probe',
+      canonicalVersion: 1,
+      probeOldId: null,
+      probeNewId: null,
+      lastError: null,
+    });
+    vi.mocked(libraryIdentityTransitionProbe).mockResolvedValue({
+      serverId: INDEX_KEY,
+      state: 'no_legacy_ids',
+      canonicalVersion: 1,
+      probeOldId: null,
+      probeNewId: null,
+      lastError: null,
+    });
+
+    await reconcileCanonicalEntityIds({
+      id: PROFILE_ID,
+      name: 'Navidrome',
+      url: 'https://music.test',
+      username: 'user',
+      password: 'password',
+    }, INDEX_KEY);
+
+    expect(libraryIdentityTransitionProbe).toHaveBeenCalledWith(INDEX_KEY, []);
+    expect(libraryIdentityTransitionRunNativeMigration).not.toHaveBeenCalled();
+    expect(useMigrationStore.getState().phase).toBe('completed');
+  });
+
+  it('does not acknowledge ownerless device-sync selections', async () => {
+    vi.mocked(libraryIdentityTransitionStatus).mockResolvedValue({
+      serverId: INDEX_KEY,
+      state: 'pending_frontend',
+      canonicalVersion: 1,
+      probeOldId: OLD_TRACK,
+      probeNewId: NEW_TRACK,
+      lastError: null,
+    });
+    vi.mocked(analysisClearServerCache).mockResolvedValue();
+    vi.mocked(clearLyricsCache).mockResolvedValue();
+    useDeviceSyncStore.setState({
+      legacySources: [{ type: 'album', id: OLD_ALBUM, name: 'Legacy album' }],
+    });
+
+    await expect(reconcileCanonicalEntityIds({
+      id: PROFILE_ID,
+      name: 'Navidrome',
+      url: 'https://music.test',
+      username: 'user',
+      password: 'password',
+    }, INDEX_KEY)).rejects.toThrow('ownerless legacy selections');
+
+    expect(libraryIdentityTransitionAck).not.toHaveBeenCalled();
+    expect(useDeviceSyncStore.getState().legacySources).toHaveLength(1);
+  });
+
+  it('reactivates canonical owners from durable ready state after restart', async () => {
+    const readyKey = 'ready.music.test';
+    vi.mocked(libraryIdentityTransitionStatus).mockResolvedValue({
+      serverId: readyKey,
+      state: 'ready',
+      canonicalVersion: 1,
+      probeOldId: OLD_TRACK,
+      probeNewId: NEW_TRACK,
+      lastError: null,
+    });
+
+    await reconcileCanonicalEntityIds({
+      id: 'ready-profile',
+      name: 'Navidrome',
+      url: `https://${readyKey}`,
+      username: 'user',
+      password: 'password',
+    }, readyKey);
+
+    expect(canonicalizeConfirmedNavidromeId(readyKey, OLD_ALBUM)).toBe(NEW_ALBUM);
+  });
+
+  it('does not acknowledge when playlist-cache persistence fails', async () => {
+    vi.mocked(libraryIdentityTransitionStatus).mockResolvedValue({
+      serverId: INDEX_KEY,
+      state: 'pending_frontend',
+      canonicalVersion: 1,
+      probeOldId: OLD_TRACK,
+      probeNewId: NEW_TRACK,
+      lastError: null,
+    });
+    vi.mocked(analysisClearServerCache).mockResolvedValue();
+    vi.mocked(clearLyricsCache).mockResolvedValue();
+    usePlaylistStore.setState({ recentIds: [`${PROFILE_ID}:${OLD_ALBUM}`] });
+    const originalSetItem = window.localStorage.setItem.bind(window.localStorage);
+    const setItem = vi.spyOn(window.localStorage, 'setItem').mockImplementation((key, value) => {
+      if (key === 'psysonic_playlists_recent') throw new DOMException('quota', 'QuotaExceededError');
+      return originalSetItem(key, value);
+    });
+
+    await expect(reconcileCanonicalEntityIds({
+      id: PROFILE_ID,
+      name: 'Navidrome',
+      url: 'https://music.test',
+      username: 'user',
+      password: 'password',
+    }, INDEX_KEY)).rejects.toThrow('quota');
+
+    setItem.mockRestore();
+    expect(libraryIdentityTransitionAck).not.toHaveBeenCalled();
+  });
+
+});

--- a/src/utils/server/reconcileCanonicalEntityIds.test.ts
+++ b/src/utils/server/reconcileCanonicalEntityIds.test.ts
@@ -36,7 +36,16 @@ import {
   canonicalizeNavidromeId,
   reconcileCanonicalEntityIds,
 } from './reconcileCanonicalEntityIds';
-import { canonicalizeConfirmedNavidromeId } from '@/lib/server/navidromeCanonicalIds';
+import {
+  canonicalizeConfirmedNavidromeId,
+  deactivateCanonicalNavidromeOwners,
+} from '@/lib/server/navidromeCanonicalIds';
+import { resetBlockingMigrationCoordinatorForTests } from '@/store/migrationCoordinator';
+import {
+  _resetTimelineSessionHistoryForTest,
+  appendTimelineSessionPlay,
+  getTimelineSessionHistorySnapshot,
+} from '@/features/playback/store/timelineSessionHistory';
 
 const OLD_TRACK = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
 const NEW_TRACK = '6VHl3uR4kss6sUPKA8Cwnk';
@@ -49,7 +58,10 @@ describe('canonical Navidrome IDs', () => {
   afterEach(() => vi.restoreAllMocks());
 
   beforeEach(async () => {
+    resetBlockingMigrationCoordinatorForTests();
+    deactivateCanonicalNavidromeOwners([PROFILE_ID, INDEX_KEY, 'ready-profile', 'ready.music.test']);
     localStorage.clear();
+    _resetTimelineSessionHistoryForTest();
     vi.mocked(libraryIdentityTransitionStatus).mockReset();
     vi.mocked(libraryIdentityTransitionAck).mockReset();
     vi.mocked(libraryIdentityTransitionProbe).mockReset();
@@ -79,6 +91,8 @@ describe('canonical Navidrome IDs', () => {
       libraryBrowseSelectionByServer: {},
       musicLibraryFilterByServer: {},
       musicLibrarySelectionByServer: {},
+      musicLibraryFilterVersion: 0,
+      libraryBrowseScopeVersion: 0,
     });
     useMigrationStore.setState({
       phase: 'completed',
@@ -116,14 +130,6 @@ describe('canonical Navidrome IDs', () => {
     vi.mocked(libraryIdentityTransitionAck).mockResolvedValue();
     vi.mocked(analysisClearServerCache).mockResolvedValue();
     vi.mocked(clearLyricsCache).mockResolvedValue();
-    const server = {
-      id: PROFILE_ID,
-      name: 'Navidrome',
-      url: 'https://music.test',
-      username: 'user',
-      password: 'password',
-    };
-
     usePlayerStore.setState({
       queueServerId: INDEX_KEY,
       currentTrack: {
@@ -139,6 +145,11 @@ describe('canonical Navidrome IDs', () => {
         { serverId: INDEX_KEY, trackId: OLD_TRACK },
         { serverId: 'other.test', trackId: OLD_TRACK },
       ],
+      starredOverrides: {
+        [`${PROFILE_ID}:${OLD_TRACK}`]: true,
+        [`${PROFILE_ID}:${NEW_TRACK}`]: false,
+        [`other-profile:${OLD_TRACK}`]: true,
+      },
     });
     useLocalPlaybackStore.setState({
       entries: {
@@ -169,6 +180,8 @@ describe('canonical Navidrome IDs', () => {
     useAuthStore.setState({
       skipStarManualSkipCountsByKey: {
         [`${PROFILE_ID}\u001f${OLD_TRACK}`]: 2,
+        [`${PROFILE_ID}\u001f${NEW_TRACK}`]: 4,
+        [`other-profile\u001f${OLD_TRACK}`]: 3,
       },
       activeServerId: PROFILE_ID,
       musicFolders: [{ id: OLD_ALBUM, name: 'Library' }],
@@ -199,14 +212,26 @@ describe('canonical Navidrome IDs', () => {
       },
     });
     usePlaylistMembershipStore.getState().setPlaylistSongIds(OLD_ALBUM, [OLD_TRACK], PROFILE_ID);
+    appendTimelineSessionPlay({ serverId: PROFILE_ID, trackId: OLD_TRACK, playedAtMs: 1 });
+    appendTimelineSessionPlay({ serverId: 'other-profile', trackId: OLD_TRACK, playedAtMs: 2 });
 
-    await reconcileCanonicalEntityIds(server, INDEX_KEY);
+    await reconcileCanonicalEntityIds({
+      id: PROFILE_ID,
+      name: 'Navidrome',
+      url: 'https://music.test',
+      username: 'user',
+      password: 'password',
+    }, INDEX_KEY);
 
     expect(usePlayerStore.getState().currentTrack?.id).toBe(NEW_TRACK);
     expect(usePlayerStore.getState().queueItems).toEqual([
       { serverId: INDEX_KEY, trackId: NEW_TRACK },
       { serverId: 'other.test', trackId: OLD_TRACK },
     ]);
+    expect(usePlayerStore.getState().starredOverrides).toEqual({
+      [`${PROFILE_ID}:${NEW_TRACK}`]: false,
+      [`other-profile:${OLD_TRACK}`]: true,
+    });
     const local = useLocalPlaybackStore.getState().entries[`${INDEX_KEY}:${NEW_TRACK}`];
     expect(local).toMatchObject({
       trackId: NEW_TRACK,
@@ -214,12 +239,17 @@ describe('canonical Navidrome IDs', () => {
       pinSource: { sourceId: NEW_ALBUM },
     });
     expect(useOfflineStore.getState().albums[`${INDEX_KEY}:${NEW_ALBUM}`]?.trackIds).toEqual([NEW_TRACK]);
-    expect(useAuthStore.getState().skipStarManualSkipCountsByKey).toEqual({});
+    expect(useAuthStore.getState().skipStarManualSkipCountsByKey).toEqual({
+      [`${PROFILE_ID}\u001f${NEW_TRACK}`]: 4,
+      [`other-profile\u001f${OLD_TRACK}`]: 3,
+    });
     expect(useAuthStore.getState().musicFolders[0]?.id).toBe(NEW_ALBUM);
     expect(useAuthStore.getState().musicFoldersByServer[PROFILE_ID]?.[0]?.id).toBe(NEW_ALBUM);
     expect(useAuthStore.getState().libraryBrowseSelectionByServer[PROFILE_ID]).toEqual([NEW_ALBUM]);
     expect(useAuthStore.getState().musicLibraryFilterByServer[PROFILE_ID]).toBe(NEW_ALBUM);
     expect(useAuthStore.getState().musicLibrarySelectionByServer[PROFILE_ID]).toEqual([NEW_ALBUM]);
+    expect(useAuthStore.getState().musicLibraryFilterVersion).toBe(1);
+    expect(useAuthStore.getState().libraryBrowseScopeVersion).toBe(1);
     expect(useDeviceSyncStore.getState().sources[0]?.id).toBe(NEW_ALBUM);
     expect(usePlaylistStore.getState()).toMatchObject({
       playlists: [],
@@ -230,6 +260,10 @@ describe('canonical Navidrome IDs', () => {
       [NEW_ALBUM]: 'folder-1',
     });
     expect(usePlaylistMembershipStore.getState().songIdsByCacheKey).toEqual({});
+    expect(getTimelineSessionHistorySnapshot()).toEqual([
+      { serverId: INDEX_KEY, trackId: NEW_TRACK, playedAtMs: 1 },
+      { serverId: 'other-profile', trackId: OLD_TRACK, playedAtMs: 2 },
+    ]);
     expect(analysisClearServerCache).toHaveBeenCalledWith(INDEX_KEY);
     expect(clearLyricsCache).toHaveBeenCalledTimes(1);
     expect(libraryIdentityTransitionRunNativeMigration).toHaveBeenCalledWith(INDEX_KEY);
@@ -418,7 +452,46 @@ describe('canonical Navidrome IDs', () => {
     expect(useMigrationStore.getState().phase).toBe('completed');
   });
 
-  it('does not acknowledge ownerless device-sync selections', async () => {
+  it('continues bounded native probe progress without requiring manual retry', async () => {
+    vi.mocked(libraryIdentityTransitionStatus).mockResolvedValue({
+      serverId: INDEX_KEY,
+      state: 'retryable',
+      canonicalVersion: 2,
+      probeOldId: null,
+      probeNewId: null,
+      lastError: 'canonical-ID inactive alias baseline is still progressing',
+    });
+    vi.mocked(libraryIdentityTransitionProbe)
+      .mockResolvedValueOnce({
+        serverId: INDEX_KEY,
+        state: 'retryable',
+        canonicalVersion: 2,
+        probeOldId: null,
+        probeNewId: null,
+        lastError: 'canonical-ID candidate scan has more catalog rows to inspect',
+      })
+      .mockResolvedValueOnce({
+        serverId: INDEX_KEY,
+        state: 'no_legacy_ids',
+        canonicalVersion: 2,
+        probeOldId: null,
+        probeNewId: null,
+        lastError: null,
+      });
+
+    await reconcileCanonicalEntityIds({
+      id: PROFILE_ID,
+      name: 'Navidrome',
+      url: 'https://music.test',
+      username: 'user',
+      password: 'password',
+    }, INDEX_KEY);
+
+    expect(libraryIdentityTransitionProbe).toHaveBeenCalledTimes(2);
+    expect(useMigrationStore.getState().phase).toBe('completed');
+  });
+
+  it('acknowledges while preserving ownerless device-sync selections for later recovery', async () => {
     vi.mocked(libraryIdentityTransitionStatus).mockResolvedValue({
       serverId: INDEX_KEY,
       state: 'pending_frontend',
@@ -432,17 +505,34 @@ describe('canonical Navidrome IDs', () => {
     useDeviceSyncStore.setState({
       legacySources: [{ type: 'album', id: OLD_ALBUM, name: 'Legacy album' }],
     });
+    useAuthStore.setState({
+      skipStarManualSkipCountsByKey: {
+        [`${PROFILE_ID}\u001f${OLD_TRACK}`]: 2,
+        [`other-profile\u001f${OLD_TRACK}`]: 3,
+      },
+    });
 
-    await expect(reconcileCanonicalEntityIds({
+    await reconcileCanonicalEntityIds({
       id: PROFILE_ID,
       name: 'Navidrome',
       url: 'https://music.test',
       username: 'user',
       password: 'password',
-    }, INDEX_KEY)).rejects.toThrow('ownerless legacy selections');
+    }, INDEX_KEY);
 
-    expect(libraryIdentityTransitionAck).not.toHaveBeenCalled();
+    expect(libraryIdentityTransitionAck).toHaveBeenCalledWith(INDEX_KEY);
     expect(useDeviceSyncStore.getState().legacySources).toHaveLength(1);
+    expect(useAuthStore.getState().skipStarManualSkipCountsByKey).toEqual({
+      [`${PROFILE_ID}\u001f${NEW_TRACK}`]: 2,
+      [`other-profile\u001f${OLD_TRACK}`]: 3,
+    });
+    const persistedAuth = JSON.parse(localStorage.getItem('psysonic-auth') ?? '{}') as {
+      state?: { skipStarManualSkipCountsByKey?: Record<string, number> };
+    };
+    expect(persistedAuth.state?.skipStarManualSkipCountsByKey).toEqual({
+      [`${PROFILE_ID}\u001f${NEW_TRACK}`]: 2,
+      [`other-profile\u001f${OLD_TRACK}`]: 3,
+    });
   });
 
   it('reactivates canonical owners from durable ready state after restart', async () => {

--- a/src/utils/server/reconcileCanonicalEntityIds.ts
+++ b/src/utils/server/reconcileCanonicalEntityIds.ts
@@ -10,6 +10,22 @@ import { analysisClearServerCache } from '@/lib/api/analysis';
 import { useAuthStore } from '@/store/authStore';
 import { useLocalPlaybackStore, type LocalPlaybackEntry } from '@/store/localPlaybackStore';
 import { useOfflineStore, type OfflineAlbumMeta } from '@/features/offline';
+import {
+  cancelAndDrainOfflinePinQueue,
+  resumeOfflinePinQueue,
+} from '@/features/offline/utils/offlinePinQueue';
+import {
+  pauseAndDrainPinnedOfflineSync,
+  resumePinnedOfflineSync,
+} from '@/features/offline/utils/pinnedOfflineSync';
+import {
+  pauseAndDrainFavoritesOfflineSync,
+  resumeFavoritesOfflineSync,
+} from '@/features/offline/utils/favoritesOfflineSync';
+import {
+  pauseAndDrainLocalPlaybackInvalidation,
+  resumeLocalPlaybackInvalidation,
+} from '@/localPlaybackInvalidation';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
 import {
   readShuffleModeSnapshot,
@@ -25,20 +41,36 @@ import {
 } from '@/features/playlist';
 import { clearLyricsCache } from '@/features/lyrics/utils/lyricsPersistentCache';
 import type { ServerProfile } from '@/store/authStoreTypes';
-import { useMigrationStore } from '@/store/migrationStore';
+import {
+  enqueueBlockingMigration,
+  type BlockingMigrationContext,
+} from '@/store/migrationCoordinator';
 import { usePlaylistMembershipStore } from '@/store/playlistMembershipStore';
+import { skipStarCountStorageKey } from '@/store/authStoreHelpers';
+import { useLibraryIndexStore } from '@/store/libraryIndexStore';
+import { runMusicLibraryCatalogReloadHandler } from '@/store/musicLibraryFilterNotify';
 import { mergeLocalPlaybackEntry, mergeOfflineAlbum } from './rewriteFrontendStoreKeys';
 import { serverIndexKeyForProfile } from '@/lib/server/serverIndexKey';
 import {
   activateCanonicalNavidromeOwners,
   canonicalizeNavidromeId,
 } from '@/lib/server/navidromeCanonicalIds';
-
-const reconciliationInFlight = new Map<string, Promise<void>>();
-let canonicalMigrationSerial: Promise<void> = Promise.resolve();
-let retryRequest: { server: ServerProfile; serverIndexKey: string } | null = null;
+import {
+  getTimelineSessionHistorySnapshot,
+  rewriteTimelineSessionHistoryForOwners,
+} from '@/features/playback/store/timelineSessionHistory';
 
 export { canonicalizeNavidromeId } from '@/lib/server/navidromeCanonicalIds';
+
+function isDeterministicProbeProgress(status: { state: string; lastError: string | null }): boolean {
+  if (status.state !== 'retryable') return false;
+  return status.lastError?.includes('inactive alias baseline is still progressing') === true
+    || status.lastError?.includes('candidate scan has more catalog rows to inspect') === true;
+}
+
+async function yieldToRenderer(): Promise<void> {
+  await new Promise<void>(resolve => setTimeout(resolve, 0));
+}
 
 function isOwnedBy(serverId: string | null | undefined, owners: Set<string>): boolean {
   return !!serverId && owners.has(serverId);
@@ -94,6 +126,9 @@ function collectProbeCandidates(owners: Set<string>): IdentityProbeCandidateDto[
   for (const item of player.queueItems) {
     if (isOwnedBy(item.serverId, owners)) add(tracks, item.trackId);
   }
+  for (const item of getTimelineSessionHistorySnapshot()) {
+    if (isOwnedBy(item.serverId, owners)) add(tracks, item.trackId);
+  }
   for (const entry of Object.values(useLocalPlaybackStore.getState().entries)) {
     if (!owners.has(entry.serverIndexKey)) continue;
     add(tracks, entry.trackId);
@@ -123,7 +158,33 @@ function rewritePlayer(owners: Set<string>): ShuffleModeSnapshot {
     const queueItems = state.queueItems.map(item => isOwnedBy(item.serverId, owners)
       ? { ...item, trackId: canonicalizeNavidromeId(item.trackId) }
       : item);
-    return { currentTrack, queueItems };
+    const sortedOwners = [...owners].sort((a, b) => b.length - a.length);
+    const rewriteOverrides = <T>(overrides: Record<string, T>): Record<string, T> => {
+      const next: Record<string, T> = {};
+      const legacy: Array<[string, T]> = [];
+      for (const [key, value] of Object.entries(overrides)) {
+        const owner = sortedOwners.find(candidate => key.startsWith(`${candidate}:`));
+        if (!owner) {
+          next[key] = value;
+          continue;
+        }
+        const id = key.slice(owner.length + 1);
+        const canonicalId = canonicalizeNavidromeId(id);
+        const nextKey = `${owner}:${canonicalId}`;
+        if (canonicalId === id) next[nextKey] = value;
+        else legacy.push([nextKey, value]);
+      }
+      for (const [key, value] of legacy) {
+        if (!(key in next)) next[key] = value;
+      }
+      return next;
+    };
+    return {
+      currentTrack,
+      queueItems,
+      starredOverrides: rewriteOverrides(state.starredOverrides),
+      userRatingOverrides: rewriteOverrides(state.userRatingOverrides),
+    };
   });
 
   const shuffle = readShuffleModeSnapshot();
@@ -204,6 +265,19 @@ function rewriteAuthState(owners: Set<string>): void {
     const libraryBrowseSelectionByServer = { ...state.libraryBrowseSelectionByServer };
     const musicLibraryFilterByServer = { ...state.musicLibraryFilterByServer };
     const musicLibrarySelectionByServer = { ...state.musicLibrarySelectionByServer };
+    const skipStarManualSkipCountsByKey: Record<string, number> = {};
+    for (const [key, count] of Object.entries(state.skipStarManualSkipCountsByKey)) {
+      const separator = key.indexOf('\u001f');
+      const owner = separator >= 0 ? key.slice(0, separator) : '';
+      const trackId = separator >= 0 ? key.slice(separator + 1) : key;
+      const nextKey = owners.has(owner)
+        ? skipStarCountStorageKey(owner, canonicalizeNavidromeId(trackId))
+        : key;
+      skipStarManualSkipCountsByKey[nextKey] = Math.max(
+        skipStarManualSkipCountsByKey[nextKey] ?? 0,
+        count,
+      );
+    }
     for (const owner of owners) {
       if (musicFoldersByServer[owner]) {
         musicFoldersByServer[owner] = rewriteFolders(musicFoldersByServer[owner]);
@@ -225,23 +299,28 @@ function rewriteAuthState(owners: Set<string>): void {
       ? rewriteFolders(state.musicFolders)
       : state.musicFolders;
     return {
-      skipStarManualSkipCountsByKey: {},
+      skipStarManualSkipCountsByKey,
       musicFolders,
       musicFoldersByServer,
       libraryBrowseSelectionByServer,
       musicLibraryFilterByServer,
       musicLibrarySelectionByServer,
+      musicLibraryFilterVersion: state.musicLibraryFilterVersion + 1,
+      libraryBrowseScopeVersion: state.libraryBrowseScopeVersion + 1,
     };
   });
+  const auth = useAuthStore.getState();
+  for (const profile of auth.servers) {
+    if (!owners.has(profile.id) && !owners.has(serverIndexKeyForProfile(profile))) continue;
+    runMusicLibraryCatalogReloadHandler(
+      profile.id,
+      useLibraryIndexStore.getState().isIndexEnabled(profile.id),
+      auth.musicLibraryFilterVersion,
+    );
+  }
 }
 
 function rewriteDeviceSync(owners: Set<string>, serverIndexKey: string): void {
-  const legacySources = useDeviceSyncStore.getState().legacySources;
-  if (legacySources.length > 0) {
-    throw new Error(
-      'Device Sync has ownerless legacy selections. Open Device Sync and add a source to recover them, then retry.',
-    );
-  }
   useDeviceSyncStore.setState(state => {
     const byKey = new Map<string, (typeof state.sources)[number]>();
     for (const source of state.sources) {
@@ -295,6 +374,7 @@ function verifyPersistence(expectedShuffle: ShuffleModeSnapshot): void {
     ['psysonic-local-playback', 'entries', useLocalPlaybackStore.getState().entries],
     ['psysonic-offline', 'albums', useOfflineStore.getState().albums],
     ['psysonic-auth', 'musicFoldersByServer', useAuthStore.getState().musicFoldersByServer],
+    ['psysonic-auth', 'skipStarManualSkipCountsByKey', useAuthStore.getState().skipStarManualSkipCountsByKey],
     ['psysonic-auth', 'libraryBrowseSelectionByServer', useAuthStore.getState().libraryBrowseSelectionByServer],
     ['psysonic-auth', 'musicLibraryFilterByServer', useAuthStore.getState().musicLibraryFilterByServer],
     ['psysonic-auth', 'musicLibrarySelectionByServer', useAuthStore.getState().musicLibrarySelectionByServer],
@@ -331,6 +411,18 @@ function assertCanonicalOwnedState(owners: Set<string>): void {
   for (const item of player.queueItems) {
     if (isOwnedBy(item.serverId, owners)) check('queue', item.trackId);
   }
+  for (const item of getTimelineSessionHistorySnapshot()) {
+    if (isOwnedBy(item.serverId, owners)) check('timeline', item.trackId);
+  }
+  const sortedOwners = [...owners].sort((a, b) => b.length - a.length);
+  for (const key of Object.keys(player.starredOverrides)) {
+    const owner = sortedOwners.find(candidate => key.startsWith(`${candidate}:`));
+    if (owner) check('starredOverride', key.slice(owner.length + 1));
+  }
+  for (const key of Object.keys(player.userRatingOverrides)) {
+    const owner = sortedOwners.find(candidate => key.startsWith(`${candidate}:`));
+    if (owner) check('ratingOverride', key.slice(owner.length + 1));
+  }
   for (const entry of Object.values(useLocalPlaybackStore.getState().entries)) {
     if (!owners.has(entry.serverIndexKey)) continue;
     check('localPlayback', entry.trackId);
@@ -342,6 +434,11 @@ function assertCanonicalOwnedState(owners: Set<string>): void {
     for (const trackId of album.trackIds) check('offlineTrack', trackId);
   }
   const auth = useAuthStore.getState();
+  for (const key of Object.keys(auth.skipStarManualSkipCountsByKey)) {
+    const separator = key.indexOf('\u001f');
+    const owner = separator >= 0 ? key.slice(0, separator) : '';
+    if (owners.has(owner)) check('skipStar', separator >= 0 ? key.slice(separator + 1) : key);
+  }
   if (owners.has(auth.activeServerId ?? '')) {
     for (const folder of auth.musicFolders) check('activeMusicFolder', folder.id);
   }
@@ -353,7 +450,6 @@ function assertCanonicalOwnedState(owners: Set<string>): void {
     if (filter && filter !== 'all') check('libraryFilter', filter);
   }
   const device = useDeviceSyncStore.getState();
-  if (device.legacySources.length > 0) legacyIds.push('deviceSync:ownerless');
   for (const source of device.sources) {
     if (owners.has(source.serverIndexKey)) check('deviceSync', source.id);
   }
@@ -369,6 +465,7 @@ function assertCanonicalOwnedState(owners: Set<string>): void {
 async function runCanonicalIdentityTransition(
   server: ServerProfile,
   serverIndexKey: string,
+  context: BlockingMigrationContext,
 ): Promise<void> {
   await ensureHydrated();
   const owners = new Set([
@@ -385,7 +482,10 @@ async function runCanonicalIdentityTransition(
     || status.state === 'awaiting_supplemental_probe'
     || status.state === 'retryable'
   ) {
-    status = await libraryIdentityTransitionProbe(serverIndexKey, probeCandidates);
+    do {
+      status = await libraryIdentityTransitionProbe(serverIndexKey, probeCandidates);
+      if (isDeterministicProbeProgress(status)) await yieldToRenderer();
+    } while (isDeterministicProbeProgress(status));
   }
   if (status.state === 'ready') {
     activateCanonicalNavidromeOwners(owners);
@@ -396,17 +496,29 @@ async function runCanonicalIdentityTransition(
     throw new Error(status.lastError ?? 'Canonical-ID probe remains inconclusive');
   }
 
-  const migration = useMigrationStore.getState();
-  retryRequest = { server, serverIndexKey };
-  migration.setStep('canonicalIds');
-  migration.setNeedsMigration(true);
-  migration.setError(null);
-  migration.setPhase('running');
+  context.setView({ step: 'canonicalIds', needsMigration: true, phase: 'running' });
 
-  try {
-    if (status.state === 'blocked') {
-      throw new Error(status.lastError ?? 'Canonical-ID transition is blocked');
+  if (status.state === 'blocked') {
+    throw new Error(status.lastError ?? 'Canonical-ID transition is blocked');
+  }
+  const needsOfflineBarrier = status.state === 'transition_detected' || status.state === 'pending_frontend';
+  if (needsOfflineBarrier) {
+    const pauseResults = await Promise.allSettled([
+      cancelAndDrainOfflinePinQueue(),
+      pauseAndDrainPinnedOfflineSync(),
+      pauseAndDrainFavoritesOfflineSync(),
+      pauseAndDrainLocalPlaybackInvalidation(),
+    ]);
+    const pauseFailure = pauseResults.find(result => result.status === 'rejected');
+    if (pauseFailure?.status === 'rejected') {
+      resumeFavoritesOfflineSync();
+      resumePinnedOfflineSync();
+      resumeOfflinePinQueue();
+      resumeLocalPlaybackInvalidation();
+      throw pauseFailure.reason;
     }
+  }
+  try {
     if (status.state === 'transition_detected') {
       status = await libraryIdentityTransitionRunNativeMigration(serverIndexKey);
     }
@@ -424,18 +536,17 @@ async function runCanonicalIdentityTransition(
     rewriteAuthState(owners);
     rewriteDeviceSync(owners, serverIndexKey);
     rewritePlaylists(owners);
+    rewriteTimelineSessionHistoryForOwners(owners, serverIndexKey);
     assertCanonicalOwnedState(owners);
     verifyPersistence(expectedShuffle);
     await libraryIdentityTransitionAck(serverIndexKey);
-
-    retryRequest = null;
-    migration.setNeedsMigration(false);
-    migration.setStep(null);
-    migration.setPhase('completed');
-  } catch (error) {
-    migration.setError(error instanceof Error ? error.message : String(error));
-    migration.setPhase('error');
-    throw error;
+  } finally {
+    if (needsOfflineBarrier) {
+      resumeFavoritesOfflineSync();
+      resumePinnedOfflineSync();
+      resumeOfflinePinQueue();
+      resumeLocalPlaybackInvalidation();
+    }
   }
 }
 
@@ -443,21 +554,23 @@ export async function reconcileCanonicalEntityIds(
   server: ServerProfile,
   serverIndexKey: string,
 ): Promise<void> {
-  const existing = reconciliationInFlight.get(serverIndexKey);
-  if (existing) return existing;
-  const promise = canonicalMigrationSerial
-    .catch(() => undefined)
-    .then(() => runCanonicalIdentityTransition(server, serverIndexKey));
-  canonicalMigrationSerial = promise.catch(() => undefined);
-  const tracked = promise.finally(() => {
-    reconciliationInFlight.delete(serverIndexKey);
+  return enqueueBlockingMigration({
+    id: `canonical-ids:${serverIndexKey}`,
+    step: 'canonicalIds',
+    initialPhase: 'idle',
+    retry: () => {
+      void reconcileCanonicalEntityIds(server, serverIndexKey).catch(() => {});
+    },
+    run: context => runCanonicalIdentityTransition(server, serverIndexKey, context),
   });
-  reconciliationInFlight.set(serverIndexKey, tracked);
-  return tracked;
 }
 
-export function retryCanonicalIdentityMigration(): void {
-  const request = retryRequest;
-  if (!request) return;
-  void reconcileCanonicalEntityIds(request.server, request.serverIndexKey).catch(() => {});
+/** Complete or reactivate a durable transition without requiring server reachability. */
+export async function restoreCanonicalEntityIdsFromLocalState(
+  server: ServerProfile,
+  serverIndexKey: string,
+): Promise<void> {
+  const status = await libraryIdentityTransitionStatus(serverIndexKey);
+  if (!['transition_detected', 'pending_frontend', 'ready'].includes(status.state)) return;
+  await reconcileCanonicalEntityIds(server, serverIndexKey);
 }

--- a/src/utils/server/reconcileCanonicalEntityIds.ts
+++ b/src/utils/server/reconcileCanonicalEntityIds.ts
@@ -1,0 +1,463 @@
+import type { Track } from '@/lib/media/trackTypes';
+import {
+  libraryIdentityTransitionAck,
+  libraryIdentityTransitionProbe,
+  libraryIdentityTransitionRunNativeMigration,
+  libraryIdentityTransitionStatus,
+  type IdentityProbeCandidateDto,
+} from '@/lib/api/library';
+import { analysisClearServerCache } from '@/lib/api/analysis';
+import { useAuthStore } from '@/store/authStore';
+import { useLocalPlaybackStore, type LocalPlaybackEntry } from '@/store/localPlaybackStore';
+import { useOfflineStore, type OfflineAlbumMeta } from '@/features/offline';
+import { usePlayerStore } from '@/features/playback/store/playerStore';
+import {
+  readShuffleModeSnapshot,
+  persistShuffleModeSnapshot,
+  type ShuffleModeSnapshot,
+} from '@/features/playback/store/shuffleModeStorage';
+import { setShuffleOriginalOrder } from '@/features/playback/store/shuffleModeActions';
+import { useDeviceSyncStore, deviceSyncSourceKey } from '@/features/deviceSync';
+import {
+  invalidatePlaylistRequestsForIdentityTransition,
+  usePlaylistFolderStore,
+  usePlaylistStore,
+} from '@/features/playlist';
+import { clearLyricsCache } from '@/features/lyrics/utils/lyricsPersistentCache';
+import type { ServerProfile } from '@/store/authStoreTypes';
+import { useMigrationStore } from '@/store/migrationStore';
+import { usePlaylistMembershipStore } from '@/store/playlistMembershipStore';
+import { mergeLocalPlaybackEntry, mergeOfflineAlbum } from './rewriteFrontendStoreKeys';
+import { serverIndexKeyForProfile } from '@/lib/server/serverIndexKey';
+import {
+  activateCanonicalNavidromeOwners,
+  canonicalizeNavidromeId,
+} from '@/lib/server/navidromeCanonicalIds';
+
+const reconciliationInFlight = new Map<string, Promise<void>>();
+let canonicalMigrationSerial: Promise<void> = Promise.resolve();
+let retryRequest: { server: ServerProfile; serverIndexKey: string } | null = null;
+
+export { canonicalizeNavidromeId } from '@/lib/server/navidromeCanonicalIds';
+
+function isOwnedBy(serverId: string | null | undefined, owners: Set<string>): boolean {
+  return !!serverId && owners.has(serverId);
+}
+
+function canonicalizeTrack(track: Track): Track {
+  return {
+    ...track,
+    id: canonicalizeNavidromeId(track.id),
+    albumId: canonicalizeNavidromeId(track.albumId),
+    artistId: track.artistId ? canonicalizeNavidromeId(track.artistId) : track.artistId,
+    coverArt: track.coverArt ? canonicalizeNavidromeId(track.coverArt) : track.coverArt,
+    artists: track.artists?.map(artist => ({
+      ...artist,
+      id: artist.id ? canonicalizeNavidromeId(artist.id) : artist.id,
+    })),
+  };
+}
+
+function canonicalizeOfflineAlbum(meta: OfflineAlbumMeta): OfflineAlbumMeta {
+  return {
+    ...meta,
+    id: canonicalizeNavidromeId(meta.id),
+    coverArt: meta.coverArt ? canonicalizeNavidromeId(meta.coverArt) : meta.coverArt,
+    trackIds: [...new Set(meta.trackIds.map(canonicalizeNavidromeId))],
+  };
+}
+
+async function ensureHydrated(): Promise<void> {
+  await Promise.all([
+    useAuthStore.persist.hasHydrated() ? undefined : useAuthStore.persist.rehydrate(),
+    usePlayerStore.persist.hasHydrated() ? undefined : usePlayerStore.persist.rehydrate(),
+    useLocalPlaybackStore.persist.hasHydrated() ? undefined : useLocalPlaybackStore.persist.rehydrate(),
+    useOfflineStore.persist.hasHydrated() ? undefined : useOfflineStore.persist.rehydrate(),
+    useDeviceSyncStore.persist.hasHydrated() ? undefined : useDeviceSyncStore.persist.rehydrate(),
+    usePlaylistStore.persist.hasHydrated() ? undefined : usePlaylistStore.persist.rehydrate(),
+    usePlaylistFolderStore.persist.hasHydrated() ? undefined : usePlaylistFolderStore.persist.rehydrate(),
+  ]);
+}
+
+function collectProbeCandidates(owners: Set<string>): IdentityProbeCandidateDto[] {
+  const tracks = new Set<string>();
+  const albums = new Set<string>();
+  const add = (target: Set<string>, id: string | null | undefined): void => {
+    if (id && canonicalizeNavidromeId(id) !== id) target.add(id);
+  };
+  const player = usePlayerStore.getState();
+  const currentOwner = player.currentTrack?.serverId ?? player.queueServerId;
+  if (player.currentTrack && isOwnedBy(currentOwner, owners)) {
+    add(tracks, player.currentTrack.id);
+    add(albums, player.currentTrack.albumId);
+  }
+  for (const item of player.queueItems) {
+    if (isOwnedBy(item.serverId, owners)) add(tracks, item.trackId);
+  }
+  for (const entry of Object.values(useLocalPlaybackStore.getState().entries)) {
+    if (!owners.has(entry.serverIndexKey)) continue;
+    add(tracks, entry.trackId);
+    if (entry.pinSource?.kind === 'album') add(albums, entry.pinSource.sourceId);
+  }
+  for (const album of Object.values(useOfflineStore.getState().albums)) {
+    if (!owners.has(album.serverId)) continue;
+    add(albums, album.id);
+    for (const trackId of album.trackIds) add(tracks, trackId);
+  }
+  for (const source of useDeviceSyncStore.getState().sources) {
+    if (!owners.has(source.serverIndexKey)) continue;
+    if (source.type === 'album') add(albums, source.id);
+  }
+  return [
+    ...[...tracks].slice(0, 4).map(id => ({ entityKind: 'track' as const, id })),
+    ...[...albums].slice(0, 4).map(id => ({ entityKind: 'album' as const, id })),
+  ];
+}
+
+function rewritePlayer(owners: Set<string>): ShuffleModeSnapshot {
+  usePlayerStore.setState(state => {
+    const currentOwner = state.currentTrack?.serverId ?? state.queueServerId;
+    const currentTrack = state.currentTrack && isOwnedBy(currentOwner, owners)
+      ? canonicalizeTrack(state.currentTrack)
+      : state.currentTrack;
+    const queueItems = state.queueItems.map(item => isOwnedBy(item.serverId, owners)
+      ? { ...item, trackId: canonicalizeNavidromeId(item.trackId) }
+      : item);
+    return { currentTrack, queueItems };
+  });
+
+  const shuffle = readShuffleModeSnapshot();
+  if (!shuffle.enabled) return shuffle;
+  const originalOrder = shuffle.originalOrder.map(identity => {
+    try {
+      const parsed = JSON.parse(identity) as unknown;
+      if (
+        Array.isArray(parsed)
+        && parsed.length === 2
+        && typeof parsed[0] === 'string'
+        && typeof parsed[1] === 'string'
+        && owners.has(parsed[0])
+      ) {
+        return JSON.stringify([parsed[0], canonicalizeNavidromeId(parsed[1])]);
+      }
+    } catch {
+      // Legacy ownerless identities cannot be assigned safely here.
+    }
+    return identity;
+  });
+  const rewritten = { ...shuffle, originalOrder };
+  setShuffleOriginalOrder(originalOrder);
+  persistShuffleModeSnapshot(rewritten);
+  return rewritten;
+}
+
+function rewriteLocalPlayback(owners: Set<string>, serverIndexKey: string): void {
+  useLocalPlaybackStore.setState(state => {
+    const entries = { ...state.entries };
+    for (const [key, entry] of Object.entries(state.entries)) {
+      if (!owners.has(entry.serverIndexKey)) continue;
+      const trackId = canonicalizeNavidromeId(entry.trackId);
+      const nextKey = `${serverIndexKey}:${trackId}`;
+      const incoming: LocalPlaybackEntry = {
+        ...entry,
+        serverIndexKey,
+        trackId,
+        pinSource: entry.pinSource ? {
+          ...entry.pinSource,
+          sourceId: canonicalizeNavidromeId(entry.pinSource.sourceId),
+        } : undefined,
+      };
+      const existing = entries[nextKey];
+      entries[nextKey] = existing
+        ? mergeLocalPlaybackEntry(existing, incoming, serverIndexKey)
+        : incoming;
+      if (key !== nextKey) delete entries[key];
+    }
+    return { entries };
+  });
+}
+
+function rewriteOffline(owners: Set<string>, serverIndexKey: string): void {
+  useOfflineStore.setState(state => {
+    const albums = { ...state.albums };
+    for (const [key, meta] of Object.entries(state.albums)) {
+      if (!owners.has(meta.serverId)) continue;
+      const incoming = { ...canonicalizeOfflineAlbum(meta), serverId: serverIndexKey };
+      const nextKey = `${serverIndexKey}:${incoming.id}`;
+      const existing = albums[nextKey];
+      albums[nextKey] = existing
+        ? mergeOfflineAlbum(existing, incoming, serverIndexKey)
+        : incoming;
+      if (key !== nextKey) delete albums[key];
+    }
+    return { albums };
+  });
+}
+
+function rewriteAuthState(owners: Set<string>): void {
+  useAuthStore.setState(state => {
+    const rewriteFolders = (folders: Array<{ id: string; name: string }>) => folders.map(folder => ({
+      ...folder,
+      id: canonicalizeNavidromeId(folder.id),
+    }));
+    const musicFoldersByServer = { ...state.musicFoldersByServer };
+    const libraryBrowseSelectionByServer = { ...state.libraryBrowseSelectionByServer };
+    const musicLibraryFilterByServer = { ...state.musicLibraryFilterByServer };
+    const musicLibrarySelectionByServer = { ...state.musicLibrarySelectionByServer };
+    for (const owner of owners) {
+      if (musicFoldersByServer[owner]) {
+        musicFoldersByServer[owner] = rewriteFolders(musicFoldersByServer[owner]);
+      }
+      if (libraryBrowseSelectionByServer[owner]) {
+        libraryBrowseSelectionByServer[owner] = libraryBrowseSelectionByServer[owner]
+          .map(canonicalizeNavidromeId);
+      }
+      const filter = musicLibraryFilterByServer[owner];
+      if (filter && filter !== 'all') {
+        musicLibraryFilterByServer[owner] = canonicalizeNavidromeId(filter);
+      }
+      if (musicLibrarySelectionByServer[owner]) {
+        musicLibrarySelectionByServer[owner] = musicLibrarySelectionByServer[owner]
+          .map(canonicalizeNavidromeId);
+      }
+    }
+    const musicFolders = owners.has(state.activeServerId ?? '')
+      ? rewriteFolders(state.musicFolders)
+      : state.musicFolders;
+    return {
+      skipStarManualSkipCountsByKey: {},
+      musicFolders,
+      musicFoldersByServer,
+      libraryBrowseSelectionByServer,
+      musicLibraryFilterByServer,
+      musicLibrarySelectionByServer,
+    };
+  });
+}
+
+function rewriteDeviceSync(owners: Set<string>, serverIndexKey: string): void {
+  const legacySources = useDeviceSyncStore.getState().legacySources;
+  if (legacySources.length > 0) {
+    throw new Error(
+      'Device Sync has ownerless legacy selections. Open Device Sync and add a source to recover them, then retry.',
+    );
+  }
+  useDeviceSyncStore.setState(state => {
+    const byKey = new Map<string, (typeof state.sources)[number]>();
+    for (const source of state.sources) {
+      const next = owners.has(source.serverIndexKey)
+        ? { ...source, serverIndexKey, id: canonicalizeNavidromeId(source.id) }
+        : source;
+      byKey.set(deviceSyncSourceKey(next), next);
+    }
+    return { sources: [...byKey.values()] };
+  });
+}
+
+function rewritePlaylists(owners: Set<string>): void {
+  // The playlist list and recency metadata are server-derived caches. Drop
+  // them instead of carrying more migration rules; the next page visit refetches.
+  usePlaylistStore.setState({
+    playlists: [],
+    recentIds: [],
+    lastModified: {},
+    playlistsLoading: false,
+  });
+  usePlaylistMembershipStore.getState().clearAllPlaylistSongIds();
+
+  usePlaylistFolderStore.setState(state => {
+    const byServer = { ...state.byServer };
+    for (const owner of owners) {
+      const server = byServer[owner];
+      if (!server) continue;
+      const assignments: Record<string, string> = {};
+      for (const [playlistId, folderId] of Object.entries(server.assignments)) {
+        assignments[canonicalizeNavidromeId(playlistId)] ??= folderId;
+      }
+      byServer[owner] = { ...server, assignments };
+    }
+    return { byServer };
+  });
+}
+
+function persistedState(key: string): Record<string, unknown> {
+  const raw = localStorage.getItem(key);
+  if (!raw) throw new Error(`canonical-ID reconciliation did not persist ${key}`);
+  const parsed = JSON.parse(raw) as { state?: Record<string, unknown> };
+  if (!parsed.state) throw new Error(`canonical-ID reconciliation found invalid ${key}`);
+  return parsed.state;
+}
+
+function verifyPersistence(expectedShuffle: ShuffleModeSnapshot): void {
+  const checks: Array<[string, string, unknown]> = [
+    ['psysonic-player', 'currentTrack', usePlayerStore.getState().currentTrack],
+    ['psysonic-player', 'queueItems', usePlayerStore.getState().queueItems],
+    ['psysonic-local-playback', 'entries', useLocalPlaybackStore.getState().entries],
+    ['psysonic-offline', 'albums', useOfflineStore.getState().albums],
+    ['psysonic-auth', 'musicFoldersByServer', useAuthStore.getState().musicFoldersByServer],
+    ['psysonic-auth', 'libraryBrowseSelectionByServer', useAuthStore.getState().libraryBrowseSelectionByServer],
+    ['psysonic-auth', 'musicLibraryFilterByServer', useAuthStore.getState().musicLibraryFilterByServer],
+    ['psysonic-auth', 'musicLibrarySelectionByServer', useAuthStore.getState().musicLibrarySelectionByServer],
+    ['psysonic_device_sync', 'sources', useDeviceSyncStore.getState().sources],
+    ['psysonic_device_sync', 'legacySources', useDeviceSyncStore.getState().legacySources],
+    ['psysonic_playlists_recent', 'playlists', usePlaylistStore.getState().playlists],
+    ['psysonic_playlists_recent', 'recentIds', usePlaylistStore.getState().recentIds],
+    ['psysonic_playlists_recent', 'lastModified', usePlaylistStore.getState().lastModified],
+    ['psysonic_playlist_folders', 'byServer', usePlaylistFolderStore.getState().byServer],
+  ];
+  for (const [storageKey, field, expected] of checks) {
+    const actual = persistedState(storageKey)[field];
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`canonical-ID reconciliation could not verify ${storageKey}.${field}`);
+    }
+  }
+  if (JSON.stringify(readShuffleModeSnapshot()) !== JSON.stringify(expectedShuffle)) {
+    throw new Error('canonical-ID reconciliation could not verify shuffle state');
+  }
+}
+
+function assertCanonicalOwnedState(owners: Set<string>): void {
+  const legacyIds: string[] = [];
+  const check = (label: string, id: string | null | undefined): void => {
+    if (id && canonicalizeNavidromeId(id) !== id) legacyIds.push(`${label}:${id}`);
+  };
+  const player = usePlayerStore.getState();
+  const currentOwner = player.currentTrack?.serverId ?? player.queueServerId;
+  if (player.currentTrack && isOwnedBy(currentOwner, owners)) {
+    check('currentTrack', player.currentTrack.id);
+    check('currentAlbum', player.currentTrack.albumId);
+    check('currentArtist', player.currentTrack.artistId);
+  }
+  for (const item of player.queueItems) {
+    if (isOwnedBy(item.serverId, owners)) check('queue', item.trackId);
+  }
+  for (const entry of Object.values(useLocalPlaybackStore.getState().entries)) {
+    if (!owners.has(entry.serverIndexKey)) continue;
+    check('localPlayback', entry.trackId);
+    check('localPlaybackSource', entry.pinSource?.sourceId);
+  }
+  for (const album of Object.values(useOfflineStore.getState().albums)) {
+    if (!owners.has(album.serverId)) continue;
+    check('offlineAlbum', album.id);
+    for (const trackId of album.trackIds) check('offlineTrack', trackId);
+  }
+  const auth = useAuthStore.getState();
+  if (owners.has(auth.activeServerId ?? '')) {
+    for (const folder of auth.musicFolders) check('activeMusicFolder', folder.id);
+  }
+  for (const owner of owners) {
+    for (const folder of auth.musicFoldersByServer[owner] ?? []) check('musicFolder', folder.id);
+    for (const folderId of auth.libraryBrowseSelectionByServer[owner] ?? []) check('browseFolder', folderId);
+    for (const folderId of auth.musicLibrarySelectionByServer[owner] ?? []) check('libraryFolder', folderId);
+    const filter = auth.musicLibraryFilterByServer[owner];
+    if (filter && filter !== 'all') check('libraryFilter', filter);
+  }
+  const device = useDeviceSyncStore.getState();
+  if (device.legacySources.length > 0) legacyIds.push('deviceSync:ownerless');
+  for (const source of device.sources) {
+    if (owners.has(source.serverIndexKey)) check('deviceSync', source.id);
+  }
+  for (const owner of owners) {
+    const folders = usePlaylistFolderStore.getState().byServer[owner];
+    for (const playlistId of Object.keys(folders?.assignments ?? {})) check('playlistFolder', playlistId);
+  }
+  if (legacyIds.length > 0) {
+    throw new Error(`Canonical-ID reconciliation left legacy references: ${legacyIds.slice(0, 5).join(', ')}`);
+  }
+}
+
+async function runCanonicalIdentityTransition(
+  server: ServerProfile,
+  serverIndexKey: string,
+): Promise<void> {
+  await ensureHydrated();
+  const owners = new Set([
+    server.id,
+    serverIndexKey,
+    ...useAuthStore.getState().servers
+      .filter(profile => serverIndexKeyForProfile(profile) === serverIndexKey)
+      .map(profile => profile.id),
+  ]);
+  let status = await libraryIdentityTransitionStatus(serverIndexKey);
+  const probeCandidates = collectProbeCandidates(owners);
+  if (
+    status.state === 'unseen'
+    || status.state === 'awaiting_supplemental_probe'
+    || status.state === 'retryable'
+  ) {
+    status = await libraryIdentityTransitionProbe(serverIndexKey, probeCandidates);
+  }
+  if (status.state === 'ready') {
+    activateCanonicalNavidromeOwners(owners);
+    return;
+  }
+  if (status.state === 'legacy' || status.state === 'no_legacy_ids') return;
+  if (status.state === 'retryable' || status.state === 'awaiting_supplemental_probe') {
+    throw new Error(status.lastError ?? 'Canonical-ID probe remains inconclusive');
+  }
+
+  const migration = useMigrationStore.getState();
+  retryRequest = { server, serverIndexKey };
+  migration.setStep('canonicalIds');
+  migration.setNeedsMigration(true);
+  migration.setError(null);
+  migration.setPhase('running');
+
+  try {
+    if (status.state === 'blocked') {
+      throw new Error(status.lastError ?? 'Canonical-ID transition is blocked');
+    }
+    if (status.state === 'transition_detected') {
+      status = await libraryIdentityTransitionRunNativeMigration(serverIndexKey);
+    }
+    if (status.state !== 'pending_frontend') {
+      throw new Error(`Unexpected canonical-ID transition state: ${status.state}`);
+    }
+
+    activateCanonicalNavidromeOwners(owners);
+    invalidatePlaylistRequestsForIdentityTransition();
+    await analysisClearServerCache(serverIndexKey);
+    await clearLyricsCache();
+    const expectedShuffle = rewritePlayer(owners);
+    rewriteLocalPlayback(owners, serverIndexKey);
+    rewriteOffline(owners, serverIndexKey);
+    rewriteAuthState(owners);
+    rewriteDeviceSync(owners, serverIndexKey);
+    rewritePlaylists(owners);
+    assertCanonicalOwnedState(owners);
+    verifyPersistence(expectedShuffle);
+    await libraryIdentityTransitionAck(serverIndexKey);
+
+    retryRequest = null;
+    migration.setNeedsMigration(false);
+    migration.setStep(null);
+    migration.setPhase('completed');
+  } catch (error) {
+    migration.setError(error instanceof Error ? error.message : String(error));
+    migration.setPhase('error');
+    throw error;
+  }
+}
+
+export async function reconcileCanonicalEntityIds(
+  server: ServerProfile,
+  serverIndexKey: string,
+): Promise<void> {
+  const existing = reconciliationInFlight.get(serverIndexKey);
+  if (existing) return existing;
+  const promise = canonicalMigrationSerial
+    .catch(() => undefined)
+    .then(() => runCanonicalIdentityTransition(server, serverIndexKey));
+  canonicalMigrationSerial = promise.catch(() => undefined);
+  const tracked = promise.finally(() => {
+    reconciliationInFlight.delete(serverIndexKey);
+  });
+  reconciliationInFlight.set(serverIndexKey, tracked);
+  return tracked;
+}
+
+export function retryCanonicalIdentityMigration(): void {
+  const request = retryRequest;
+  if (!request) return;
+  void reconcileCanonicalEntityIds(request.server, request.serverIndexKey).catch(() => {});
+}

--- a/src/utils/server/rewriteFrontendStoreKeys.ts
+++ b/src/utils/server/rewriteFrontendStoreKeys.ts
@@ -43,7 +43,7 @@ function matchCompositeKey(key: string, mappings: Mapping[]): (Mapping & { suffi
   return { ...matched, suffix: key.slice(matched.legacyId.length + 1) };
 }
 
-function mergeOfflineAlbum(
+export function mergeOfflineAlbum(
   existing: OfflineAlbumMeta,
   incoming: OfflineAlbumMeta,
   serverId: string,
@@ -62,13 +62,17 @@ const LOCAL_PLAYBACK_TIER_PRIORITY: Record<LocalPlaybackTier, number> = {
   library: 2,
 };
 
-function mergeLocalPlaybackEntry(
+export function mergeLocalPlaybackEntry(
   existing: LocalPlaybackEntry,
   incoming: LocalPlaybackEntry,
   serverIndexKey: string,
 ): LocalPlaybackEntry {
   const incomingWins =
-    LOCAL_PLAYBACK_TIER_PRIORITY[incoming.tier] > LOCAL_PLAYBACK_TIER_PRIORITY[existing.tier];
+    LOCAL_PLAYBACK_TIER_PRIORITY[incoming.tier] > LOCAL_PLAYBACK_TIER_PRIORITY[existing.tier]
+    || (
+      LOCAL_PLAYBACK_TIER_PRIORITY[incoming.tier] === LOCAL_PLAYBACK_TIER_PRIORITY[existing.tier]
+      && incoming.cachedAt > existing.cachedAt
+    );
   const winner = incomingWins ? incoming : existing;
   const other = incomingWins ? existing : incoming;
   return {


### PR DESCRIPTION
## Summary

- Detect Navidrome's canonical entity-ID transition through bounded live old/new probes on bind, reconnect, targeted `NotFound`, and manual retry paths.
- Run an explicit blocking migration that drains sync, acquires a native mutation barrier, transactionally remaps library IDs, and activates durable old-to-new aliases only at commit.
- Remap durable user-owned frontend state, clear derived caches, verify persisted state, and acknowledge completion before normal sync resumes.

## Why

Navidrome PR #5824 changes stored artist, album, track, and folder IDs to a canonical base62 representation. Existing Psysonic installations can otherwise retain legacy IDs while the upgraded server returns canonical IDs, causing duplicate rows or broken references across library, playback, offline, playlist-folder, and Device Sync state.

## Library DB migration

- Adds additive schema migration `027_navidrome_canonical_ids.sql`.
- Adds durable `server_identity_transition` state and `entity_id_remap` journal tables.
- Keeps the heavy data rewrite out of startup DDL; it runs only after live server evidence confirms the transition.
- Collision checks, `PRAGMA foreign_key_check`, browse projection rebuild, and active alias activation happen inside the guarded native transaction.

## Detection and concurrency

- No periodic identity polling and no probe before every foreground sync.
- Inconclusive evidence never becomes `legacy`.
- Targeted track/album `NotFound` probes are single-flight and distinguish deletion from an ID transition.
- Sync and identity-bearing native writes are gated during migration; late writes resolve active aliases.

## Frontend reconciliation

- Preserves current track, queue, shuffle, offline/local playback, Device Sync, music-folder selections, and playlist-folder assignments.
- Clears derived analysis, lyrics, playlist membership/list metadata, request-generation, and transient browse caches.
- Verifies required persisted state before sending the native ACK.

## Tauri boundary

Added commands:

- `library_identity_transition_status`
- `library_identity_transition_probe`
- `library_identity_transition_run_native_migration`
- `library_identity_transition_ack`

Added/used event:

- `library:identity-transition-required`

No existing command or event was removed or renamed. Generated Specta bindings were regenerated.

## Verification

Frontend:

```text
npm run lint
npm run dep:check
npm test                         # 560 files, 4,105 tests
npm run prebuild:release-notes
npx tsc --noEmit
npx vitest run --coverage
bash scripts/check-frontend-hot-path-coverage.sh
```

Rust:

```text
cargo test --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- --test-threads=1
cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
```

Focused frontend verification passed 57 reconciliation, offline, local-playback, and canonical-ID tests. The default parallel Rust workspace run hit two wall-clock performance-budget assertions under local runner contention; both pass individually in about 70-80 ms, and the full workspace passes with `--test-threads=1`.

## Runtime benchmark

- Applicability: required; this changes startup/bind, SQLite queries and migration work, global migration state, and the Tauri boundary.
- Baseline: `c2c896994eeb196cf1697b7207824701ef338469`, report `2026-08-12T23-48-03-871Z`.
- Final: `404b75a460cb07094fbf82f2fa592433ef05f9f9`, report `2026-08-13T00-02-59-311Z`.
- Command: `psysonic benchmark run --scenario all-pages --runs 3 --profile realistic --json`.
- Environment: identical `1284x694` viewport, DPR 2, four selected servers, user agent, and library scope fingerprint.
- Result: no errors, wrong routes, route/interaction timeouts, or long tasks. The label detail route was skipped in both reports because no reachable owned album with a record label was available; all other static and dynamic routes were measured.

| Route | Readiness, base -> final | Total, base -> final |
|---|---:|---:|
| Home | `1360 -> 1507 ms` | `2177 -> 2283 ms` |
| Albums | `0 -> 0 ms` | `979 -> 909 ms` |
| Artists | `0 -> 0 ms` | `871 -> 866 ms` |
| Tracks | `0 -> 100 ms` | `1507 -> 1395 ms` |
| Favourites | `152 -> 159 ms` | `1638 -> 1574 ms` |
| Dynamic album | `0 -> 0 ms` | `898 -> 1572 ms` |

Home readiness increased by 147 ms (11%), below the material-regression percentage threshold, while React work fell from 171 to 107 ms. The dynamic album total increase is entirely post-ready quiet work: the final route renders 898 DOM nodes and 6 images versus 651 nodes and 1 image at baseline, with no readiness delay, incomplete image, long task, or timeout. A second final run reproduced the album result within 2%. All measured filter, search, and pagination interactions completed.

## Follow-up

`navidrome_identity.rs` is intentionally kept cohesive for this correctness-sensitive migration but is above the project's soft module-size trigger. Splitting codec, detection, state, and migration code is recorded as focused follow-up debt.

The first Navidrome release containing PR #5824 is not known yet; detection intentionally relies on live behaviour rather than a version gate.
