### PR TITLE
fix(library): migrate Navidrome IDs before app startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -418,6 +418,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The genre name and the album count beside it now sit on one line instead of a couple of pixels apart, on the **Genres** overview as well as on a genre's own page. The alignment holds when the heading shrinks as you scroll.
 * The small icon between the two gives way to a dash, and a long genre name now shortens with its full text on hover instead of making the row taller.
 
+### Navidrome libraries — migrate entity IDs before startup
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1409](https://github.com/Psychotoxical/psysonic/pull/1409)**
+
+* Existing single-server Navidrome libraries now migrate legacy entity IDs before browse, playback, sync or offline work can start, preventing mixed IDs from breaking links, artwork, caches or analysis data.
+* The migration is journaled and resumes safely after interruption. If the server namespace cannot be verified, Psysonic stays on a visible blocking screen instead of opening with partially converted data.
+
 ## [1.50.0]
 
 ## Added

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4270,6 +4270,7 @@ dependencies = [
 name = "psysonic-library"
 version = "1.51.0-dev"
 dependencies = [
+ "md5",
  "psysonic-core",
  "psysonic-integration",
  "reqwest",

--- a/src-tauri/crates/psysonic-library/Cargo.toml
+++ b/src-tauri/crates/psysonic-library/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1"
 rusqlite = { version = "0.40", features = ["bundled", "functions"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "gzip", "brotli"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time"] }
+md5 = "0.8"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "test-util"] }

--- a/src-tauri/crates/psysonic-library/migrations/027_navidrome_canonical_ids.sql
+++ b/src-tauri/crates/psysonic-library/migrations/027_navidrome_canonical_ids.sql
@@ -1,0 +1,36 @@
+-- Durable state and finite old->new journal for the stop-the-world Navidrome
+-- canonical-ID migration. Journal rows remain only until final verification.
+CREATE TABLE IF NOT EXISTS navidrome_canonical_migration (
+  server_id            TEXT PRIMARY KEY,
+  canonical_version    INTEGER NOT NULL DEFAULT 1,
+  state                TEXT NOT NULL,
+  probe_kind           TEXT,
+  probe_old_id         TEXT,
+  probe_new_id         TEXT,
+  detected_at          INTEGER NOT NULL,
+  native_migrated_at   INTEGER,
+  frontend_migrated_at INTEGER,
+  full_sync_started_at INTEGER,
+  verified_at          INTEGER,
+  last_error           TEXT,
+  CHECK (state IN (
+    'checking', 'not_applicable', 'legacy', 'required', 'rewriting', 'frontend',
+    'resyncing', 'ready', 'retryable', 'blocked'
+  )),
+  CHECK (probe_kind IS NULL OR probe_kind IN ('track', 'album'))
+);
+
+CREATE TABLE IF NOT EXISTS navidrome_canonical_journal (
+  server_id   TEXT NOT NULL,
+  entity_kind TEXT NOT NULL,
+  old_id      TEXT NOT NULL,
+  new_id      TEXT NOT NULL,
+  status      TEXT NOT NULL DEFAULT 'pending',
+  error       TEXT,
+  PRIMARY KEY (server_id, entity_kind, old_id),
+  CHECK (entity_kind IN ('artist', 'album', 'track', 'folder')),
+  CHECK (status IN ('pending', 'applied', 'failed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_navidrome_canonical_journal_new
+  ON navidrome_canonical_journal(server_id, entity_kind, new_id);

--- a/src-tauri/crates/psysonic-library/src/commands.rs
+++ b/src-tauri/crates/psysonic-library/src/commands.rs
@@ -2049,6 +2049,63 @@ pub fn library_migrate_server_index_keys(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn library_navidrome_canonical_inspect(
+    runtime: State<'_, LibraryRuntime>,
+    http_registry: State<'_, Arc<ServerHttpRegistry>>,
+    server_id: String,
+) -> Result<crate::navidrome_canonical_ids::CanonicalMigrationDto, String> {
+    let Some(session) = runtime.get_session(&server_id) else {
+        let current = crate::navidrome_canonical_ids::status(&runtime.store, &server_id)?;
+        if matches!(current.state.as_str(), "legacy" | "not_applicable" | "ready") {
+            return Ok(current);
+        }
+        return Err(format!(
+            "no bound session for server `{server_id}` - bind it before canonical-ID preflight"
+        ));
+    };
+    let subsonic = subsonic_client_with_registry(
+        Some(http_registry.as_ref()),
+        &server_id,
+        session.base_url,
+        session.username,
+        session.password,
+    );
+    crate::navidrome_canonical_ids::inspect(&runtime.store, &subsonic, &server_id).await
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn library_navidrome_canonical_rewrite(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+) -> Result<crate::navidrome_canonical_ids::CanonicalMigrationDto, String> {
+    let barrier = runtime
+        .cancel_and_drain_sync(None, Some(&server_id))
+        .await?;
+    let _barrier = barrier;
+    crate::navidrome_canonical_ids::rewrite(&runtime.store, &server_id)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn library_navidrome_canonical_ack_frontend(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+) -> Result<crate::navidrome_canonical_ids::CanonicalMigrationDto, String> {
+    crate::navidrome_canonical_ids::acknowledge_frontend(&runtime.store, &server_id)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn library_navidrome_canonical_finalize(
+    runtime: State<'_, LibraryRuntime>,
+    server_id: String,
+) -> Result<crate::navidrome_canonical_ids::CanonicalMigrationDto, String> {
+    crate::navidrome_canonical_ids::finalize(&runtime.store, &server_id)
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn library_delete_server_data(
     runtime: State<'_, LibraryRuntime>,
     server_id: String,

--- a/src-tauri/crates/psysonic-library/src/lib.rs
+++ b/src-tauri/crates/psysonic-library/src/lib.rs
@@ -40,6 +40,8 @@ pub mod lossless_formats;
 pub mod mainstage_browse;
 pub mod mood_groups;
 pub mod most_played;
+pub mod navidrome_canonical_ids;
+pub mod navidrome_id_codec;
 pub mod orphan_cleanup;
 pub mod payload;
 #[cfg(test)]

--- a/src-tauri/crates/psysonic-library/src/navidrome_canonical_ids.rs
+++ b/src-tauri/crates/psysonic-library/src/navidrome_canonical_ids.rs
@@ -905,8 +905,36 @@ fn now_unix_ms() -> i64 {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     use super::*;
+
+    static NEXT_TEST_DB: AtomicU64 = AtomicU64::new(1);
+
+    struct TestDatabase {
+        directory: PathBuf,
+        path: PathBuf,
+    }
+
+    impl TestDatabase {
+        fn new(label: &str) -> Self {
+            let id = NEXT_TEST_DB.fetch_add(1, Ordering::Relaxed);
+            let directory = std::env::temp_dir().join(format!(
+                "psysonic-canonical-{label}-{}-{id}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&directory).unwrap();
+            let path = directory.join("library.sqlite");
+            Self { directory, path }
+        }
+    }
+
+    impl Drop for TestDatabase {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.directory);
+        }
+    }
 
     fn identity_shaped_columns(conn: &Connection, schema: &str) -> BTreeSet<String> {
         let mut tables = conn
@@ -1107,5 +1135,40 @@ mod tests {
         assert_eq!(first.state, "frontend");
         let second = rewrite(&store, "s1").unwrap();
         assert_eq!(second.state, "frontend");
+    }
+
+    #[test]
+    fn restart_resumes_after_journal_creation_and_native_commit() {
+        let database = TestDatabase::new("restart");
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        {
+            let store = LibraryStore::open_path_for_test(&database.path).unwrap();
+            store
+                .with_conn("test.seed", |conn| {
+                    conn.execute(
+                        "INSERT INTO track(server_id,id,title,synced_at,raw_json) VALUES ('s1',?1,'Track',1,'{}')",
+                        params![old],
+                    )?;
+                    conn.execute(
+                        "INSERT INTO navidrome_canonical_migration(server_id, canonical_version, state, detected_at) VALUES ('s1',1,'required',1)",
+                        [],
+                    )?;
+                    Ok(())
+                })
+                .unwrap();
+            populate_journal(&store, "s1").unwrap();
+        }
+
+        {
+            let store = LibraryStore::open_path_for_test(&database.path).unwrap();
+            let pending = status(&store, "s1").unwrap();
+            assert_eq!(pending.state, "required");
+            assert!(!pending.mappings.is_empty());
+            assert_eq!(rewrite(&store, "s1").unwrap().state, "frontend");
+        }
+
+        let store = LibraryStore::open_path_for_test(&database.path).unwrap();
+        assert_eq!(status(&store, "s1").unwrap().state, "frontend");
+        assert_eq!(rewrite(&store, "s1").unwrap().state, "frontend");
     }
 }

--- a/src-tauri/crates/psysonic-library/src/navidrome_canonical_ids.rs
+++ b/src-tauri/crates/psysonic-library/src/navidrome_canonical_ids.rs
@@ -1,0 +1,1087 @@
+//! Strict stop-the-world migration for Navidrome's uniform canonical IDs.
+
+use std::collections::{HashMap, HashSet};
+use std::io;
+
+use psysonic_integration::subsonic::{SubsonicClient, SubsonicError};
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
+use serde_json::Value;
+
+use crate::navidrome_id_codec::{canonical_artwork_id, canonical_id};
+use crate::store::LibraryStore;
+
+pub const CANONICAL_VERSION: i64 = 1;
+const MAX_PROBE_CANDIDATES: usize = 20;
+
+#[derive(Debug, Clone, serde::Serialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CanonicalIdMappingDto {
+    pub entity_kind: String,
+    pub old_id: String,
+    pub new_id: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CanonicalMigrationDto {
+    pub server_id: String,
+    pub state: String,
+    pub canonical_version: i64,
+    pub probe_kind: Option<String>,
+    pub probe_old_id: Option<String>,
+    pub probe_new_id: Option<String>,
+    pub last_error: Option<String>,
+    pub mappings: Vec<CanonicalIdMappingDto>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EntityKind {
+    Artist,
+    Album,
+    Track,
+    Folder,
+}
+
+impl EntityKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Artist => "artist",
+            Self::Album => "album",
+            Self::Track => "track",
+            Self::Folder => "folder",
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct IdSets {
+    artist: HashSet<String>,
+    album: HashSet<String>,
+    track: HashSet<String>,
+    folder: HashSet<String>,
+}
+
+impl IdSets {
+    fn values_mut(&mut self, kind: EntityKind) -> &mut HashSet<String> {
+        match kind {
+            EntityKind::Artist => &mut self.artist,
+            EntityKind::Album => &mut self.album,
+            EntityKind::Track => &mut self.track,
+            EntityKind::Folder => &mut self.folder,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct IdMaps {
+    artist: HashMap<String, String>,
+    album: HashMap<String, String>,
+    track: HashMap<String, String>,
+    folder: HashMap<String, String>,
+}
+
+impl IdMaps {
+    fn get(&self, kind: EntityKind, value: &str) -> Option<&str> {
+        match kind {
+            EntityKind::Artist => self.artist.get(value),
+            EntityKind::Album => self.album.get(value),
+            EntityKind::Track => self.track.get(value),
+            EntityKind::Folder => self.folder.get(value),
+        }
+        .map(String::as_str)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ProbeCandidate {
+    kind: EntityKind,
+    old_id: String,
+    new_id: String,
+}
+
+pub fn status(store: &LibraryStore, server_id: &str) -> Result<CanonicalMigrationDto, String> {
+    let server_id = server_id.trim();
+    if server_id.is_empty() {
+        return Err("server id is required".to_string());
+    }
+    store.with_read_conn(|conn| read_status(conn, server_id))
+}
+
+pub async fn inspect(
+    store: &LibraryStore,
+    subsonic: &SubsonicClient,
+    server_id: &str,
+) -> Result<CanonicalMigrationDto, String> {
+    let server_id = server_id.trim();
+    if server_id.is_empty() {
+        return Err("server id is required".to_string());
+    }
+    let current = status(store, server_id)?;
+    if matches!(
+        current.state.as_str(),
+        "required" | "rewriting" | "frontend" | "ready"
+    ) {
+        return Ok(current);
+    }
+    let info = subsonic.server_info().await.map_err(|error| {
+        let message = format!("Navidrome identity preflight failed: {error}");
+        let _ = record_state(store, server_id, "retryable", None, None, None, Some(&message));
+        message
+    })?;
+    if !matches!(info.server_type.as_deref(), Some(kind) if kind.eq_ignore_ascii_case("navidrome")) {
+        record_state(store, server_id, "not_applicable", None, None, None, None)?;
+        return status(store, server_id);
+    }
+
+    let candidates = collect_probe_candidates(store, server_id)?;
+    if candidates.is_empty() {
+        if current.state == "resyncing" {
+            return Ok(current);
+        }
+        let sets = store.with_read_conn(|conn| collect_id_sets(conn, server_id))?;
+        let legacy = [sets.artist, sets.album, sets.track, sets.folder]
+            .into_iter()
+            .flatten()
+            .find(|value| canonical_id(value) != *value);
+        if let Some(value) = legacy {
+            let message = format!(
+                "legacy ID `{value}` remains, but no live track or album can establish the active namespace"
+            );
+            record_state(store, server_id, "retryable", None, None, None, Some(&message))?;
+            return status(store, server_id);
+        }
+        prepare_resync_without_rewrite(store, server_id)?;
+        return status(store, server_id);
+    }
+
+    record_state(store, server_id, "checking", None, None, None, None)?;
+    let mut first_failure = None;
+    for candidate in candidates {
+        let (old, new) = tokio::join!(
+            probe_entity(subsonic, candidate.kind, &candidate.old_id),
+            probe_entity(subsonic, candidate.kind, &candidate.new_id),
+        );
+        match (&old, &new) {
+            (Ok(()), Err(SubsonicError::NotFound)) => {
+                record_state(
+                    store,
+                    server_id,
+                    "legacy",
+                    Some(candidate.kind.label()),
+                    Some(&candidate.old_id),
+                    Some(&candidate.new_id),
+                    None,
+                )?;
+                return status(store, server_id);
+            }
+            (Err(SubsonicError::NotFound), Ok(())) => {
+                populate_journal(store, server_id)?;
+                record_state(
+                    store,
+                    server_id,
+                    "required",
+                    Some(candidate.kind.label()),
+                    Some(&candidate.old_id),
+                    Some(&candidate.new_id),
+                    None,
+                )?;
+                return status(store, server_id);
+            }
+            (Err(SubsonicError::NotFound), Err(SubsonicError::NotFound)) => {}
+            (Ok(()), Ok(())) => {
+                let message = "legacy and canonical IDs both resolve; refusing ambiguous migration";
+                record_state(
+                    store,
+                    server_id,
+                    "blocked",
+                    Some(candidate.kind.label()),
+                    Some(&candidate.old_id),
+                    Some(&candidate.new_id),
+                    Some(message),
+                )?;
+                return status(store, server_id);
+            }
+            _ => {
+                first_failure.get_or_insert_with(|| {
+                    format!(
+                        "canonical-ID probe failed (legacy: {}; canonical: {})",
+                        probe_label(&old),
+                        probe_label(&new)
+                    )
+                });
+            }
+        }
+    }
+    let message = first_failure.unwrap_or_else(|| {
+        "no live entity established the active Navidrome ID namespace".to_string()
+    });
+    record_state(store, server_id, "retryable", None, None, None, Some(&message))?;
+    status(store, server_id)
+}
+
+pub fn rewrite(store: &LibraryStore, server_id: &str) -> Result<CanonicalMigrationDto, String> {
+    let current = status(store, server_id)?;
+    match current.state.as_str() {
+        "frontend" | "resyncing" | "ready" => return Ok(current),
+        "required" | "rewriting" => {}
+        other => return Err(format!("canonical-ID rewrite cannot run from state `{other}`")),
+    }
+
+    if current.mappings.is_empty() {
+        populate_journal(store, server_id)?;
+    }
+    record_state(store, server_id, "rewriting", None, None, None, None)?;
+    let result = store.with_conn_mut("navidrome_canonical_ids.rewrite", |conn| {
+        let tx = conn.transaction()?;
+        let maps = load_maps(&tx, server_id)?;
+        create_temp_maps(&tx, &maps)?;
+        reject_collisions(&tx, server_id)?;
+        apply_rewrite(&tx, server_id, &maps)?;
+        verify_native_tx(&tx, server_id, false)?;
+        tx.execute(
+            "UPDATE navidrome_canonical_journal SET status = 'applied', error = NULL WHERE server_id = ?1",
+            params![server_id],
+        )?;
+        tx.execute(
+            "UPDATE navidrome_canonical_migration SET state = 'frontend', native_migrated_at = ?2, last_error = NULL WHERE server_id = ?1",
+            params![server_id, now_unix_ms()],
+        )?;
+        tx.commit()
+    });
+    if let Err(error) = result {
+        let _ = record_state(store, server_id, "blocked", None, None, None, Some(&error));
+        return Err(error);
+    }
+    status(store, server_id)
+}
+
+pub fn acknowledge_frontend(
+    store: &LibraryStore,
+    server_id: &str,
+) -> Result<CanonicalMigrationDto, String> {
+    clear_cluster_sidecar(store, server_id)?;
+    store.with_conn("navidrome_canonical_ids.ack_frontend", |conn| {
+        let state: Option<String> = conn
+            .query_row(
+                "SELECT state FROM navidrome_canonical_migration WHERE server_id = ?1",
+                params![server_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if !matches!(state.as_deref(), Some("frontend") | Some("resyncing")) {
+            return Err(invalid_query(format!(
+                "canonical-ID frontend acknowledgement cannot run from `{}`",
+                state.as_deref().unwrap_or("unseen")
+            )));
+        }
+        conn.execute(
+            "UPDATE navidrome_canonical_migration SET state = 'resyncing', frontend_migrated_at = COALESCE(frontend_migrated_at, ?2), full_sync_started_at = COALESCE(full_sync_started_at, ?2), last_error = NULL WHERE server_id = ?1",
+            params![server_id, now_unix_ms()],
+        )?;
+        Ok(())
+    })?;
+    status(store, server_id)
+}
+
+pub fn finalize(store: &LibraryStore, server_id: &str) -> Result<CanonicalMigrationDto, String> {
+    clear_cluster_sidecar(store, server_id)?;
+    store.with_conn_mut("navidrome_canonical_ids.finalize", |conn| {
+        let tx = conn.transaction()?;
+        let state: Option<String> = tx
+            .query_row(
+                "SELECT state FROM navidrome_canonical_migration WHERE server_id = ?1",
+                params![server_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if state.as_deref() == Some("ready") {
+            tx.commit()?;
+            return Ok(());
+        }
+        if state.as_deref() != Some("resyncing") {
+            return Err(invalid_query(format!(
+                "canonical-ID final verification cannot run from `{}`",
+                state.as_deref().unwrap_or("unseen")
+            )));
+        }
+        let full_sync_started_at: i64 = tx.query_row(
+            "SELECT full_sync_started_at FROM navidrome_canonical_migration WHERE server_id = ?1",
+            params![server_id],
+            |row| row.get(0),
+        )?;
+        let full_sync_complete: bool = tx.query_row(
+            "SELECT EXISTS(SELECT 1 FROM sync_state WHERE server_id = ?1 AND library_scope = '' AND sync_phase = 'ready' AND last_full_sync_at >= ?2)",
+            params![server_id, full_sync_started_at],
+            |row| row.get(0),
+        )?;
+        if !full_sync_complete {
+            return Err(invalid_query("the required full sync has not completed"));
+        }
+        verify_native_tx(&tx, server_id, true)?;
+        tx.execute(
+            "DELETE FROM navidrome_canonical_journal WHERE server_id = ?1",
+            params![server_id],
+        )?;
+        tx.execute(
+            "UPDATE navidrome_canonical_migration SET state = 'ready', verified_at = ?2, last_error = NULL WHERE server_id = ?1",
+            params![server_id, now_unix_ms()],
+        )?;
+        tx.commit()
+    })?;
+    status(store, server_id)
+}
+
+fn prepare_resync_without_rewrite(store: &LibraryStore, server_id: &str) -> Result<(), String> {
+    store.with_conn_mut("navidrome_canonical_ids.prepare_resync", |conn| {
+        let tx = conn.transaction()?;
+        reset_sync_and_derived(&tx, server_id)?;
+        tx.execute(
+            "INSERT INTO navidrome_canonical_migration(server_id, canonical_version, state, detected_at, frontend_migrated_at, full_sync_started_at) VALUES (?1, ?2, 'resyncing', ?3, ?3, ?3) ON CONFLICT(server_id) DO UPDATE SET canonical_version = excluded.canonical_version, state = excluded.state, detected_at = excluded.detected_at, frontend_migrated_at = excluded.frontend_migrated_at, full_sync_started_at = excluded.full_sync_started_at, last_error = NULL",
+            params![server_id, CANONICAL_VERSION, now_unix_ms()],
+        )?;
+        tx.commit()
+    })
+}
+
+fn collect_probe_candidates(
+    store: &LibraryStore,
+    server_id: &str,
+) -> Result<Vec<ProbeCandidate>, String> {
+    store.with_read_conn(|conn| {
+        let mut candidates = Vec::new();
+        for (kind, table) in [(EntityKind::Track, "track"), (EntityKind::Album, "album")] {
+            let sql = format!(
+                "SELECT id FROM {table} WHERE server_id = ?1{} ORDER BY id LIMIT ?2",
+                if table == "track" { " AND deleted = 0" } else { "" }
+            );
+            let ids = conn
+                .prepare(&sql)?
+                .query_map(params![server_id, (MAX_PROBE_CANDIDATES * 8) as i64], |row| {
+                    row.get::<_, String>(0)
+                })?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            for old_id in ids {
+                let new_id = canonical_id(&old_id);
+                if new_id != old_id {
+                    candidates.push(ProbeCandidate { kind, old_id, new_id });
+                    if candidates.len() >= MAX_PROBE_CANDIDATES {
+                        return Ok(candidates);
+                    }
+                }
+            }
+        }
+        Ok(candidates)
+    })
+}
+
+async fn probe_entity(
+    subsonic: &SubsonicClient,
+    kind: EntityKind,
+    id: &str,
+) -> Result<(), SubsonicError> {
+    match kind {
+        EntityKind::Track => subsonic.get_song(id).await.map(|_| ()),
+        EntityKind::Album => subsonic.get_album(id).await.map(|_| ()),
+        _ => unreachable!("only track and album candidates are probed"),
+    }
+}
+
+fn probe_label(result: &Result<(), SubsonicError>) -> String {
+    match result {
+        Ok(()) => "found".to_string(),
+        Err(SubsonicError::NotFound) => "not_found".to_string(),
+        Err(error) => error.to_string(),
+    }
+}
+
+fn populate_journal(store: &LibraryStore, server_id: &str) -> Result<(), String> {
+    store.with_conn_mut("navidrome_canonical_ids.populate_journal", |conn| {
+        let sets = collect_id_sets(conn, server_id)?;
+        let tx = conn.transaction()?;
+        tx.execute(
+            "DELETE FROM navidrome_canonical_journal WHERE server_id = ?1",
+            params![server_id],
+        )?;
+        let mut insert = tx.prepare(
+            "INSERT INTO navidrome_canonical_journal(server_id, entity_kind, old_id, new_id) VALUES (?1, ?2, ?3, ?4)",
+        )?;
+        for (kind, values) in [
+            (EntityKind::Artist, sets.artist),
+            (EntityKind::Album, sets.album),
+            (EntityKind::Track, sets.track),
+            (EntityKind::Folder, sets.folder),
+        ] {
+            for old_id in values {
+                let new_id = canonical_id(&old_id);
+                if new_id != old_id {
+                    insert.execute(params![server_id, kind.label(), old_id, new_id])?;
+                }
+            }
+        }
+        drop(insert);
+        let duplicate: Option<(String, String)> = tx
+            .query_row(
+                "SELECT entity_kind, new_id FROM navidrome_canonical_journal WHERE server_id = ?1 GROUP BY entity_kind, new_id HAVING COUNT(*) > 1 LIMIT 1",
+                params![server_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        if let Some((kind, id)) = duplicate {
+            return Err(invalid_query(format!("multiple legacy {kind} IDs map to `{id}`")));
+        }
+        tx.commit()
+    })
+}
+
+fn collect_id_sets(conn: &Connection, server_id: &str) -> rusqlite::Result<IdSets> {
+    let mut sets = IdSets::default();
+    for (kind, table, column, owner_column) in [
+        (EntityKind::Artist, "artist", "id", "server_id"),
+        (EntityKind::Artist, "album", "artist_id", "server_id"),
+        (EntityKind::Artist, "track", "artist_id", "server_id"),
+        (EntityKind::Artist, "artist_artwork_lookup", "artist_id", "server_id"),
+        (EntityKind::Album, "album", "id", "server_id"),
+        (EntityKind::Album, "track", "album_id", "server_id"),
+        (EntityKind::Album, "track_genre", "album_id", "server_id"),
+        (EntityKind::Track, "track", "id", "server_id"),
+        (EntityKind::Track, "track_extension", "track_id", "server_id"),
+        (EntityKind::Track, "track_offline", "track_id", "server_id"),
+        (EntityKind::Track, "track_fact", "track_id", "server_id"),
+        (EntityKind::Track, "track_artifact", "track_id", "server_id"),
+        (EntityKind::Track, "track_canonical_link", "track_id", "server_id"),
+        (EntityKind::Track, "canonical_enrichment_link", "owner_track_id", "owner_server_id"),
+        (EntityKind::Track, "play_session", "track_id", "server_id"),
+        (EntityKind::Track, "track_genre", "track_id", "server_id"),
+        (EntityKind::Track, "track_id_history", "new_id", "server_id"),
+        (EntityKind::Folder, "track", "library_id", "server_id"),
+        (EntityKind::Folder, "track_genre", "library_id", "server_id"),
+        (EntityKind::Folder, "sync_state", "library_scope", "server_id"),
+    ] {
+        collect_column(conn, server_id, kind, table, column, owner_column, &mut sets)?;
+    }
+    let mut ratings = conn.prepare(
+        "SELECT entity_kind, entity_id FROM entity_user_rating WHERE server_id = ?1 AND entity_id <> ''",
+    )?;
+    for row in ratings.query_map(params![server_id], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })? {
+        let (kind, value) = row?;
+        let kind = match kind.as_str() {
+            "artist" => EntityKind::Artist,
+            "album" => EntityKind::Album,
+            "track" => EntityKind::Track,
+            _ => continue,
+        };
+        sets.values_mut(kind).insert(value);
+    }
+    for (table, root_kind) in [
+        ("artist", EntityKind::Artist),
+        ("album", EntityKind::Album),
+        ("track", EntityKind::Track),
+    ] {
+        let sql = format!("SELECT raw_json FROM {table} WHERE server_id = ?1 AND raw_json IS NOT NULL");
+        let rows = conn
+            .prepare(&sql)?
+            .query_map(params![server_id], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        for raw in rows {
+            let value: Value = serde_json::from_str(&raw).map_err(json_error)?;
+            collect_json_ids(&value, root_kind, &mut sets);
+        }
+    }
+    Ok(sets)
+}
+
+fn collect_column(
+    conn: &Connection,
+    server_id: &str,
+    kind: EntityKind,
+    table: &str,
+    column: &str,
+    owner_column: &str,
+    sets: &mut IdSets,
+) -> rusqlite::Result<()> {
+    let sql = format!(
+        "SELECT DISTINCT {column} FROM {table} WHERE {owner_column} = ?1 AND {column} IS NOT NULL AND {column} <> ''"
+    );
+    let values = conn
+        .prepare(&sql)?
+        .query_map(params![server_id], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    sets.values_mut(kind).extend(values);
+    Ok(())
+}
+
+fn collect_json_ids(value: &Value, context: EntityKind, sets: &mut IdSets) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                collect_json_ids(value, context, sets);
+            }
+        }
+        Value::Object(values) => {
+            for (key, value) in values {
+                let explicit = match key.as_str() {
+                    "albumId" => Some(EntityKind::Album),
+                    "artistId" | "albumArtistId" => Some(EntityKind::Artist),
+                    "libraryId" | "library_id" | "musicFolderId" => Some(EntityKind::Folder),
+                    "artists" | "albumArtists" => Some(EntityKind::Artist),
+                    "song" | "songs" => Some(EntityKind::Track),
+                    _ => None,
+                };
+                if key == "id" {
+                    if let Value::String(id) = value {
+                        sets.values_mut(context).insert(id.clone());
+                    }
+                } else if let Some(kind) = explicit {
+                    if let Value::String(id) = value {
+                        sets.values_mut(kind).insert(id.clone());
+                    } else {
+                        collect_json_ids(value, kind, sets);
+                    }
+                } else if key == "contributors" || (key == "artist" && !value.is_string()) {
+                    collect_json_ids(value, EntityKind::Artist, sets);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn load_maps(conn: &Connection, server_id: &str) -> rusqlite::Result<IdMaps> {
+    let mut maps = IdMaps::default();
+    let mut statement = conn.prepare(
+        "SELECT entity_kind, old_id, new_id FROM navidrome_canonical_journal WHERE server_id = ?1 ORDER BY entity_kind, old_id",
+    )?;
+    for row in statement.query_map(params![server_id], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+    })? {
+        let (kind, old_id, new_id) = row?;
+        match kind.as_str() {
+            "artist" => { maps.artist.insert(old_id, new_id); }
+            "album" => { maps.album.insert(old_id, new_id); }
+            "track" => { maps.track.insert(old_id, new_id); }
+            "folder" => { maps.folder.insert(old_id, new_id); }
+            _ => {}
+        }
+    }
+    Ok(maps)
+}
+
+fn create_temp_maps(tx: &Transaction<'_>, maps: &IdMaps) -> rusqlite::Result<()> {
+    tx.execute_batch(
+        "PRAGMA defer_foreign_keys = ON;
+         DROP TABLE IF EXISTS temp.canonical_artist_map;
+         DROP TABLE IF EXISTS temp.canonical_album_map;
+         DROP TABLE IF EXISTS temp.canonical_track_map;
+         DROP TABLE IF EXISTS temp.canonical_folder_map;
+         CREATE TEMP TABLE canonical_artist_map(old_id TEXT PRIMARY KEY, new_id TEXT NOT NULL);
+         CREATE TEMP TABLE canonical_album_map(old_id TEXT PRIMARY KEY, new_id TEXT NOT NULL);
+         CREATE TEMP TABLE canonical_track_map(old_id TEXT PRIMARY KEY, new_id TEXT NOT NULL);
+         CREATE TEMP TABLE canonical_folder_map(old_id TEXT PRIMARY KEY, new_id TEXT NOT NULL);",
+    )?;
+    for (table, map) in [
+        ("canonical_artist_map", &maps.artist),
+        ("canonical_album_map", &maps.album),
+        ("canonical_track_map", &maps.track),
+        ("canonical_folder_map", &maps.folder),
+    ] {
+        let mut insert = tx.prepare(&format!("INSERT INTO {table}(old_id, new_id) VALUES (?1, ?2)"))?;
+        for (old_id, new_id) in map {
+            insert.execute(params![old_id, new_id])?;
+        }
+    }
+    Ok(())
+}
+
+fn reject_collisions(tx: &Transaction<'_>, server_id: &str) -> rusqlite::Result<()> {
+    for (label, query) in [
+        ("artist", "SELECT entity.id FROM artist entity JOIN canonical_artist_map mapping ON mapping.new_id = entity.id WHERE entity.server_id = ?1 LIMIT 1"),
+        ("album", "SELECT entity.id FROM album entity JOIN canonical_album_map mapping ON mapping.new_id = entity.id WHERE entity.server_id = ?1 LIMIT 1"),
+        ("track", "SELECT entity.id FROM track entity JOIN canonical_track_map mapping ON mapping.new_id = entity.id WHERE entity.server_id = ?1 LIMIT 1"),
+        ("sync scope", "SELECT old.library_scope FROM sync_state old JOIN canonical_folder_map mapping ON mapping.old_id = old.library_scope JOIN sync_state destination ON destination.server_id = old.server_id AND destination.library_scope = mapping.new_id WHERE old.server_id = ?1 LIMIT 1"),
+        ("artist artwork", "SELECT old.artist_id FROM artist_artwork_lookup old JOIN canonical_artist_map mapping ON mapping.old_id = old.artist_id JOIN artist_artwork_lookup destination ON destination.server_id = old.server_id AND destination.artist_id = mapping.new_id AND destination.surface_kind = old.surface_kind WHERE old.server_id = ?1 LIMIT 1"),
+        ("offline track", "SELECT old.track_id FROM track_offline old JOIN canonical_track_map mapping ON mapping.old_id = old.track_id JOIN track_offline destination ON destination.server_id = old.server_id AND destination.track_id = mapping.new_id WHERE old.server_id = ?1 LIMIT 1"),
+        ("canonical enrichment", "SELECT old.owner_track_id FROM canonical_enrichment_link old JOIN canonical_track_map mapping ON mapping.old_id = old.owner_track_id JOIN canonical_enrichment_link destination ON destination.canonical_id = old.canonical_id AND destination.enrichment_kind = old.enrichment_kind AND destination.owner_server_id = old.owner_server_id AND destination.owner_track_id = mapping.new_id WHERE old.owner_server_id = ?1 LIMIT 1"),
+        ("entity rating", "SELECT old.entity_id FROM entity_user_rating old JOIN navidrome_canonical_journal mapping ON mapping.server_id = old.server_id AND mapping.entity_kind = old.entity_kind AND mapping.old_id = old.entity_id JOIN entity_user_rating destination ON destination.server_id = old.server_id AND destination.entity_kind = old.entity_kind AND destination.entity_id = mapping.new_id WHERE old.server_id = ?1 LIMIT 1"),
+    ] {
+        let collision = tx
+            .query_row(query, params![server_id], |row| row.get::<_, String>(0))
+            .optional()?;
+        if let Some(id) = collision {
+            return Err(invalid_query(format!("canonical {label} collision at `{id}`")));
+        }
+    }
+    Ok(())
+}
+
+fn apply_rewrite(tx: &Transaction<'_>, server_id: &str, maps: &IdMaps) -> rusqlite::Result<()> {
+    for statement in [
+        "UPDATE artist SET id = (SELECT new_id FROM canonical_artist_map WHERE old_id = artist.id) WHERE server_id = ?1 AND id IN (SELECT old_id FROM canonical_artist_map)",
+        "UPDATE artist_artwork_lookup SET artist_id = (SELECT new_id FROM canonical_artist_map WHERE old_id = artist_artwork_lookup.artist_id) WHERE server_id = ?1 AND artist_id IN (SELECT old_id FROM canonical_artist_map)",
+        "UPDATE album SET id = COALESCE((SELECT new_id FROM canonical_album_map WHERE old_id = album.id), id), artist_id = COALESCE((SELECT new_id FROM canonical_artist_map WHERE old_id = album.artist_id), artist_id) WHERE server_id = ?1",
+        "UPDATE track SET id = COALESCE((SELECT new_id FROM canonical_track_map WHERE old_id = track.id), id), artist_id = COALESCE((SELECT new_id FROM canonical_artist_map WHERE old_id = track.artist_id), artist_id), album_id = COALESCE((SELECT new_id FROM canonical_album_map WHERE old_id = track.album_id), album_id), library_id = COALESCE((SELECT new_id FROM canonical_folder_map WHERE old_id = track.library_id), library_id) WHERE server_id = ?1",
+        "UPDATE track_extension SET track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = track_extension.track_id) WHERE server_id = ?1 AND track_id IN (SELECT old_id FROM canonical_track_map)",
+        "UPDATE track_offline SET track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = track_offline.track_id) WHERE server_id = ?1 AND track_id IN (SELECT old_id FROM canonical_track_map)",
+        "UPDATE track_fact SET track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = track_fact.track_id) WHERE server_id = ?1 AND track_id IN (SELECT old_id FROM canonical_track_map)",
+        "UPDATE track_artifact SET track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = track_artifact.track_id) WHERE server_id = ?1 AND track_id IN (SELECT old_id FROM canonical_track_map)",
+        "UPDATE track_canonical_link SET track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = track_canonical_link.track_id) WHERE server_id = ?1 AND track_id IN (SELECT old_id FROM canonical_track_map)",
+        "UPDATE canonical_enrichment_link SET owner_track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = canonical_enrichment_link.owner_track_id) WHERE owner_server_id = ?1 AND owner_track_id IN (SELECT old_id FROM canonical_track_map)",
+        "UPDATE play_session SET track_id = (SELECT new_id FROM canonical_track_map WHERE old_id = play_session.track_id) WHERE server_id = ?1 AND track_id IN (SELECT old_id FROM canonical_track_map)",
+        "UPDATE track_genre SET track_id = COALESCE((SELECT new_id FROM canonical_track_map WHERE old_id = track_genre.track_id), track_id), album_id = COALESCE((SELECT new_id FROM canonical_album_map WHERE old_id = track_genre.album_id), album_id), library_id = COALESCE((SELECT new_id FROM canonical_folder_map WHERE old_id = track_genre.library_id), library_id) WHERE server_id = ?1",
+        "UPDATE track_id_history SET new_id = COALESCE((SELECT new_id FROM canonical_track_map WHERE old_id = track_id_history.new_id), new_id) WHERE server_id = ?1",
+        "UPDATE sync_state SET library_scope = COALESCE((SELECT new_id FROM canonical_folder_map WHERE old_id = sync_state.library_scope), library_scope) WHERE server_id = ?1",
+    ] {
+        tx.execute(statement, params![server_id])?;
+    }
+    for kind in ["artist", "album", "track"] {
+        tx.execute(
+            "UPDATE entity_user_rating SET entity_id = (SELECT new_id FROM navidrome_canonical_journal WHERE server_id = ?1 AND entity_kind = ?2 AND old_id = entity_user_rating.entity_id) WHERE server_id = ?1 AND entity_kind = ?2 AND entity_id IN (SELECT old_id FROM navidrome_canonical_journal WHERE server_id = ?1 AND entity_kind = ?2)",
+            params![server_id, kind],
+        )?;
+    }
+    rewrite_artwork_columns(tx, server_id)?;
+    rewrite_raw_json(tx, server_id, maps)?;
+    reset_sync_and_derived(tx, server_id)?;
+    Ok(())
+}
+
+fn rewrite_artwork_columns(tx: &Transaction<'_>, server_id: &str) -> rusqlite::Result<()> {
+    for table in ["album", "track"] {
+        let sql = format!("SELECT rowid, cover_art_id FROM {table} WHERE server_id = ?1 AND cover_art_id IS NOT NULL AND cover_art_id <> ''");
+        let rows = tx
+            .prepare(&sql)?
+            .query_map(params![server_id], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        let mut update = tx.prepare(&format!("UPDATE {table} SET cover_art_id = ?1 WHERE rowid = ?2"))?;
+        for (rowid, value) in rows {
+            let rewritten = canonical_artwork_id(&value);
+            if rewritten != value {
+                update.execute(params![rewritten, rowid])?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn rewrite_raw_json(tx: &Transaction<'_>, server_id: &str, maps: &IdMaps) -> rusqlite::Result<()> {
+    for (table, root_kind) in [
+        ("artist", EntityKind::Artist),
+        ("album", EntityKind::Album),
+        ("track", EntityKind::Track),
+    ] {
+        let sql = format!("SELECT rowid, raw_json FROM {table} WHERE server_id = ?1 AND raw_json IS NOT NULL");
+        let rows = tx
+            .prepare(&sql)?
+            .query_map(params![server_id], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        let mut update = tx.prepare(&format!("UPDATE {table} SET raw_json = ?1 WHERE rowid = ?2"))?;
+        for (rowid, raw) in rows {
+            let mut value: Value = serde_json::from_str(&raw).map_err(json_error)?;
+            if rewrite_json_ids(&mut value, root_kind, maps) {
+                update.execute(params![value.to_string(), rowid])?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn rewrite_json_ids(value: &mut Value, context: EntityKind, maps: &IdMaps) -> bool {
+    match value {
+        Value::Array(values) => {
+            let mut changed = false;
+            for value in values {
+                changed |= rewrite_json_ids(value, context, maps);
+            }
+            changed
+        }
+        Value::Object(values) => {
+            let mut changed = false;
+            for (key, value) in values {
+                let explicit = match key.as_str() {
+                    "albumId" => Some(EntityKind::Album),
+                    "artistId" | "albumArtistId" => Some(EntityKind::Artist),
+                    "libraryId" | "library_id" | "musicFolderId" => Some(EntityKind::Folder),
+                    "artists" | "albumArtists" => Some(EntityKind::Artist),
+                    "song" | "songs" => Some(EntityKind::Track),
+                    _ => None,
+                };
+                if key == "id" {
+                    changed |= rewrite_string(value, maps.get(context, value.as_str().unwrap_or_default()));
+                } else if matches!(key.as_str(), "coverArt" | "coverArtId") {
+                    if let Value::String(text) = value {
+                        let rewritten = canonical_artwork_id(text);
+                        if rewritten != *text {
+                            *text = rewritten;
+                            changed = true;
+                        }
+                    }
+                } else if let Some(kind) = explicit {
+                    if value.is_string() {
+                        changed |= rewrite_string(value, maps.get(kind, value.as_str().unwrap_or_default()));
+                    } else {
+                        changed |= rewrite_json_ids(value, kind, maps);
+                    }
+                } else if key == "contributors" || (key == "artist" && !value.is_string()) {
+                    changed |= rewrite_json_ids(value, EntityKind::Artist, maps);
+                }
+            }
+            changed
+        }
+        _ => false,
+    }
+}
+
+fn rewrite_string(value: &mut Value, replacement: Option<&str>) -> bool {
+    let Some(replacement) = replacement else { return false; };
+    *value = Value::String(replacement.to_string());
+    true
+}
+
+fn reset_sync_and_derived(tx: &Transaction<'_>, server_id: &str) -> rusqlite::Result<()> {
+    for statement in [
+        "DELETE FROM album_browse_projection WHERE server_id = ?1",
+        "DELETE FROM composer_album_projection WHERE server_id = ?1",
+        "DELETE FROM library_tag_state WHERE server_id = ?1",
+        "DELETE FROM library_tag_cursor WHERE server_id = ?1",
+        "DELETE FROM identity_invalidation WHERE server_id = ?1",
+    ] {
+        tx.execute(statement, params![server_id])?;
+    }
+    tx.execute(
+        "DELETE FROM cluster.cluster_meta WHERE key = ?1",
+        params![format!("dirty_server:{server_id}")],
+    )?;
+    tx.execute(
+        "INSERT INTO identity_invalidation(server_id, kind, entity_id) VALUES (?1, 'server', '')",
+        params![server_id],
+    )?;
+    tx.execute(
+        "UPDATE sync_state SET initial_sync_cursor_json = '{}', sync_phase = 'idle', last_full_sync_at = NULL, last_delta_sync_at = NULL, last_error = NULL WHERE server_id = ?1",
+        params![server_id],
+    )?;
+    Ok(())
+}
+
+fn clear_cluster_sidecar(store: &LibraryStore, server_id: &str) -> Result<(), String> {
+    store.with_conn("navidrome_canonical_ids.clear_cluster_sidecar", |conn| {
+        conn.execute(
+            "DELETE FROM cluster.track_cluster_key WHERE server_id = ?1",
+            params![server_id],
+        )?;
+        Ok(())
+    })
+}
+
+fn verify_native_tx(
+    tx: &Transaction<'_>,
+    server_id: &str,
+    require_applied_journal: bool,
+) -> rusqlite::Result<()> {
+    let sets = collect_id_sets(tx, server_id)?;
+    for (kind, values) in [
+        ("artist", sets.artist),
+        ("album", sets.album),
+        ("track", sets.track),
+        ("folder", sets.folder),
+    ] {
+        if let Some(value) = values.into_iter().find(|value| canonical_id(value) != *value) {
+            return Err(invalid_query(format!("legacy {kind} ID remains at `{value}`")));
+        }
+    }
+    for table in ["album", "track"] {
+        let sql = format!("SELECT cover_art_id FROM {table} WHERE server_id = ?1 AND cover_art_id IS NOT NULL AND cover_art_id <> ''");
+        let values = tx
+            .prepare(&sql)?
+            .query_map(params![server_id], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        if let Some(value) = values
+            .into_iter()
+            .find(|value| canonical_artwork_id(value) != *value)
+        {
+            return Err(invalid_query(format!("legacy structured artwork ID remains at `{value}`")));
+        }
+    }
+    let pending: i64 = tx.query_row(
+        if require_applied_journal {
+            "SELECT COUNT(*) FROM navidrome_canonical_journal WHERE server_id = ?1 AND status <> 'applied'"
+        } else {
+            "SELECT COUNT(*) FROM navidrome_canonical_journal WHERE server_id = ?1 AND status = 'failed'"
+        },
+        params![server_id],
+        |row| row.get(0),
+    )?;
+    if pending > 0 {
+        return Err(invalid_query("canonical-ID journal contains incomplete rows"));
+    }
+    let fk_error: Option<String> = tx
+        .query_row("PRAGMA foreign_key_check", [], |row| {
+            Ok(format!("{} row {}", row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })
+        .optional()?;
+    if let Some(error) = fk_error {
+        return Err(invalid_query(format!("foreign key check failed: {error}")));
+    }
+    Ok(())
+}
+
+fn read_status(conn: &Connection, server_id: &str) -> rusqlite::Result<CanonicalMigrationDto> {
+    let row = conn
+        .query_row(
+            "SELECT state, canonical_version, probe_kind, probe_old_id, probe_new_id, last_error FROM navidrome_canonical_migration WHERE server_id = ?1",
+            params![server_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                ))
+            },
+        )
+        .optional()?;
+    let mappings = conn
+        .prepare(
+            "SELECT entity_kind, old_id, new_id FROM navidrome_canonical_journal WHERE server_id = ?1 ORDER BY entity_kind, old_id",
+        )?
+        .query_map(params![server_id], |row| {
+            Ok(CanonicalIdMappingDto {
+                entity_kind: row.get(0)?,
+                old_id: row.get(1)?,
+                new_id: row.get(2)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let (state, canonical_version, probe_kind, probe_old_id, probe_new_id, last_error) = row
+        .unwrap_or_else(|| ("unseen".to_string(), CANONICAL_VERSION, None, None, None, None));
+    Ok(CanonicalMigrationDto {
+        server_id: server_id.to_string(),
+        state,
+        canonical_version,
+        probe_kind,
+        probe_old_id,
+        probe_new_id,
+        last_error,
+        mappings,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_state(
+    store: &LibraryStore,
+    server_id: &str,
+    state: &str,
+    probe_kind: Option<&str>,
+    probe_old_id: Option<&str>,
+    probe_new_id: Option<&str>,
+    last_error: Option<&str>,
+) -> Result<(), String> {
+    store.with_conn("navidrome_canonical_ids.record_state", |conn| {
+        conn.execute(
+            "INSERT INTO navidrome_canonical_migration(server_id, canonical_version, state, probe_kind, probe_old_id, probe_new_id, detected_at, last_error) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8) ON CONFLICT(server_id) DO UPDATE SET canonical_version = excluded.canonical_version, state = excluded.state, probe_kind = COALESCE(excluded.probe_kind, navidrome_canonical_migration.probe_kind), probe_old_id = COALESCE(excluded.probe_old_id, navidrome_canonical_migration.probe_old_id), probe_new_id = COALESCE(excluded.probe_new_id, navidrome_canonical_migration.probe_new_id), detected_at = excluded.detected_at, last_error = excluded.last_error",
+            params![server_id, CANONICAL_VERSION, state, probe_kind, probe_old_id, probe_new_id, now_unix_ms(), last_error],
+        )?;
+        Ok(())
+    })
+}
+
+fn json_error(error: serde_json::Error) -> rusqlite::Error {
+    invalid_query(format!("malformed persisted library JSON: {error}"))
+}
+
+fn invalid_query(message: impl Into<String>) -> rusqlite::Error {
+    rusqlite::Error::ToSqlConversionFailure(Box::new(io::Error::other(message.into())))
+}
+
+fn now_unix_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+
+    fn identity_shaped_columns(conn: &Connection, schema: &str) -> BTreeSet<String> {
+        let mut tables = conn
+            .prepare(&format!(
+                "SELECT name FROM {schema}.sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'track_fts%' ORDER BY name"
+            ))
+            .unwrap();
+        let table_names = tables
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        let mut columns = BTreeSet::new();
+        for table in table_names {
+            let mut statement = conn
+                .prepare(&format!("PRAGMA {schema}.table_info('{table}')"))
+                .unwrap();
+            for column in statement
+                .query_map([], |row| row.get::<_, String>(1))
+                .unwrap()
+            {
+                let column = column.unwrap();
+                if column == "id" || column.ends_with("_id") || column == "library_scope" {
+                    columns.insert(format!("{table}.{column}"));
+                }
+            }
+        }
+        columns
+    }
+
+    #[test]
+    fn schema_identity_inventory_has_no_unclassified_columns() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_read_conn(|conn| {
+                let actual = identity_shaped_columns(conn, "main");
+                let expected = [
+                    "album.artist_id",
+                    "album.cover_art_id",
+                    "album.id",
+                    "album.server_id",
+                    "album_browse_projection.album_id",
+                    "album_browse_projection.artist_id",
+                    "album_browse_projection.cover_art_id",
+                    "album_browse_projection.library_id",
+                    "album_browse_projection.representative_track_id",
+                    "album_browse_projection.server_id",
+                    "artist.id",
+                    "artist.server_id",
+                    "artist_artwork_lookup.artist_id",
+                    "artist_artwork_lookup.server_id",
+                    "canonical_enrichment_link.canonical_id",
+                    "canonical_enrichment_link.owner_server_id",
+                    "canonical_enrichment_link.owner_track_id",
+                    "canonical_identity.canonical_id",
+                    "canonical_track.id",
+                    "composer_album_projection.album_id",
+                    "composer_album_projection.composer_id",
+                    "composer_album_projection.library_id",
+                    "composer_album_projection.representative_track_id",
+                    "composer_album_projection.server_id",
+                    "entity_user_rating.entity_id",
+                    "entity_user_rating.server_id",
+                    "identity_invalidation.entity_id",
+                    "identity_invalidation.server_id",
+                    "library_data_migration.id",
+                    "library_tag_cursor.next_folder_id",
+                    "library_tag_cursor.server_id",
+                    "library_tag_state.server_id",
+                    "navidrome_canonical_journal.new_id",
+                    "navidrome_canonical_journal.old_id",
+                    "navidrome_canonical_journal.server_id",
+                    "navidrome_canonical_migration.probe_new_id",
+                    "navidrome_canonical_migration.probe_old_id",
+                    "navidrome_canonical_migration.server_id",
+                    "play_session.id",
+                    "play_session.server_id",
+                    "play_session.track_id",
+                    "sync_state.library_scope",
+                    "sync_state.server_id",
+                    "track.album_id",
+                    "track.artist_id",
+                    "track.cover_art_id",
+                    "track.id",
+                    "track.library_id",
+                    "track.server_id",
+                    "track_artifact.server_id",
+                    "track_artifact.source_id",
+                    "track_artifact.track_id",
+                    "track_canonical_link.canonical_id",
+                    "track_canonical_link.server_id",
+                    "track_canonical_link.track_id",
+                    "track_extension.server_id",
+                    "track_extension.track_id",
+                    "track_fact.server_id",
+                    "track_fact.source_id",
+                    "track_fact.track_id",
+                    "track_genre.album_id",
+                    "track_genre.library_id",
+                    "track_genre.server_id",
+                    "track_genre.track_id",
+                    "track_id_history.new_id",
+                    "track_id_history.old_id",
+                    "track_id_history.server_id",
+                    "track_offline.server_id",
+                    "track_offline.track_id",
+                ]
+                .into_iter()
+                .map(str::to_string)
+                .collect::<BTreeSet<_>>();
+                assert_eq!(actual, expected, "classify new identity-shaped columns in the canonical migration inventory");
+
+                let cluster_actual = identity_shaped_columns(conn, "cluster");
+                let cluster_expected = [
+                    "track_cluster_key.library_id",
+                    "track_cluster_key.server_id",
+                    "track_cluster_key.track_id",
+                ]
+                .into_iter()
+                .map(str::to_string)
+                .collect::<BTreeSet<_>>();
+                assert_eq!(cluster_actual, cluster_expected, "classify new cluster-sidecar identity columns");
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn raw_json_rewrites_album_artist_without_musicbrainz_ids() {
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = canonical_id(old);
+        let mut maps = IdMaps::default();
+        maps.artist.insert(old.to_string(), new.clone());
+        let mut value = serde_json::json!({
+            "albumArtistId": old,
+            "artist": old,
+            "albumArtists": [{"id": old}],
+            "contributors": [{"artistId": old, "musicBrainzId": old}],
+            "musicBrainzId": old,
+        });
+        assert!(rewrite_json_ids(&mut value, EntityKind::Album, &maps));
+        assert_eq!(value["albumArtistId"], new);
+        assert_eq!(value["artist"], old);
+        assert_eq!(value["albumArtists"][0]["id"], canonical_id(old));
+        assert_eq!(value["contributors"][0]["artistId"], canonical_id(old));
+        assert_eq!(value["contributors"][0]["musicBrainzId"], old);
+        assert_eq!(value["musicBrainzId"], old);
+    }
+
+    #[test]
+    fn journal_precedes_id_rewrite_and_resume_is_idempotent() {
+        let store = LibraryStore::open_in_memory();
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        store
+            .with_conn("test.seed", |conn| {
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,album,synced_at,raw_json) VALUES ('s1',?1,'Track','Album',1,?2)",
+                    params![old, format!(r#"{{"id":"{old}","albumArtistId":"{old}","musicBrainzId":"{old}"}}"#)],
+                )?;
+                conn.execute(
+                    "INSERT INTO artist(server_id,id,name,synced_at,raw_json) VALUES ('s1',?1,'Artist',1,'{}')",
+                    params![old],
+                )?;
+                conn.execute(
+                    "INSERT INTO navidrome_canonical_migration(server_id, canonical_version, state, detected_at) VALUES ('s1',1,'required',1)",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        populate_journal(&store, "s1").unwrap();
+        assert!(!status(&store, "s1").unwrap().mappings.is_empty());
+        let first = rewrite(&store, "s1").unwrap();
+        assert_eq!(first.state, "frontend");
+        let second = rewrite(&store, "s1").unwrap();
+        assert_eq!(second.state, "frontend");
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/navidrome_canonical_ids.rs
+++ b/src-tauri/crates/psysonic-library/src/navidrome_canonical_ids.rs
@@ -351,7 +351,7 @@ fn collect_probe_candidates(
         let mut candidates = Vec::new();
         for (kind, table) in [(EntityKind::Track, "track"), (EntityKind::Album, "album")] {
             let sql = format!(
-                "SELECT id FROM {table} WHERE server_id = ?1{} ORDER BY id LIMIT ?2",
+                "SELECT id FROM {table} WHERE server_id = ?1{} ORDER BY synced_at DESC, id LIMIT ?2",
                 if table == "track" { " AND deleted = 0" } else { "" }
             );
             let ids = conn
@@ -1054,6 +1054,30 @@ mod tests {
         assert_eq!(value["contributors"][0]["artistId"], canonical_id(old));
         assert_eq!(value["contributors"][0]["musicBrainzId"], old);
         assert_eq!(value["musicBrainzId"], old);
+    }
+
+    #[test]
+    fn probe_candidates_prefer_recently_synced_rows() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn("test.seed", |conn| {
+                for index in 0..MAX_PROBE_CANDIDATES {
+                    conn.execute(
+                        "INSERT INTO track(server_id,id,title,synced_at,raw_json) VALUES ('s1',?1,'Stale',1,'{}')",
+                        params![format!("{index:032x}")],
+                    )?;
+                }
+                conn.execute(
+                    "INSERT INTO track(server_id,id,title,synced_at,raw_json) VALUES ('s1','ffffffffffffffffffffffffffffffff','Live',2,'{}')",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        let candidates = collect_probe_candidates(&store, "s1").unwrap();
+        assert_eq!(candidates.len(), MAX_PROBE_CANDIDATES);
+        assert_eq!(candidates[0].old_id, "ffffffffffffffffffffffffffffffff");
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/navidrome_id_codec.rs
+++ b/src-tauri/crates/psysonic-library/src/navidrome_id_codec.rs
@@ -1,0 +1,161 @@
+//! Canonical Navidrome entity and structured-artwork ID codec.
+
+/// Exact port of Navidrome's uniform canonical-ID migration helper.
+pub fn canonical_id(value: &str) -> String {
+    let bytes = match value.len() {
+        22 => match decode_base62_u128(value) {
+            Ok(_) => return value.to_string(),
+            Err(Base62Error::Overflow) => md5::compute(value.as_bytes()).0,
+            Err(Base62Error::Invalid) => return value.to_string(),
+        },
+        32 => match decode_hex_16(value) {
+            Some(bytes) => bytes,
+            None => return value.to_string(),
+        },
+        36 => {
+            if value.as_bytes().get(8) != Some(&b'-')
+                || value.as_bytes().get(13) != Some(&b'-')
+                || value.as_bytes().get(18) != Some(&b'-')
+                || value.as_bytes().get(23) != Some(&b'-')
+            {
+                return value.to_string();
+            }
+            let compact = value.chars().filter(|character| *character != '-').collect::<String>();
+            match decode_hex_16(&compact) {
+                Some(bytes) => bytes,
+                None => return value.to_string(),
+            }
+        }
+        _ => return value.to_string(),
+    };
+    encode_base62(bytes)
+}
+
+/// Rewrite only the entity-bearing payload of a Navidrome artwork ID.
+pub fn canonical_artwork_id(value: &str) -> String {
+    let Some((prefix, payload)) = ["mf-", "al-", "ar-", "pl-", "dc-", "ra-"]
+        .into_iter()
+        .find_map(|prefix| value.strip_prefix(prefix).map(|payload| (prefix, payload)))
+    else {
+        return canonical_id(value);
+    };
+
+    let (payload, update_token) = split_update_token(payload);
+    let rewritten = if prefix == "dc-" {
+        match payload.split_once(':') {
+            Some((album_id, disc_number)) => {
+                format!("{}:{disc_number}", canonical_id(album_id))
+            }
+            None => payload.to_string(),
+        }
+    } else {
+        canonical_id(payload)
+    };
+    match update_token {
+        Some(token) => format!("{prefix}{rewritten}_{token}"),
+        None => format!("{prefix}{rewritten}"),
+    }
+}
+
+fn split_update_token(value: &str) -> (&str, Option<&str>) {
+    let Some((payload, token)) = value.rsplit_once('_') else {
+        return (value, None);
+    };
+    if !token.is_empty() && token.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        (payload, Some(token))
+    } else {
+        (value, None)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Base62Error {
+    Invalid,
+    Overflow,
+}
+
+fn decode_base62_u128(value: &str) -> Result<u128, Base62Error> {
+    let mut out = 0u128;
+    for byte in value.bytes() {
+        let digit = match byte {
+            b'0'..=b'9' => (byte - b'0') as u128,
+            b'a'..=b'z' => (byte - b'a' + 10) as u128,
+            b'A'..=b'Z' => (byte - b'A' + 36) as u128,
+            _ => return Err(Base62Error::Invalid),
+        };
+        out = out
+            .checked_mul(62)
+            .and_then(|current| current.checked_add(digit))
+            .ok_or(Base62Error::Overflow)?;
+    }
+    Ok(out)
+}
+
+fn decode_hex_16(value: &str) -> Option<[u8; 16]> {
+    if value.len() != 32 {
+        return None;
+    }
+    let mut out = [0u8; 16];
+    for (index, slot) in out.iter_mut().enumerate() {
+        let high = hex_digit(value.as_bytes()[index * 2])?;
+        let low = hex_digit(value.as_bytes()[index * 2 + 1])?;
+        *slot = (high << 4) | low;
+    }
+    Some(out)
+}
+
+fn hex_digit(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn encode_base62(bytes: [u8; 16]) -> String {
+    const DIGITS: &[u8; 62] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    let mut value = u128::from_be_bytes(bytes);
+    let mut encoded = [b'0'; 22];
+    let mut index = encoded.len();
+    while value > 0 {
+        index -= 1;
+        encoded[index] = DIGITS[(value % 62) as usize];
+        value /= 62;
+    }
+    String::from_utf8(encoded.to_vec()).expect("base62 alphabet is UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_upstream_vectors() {
+        for (input, expected) in [
+            ("5cLJPkLA5DK2BADhoeotPk", "5cLJPkLA5DK2BADhoeotPk"),
+            ("zzzzzzzzzzzzzzzzzzzzzz", "3LyqmwQBm5IRqlVjNYASwb"),
+            ("e3b7fc2ae9447bbec37a13bf916e3cf6", "6VHl3uR4kss6sUPKA8Cwnk"),
+            ("f47ac10b-58cc-4372-a567-0e02b2c3d479", "7rke2SAWaicSeSYzkhww6R"),
+        ] {
+            assert_eq!(canonical_id(input), expected);
+        }
+    }
+
+    #[test]
+    fn rewrites_structured_artwork_without_losing_suffixes() {
+        let old = "e3b7fc2ae9447bbec37a13bf916e3cf6";
+        let new = "6VHl3uR4kss6sUPKA8Cwnk";
+        for prefix in ["mf-", "al-", "ar-", "pl-", "ra-"] {
+            assert_eq!(canonical_artwork_id(&format!("{prefix}{old}")), format!("{prefix}{new}"));
+            assert_eq!(
+                canonical_artwork_id(&format!("{prefix}{old}_60fc987f")),
+                format!("{prefix}{new}_60fc987f")
+            );
+        }
+        assert_eq!(
+            canonical_artwork_id(&format!("dc-{old}:2_60fc987f")),
+            format!("dc-{new}:2_60fc987f")
+        );
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/store.rs
+++ b/src-tauri/crates/psysonic-library/src/store.rs
@@ -12,7 +12,7 @@ use tauri::Manager;
 ///
 /// Migration checklist (wiring, data backfill, open/swap path):
 /// psysonic-workdocs `ai/agent-rules/08-library-db-migrations.md`.
-pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 26;
+pub const LIBRARY_DB_SCHEMA_VERSION: i64 = 27;
 
 /// One-time data repair after migration 014 (`artist.name_sort`).
 pub(crate) const ARTIST_NAME_SORT_RECONCILE_ID: &str = "artist_name_sort_reconcile_v1";
@@ -89,6 +89,9 @@ pub(crate) const MIGRATION_025_IDENTITY_INVALIDATION: &str =
 /// Version 26: resumable cursor for bounded post-sync library tagging.
 pub(crate) const MIGRATION_026_LIBRARY_TAG_CURSOR: &str =
     include_str!("../migrations/026_library_tag_cursor.sql");
+/// Version 27: durable stop-the-world Navidrome canonical-ID migration state.
+pub(crate) const MIGRATION_027_NAVIDROME_CANONICAL_IDS: &str =
+    include_str!("../migrations/027_navidrome_canonical_ids.sql");
 
 /// Embedded migrations. Ordered ascending by `version`; the runner sorts
 /// defensively before applying so the source order can stay readable.
@@ -109,6 +112,7 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (24, MIGRATION_024_COMPOSER_BROWSE_PROJECTION),
     (25, MIGRATION_025_IDENTITY_INVALIDATION),
     (26, MIGRATION_026_LIBRARY_TAG_CURSOR),
+    (27, MIGRATION_027_NAVIDROME_CANONICAL_IDS),
 ];
 
 /// Idempotent repair — also runs after the migration runner on every open so

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -203,6 +203,10 @@ fn specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             psysonic_library::commands::library_get_recent_play_sessions,
             psysonic_library::commands::library_purge_server,
             psysonic_library::commands::library_migrate_server_index_keys,
+            psysonic_library::commands::library_navidrome_canonical_inspect,
+            psysonic_library::commands::library_navidrome_canonical_rewrite,
+            psysonic_library::commands::library_navidrome_canonical_ack_frontend,
+            psysonic_library::commands::library_navidrome_canonical_finalize,
             psysonic_library::commands::library_delete_server_data,
             // psysonic-audio (audio_play + audio_chain_preload excluded: >10 args
             // exceed specta's SpectaFn limit — see the note at their definitions)
@@ -1533,6 +1537,10 @@ pub fn run() {
             psysonic_library::commands::library_get_recent_play_sessions,
             psysonic_library::commands::library_purge_server,
             psysonic_library::commands::library_migrate_server_index_keys,
+            psysonic_library::commands::library_navidrome_canonical_inspect,
+            psysonic_library::commands::library_navidrome_canonical_rewrite,
+            psysonic_library::commands::library_navidrome_canonical_ack_frontend,
+            psysonic_library::commands::library_navidrome_canonical_finalize,
             psysonic_library::commands::library_delete_server_data,
             psysonic_library::commands::library_analysis_backfill_batch,
             library_analysis_backfill::library_analysis_backfill_configure,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useAuthStore } from './store/authStore';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { useLyricsStore } from './store/lyricsStore';
@@ -12,6 +12,30 @@ import { getWindowKind } from './app/windowKind';
 import { showToast } from '@/lib/dom/toast';
 import MiniPlayerApp from './app/MiniPlayerApp';
 import MainApp from './app/MainApp';
+import BlockingMigrationGate from './app/BlockingMigrationGate';
+import { useMigrationOrchestrator } from '@/app/hooks/useMigrationOrchestrator';
+import { useMigrationStore } from '@/store/migrationStore';
+
+function MainWindowRoot() {
+  useMigrationOrchestrator();
+  const migrationReady = useMigrationStore(state => state.phase === 'completed');
+  const [playbackBridgeReady, setPlaybackBridgeReady] = useState(false);
+
+  useEffect(() => {
+    if (!migrationReady) return;
+    let disposed = false;
+    void import('@/features/playback/store/playbackEngineBridgeRegister').then(() => {
+      if (!disposed) setPlaybackBridgeReady(true);
+    });
+    return () => { disposed = true; };
+  }, [migrationReady]);
+
+  return (
+    <BlockingMigrationGate>
+      {playbackBridgeReady ? <MainApp /> : null}
+    </BlockingMigrationGate>
+  );
+}
 
 export default function App() {
   const theme = useThemeStore(s => s.theme);
@@ -207,5 +231,5 @@ export default function App() {
     );
   }, [trackPreviewDurationSec]);
 
-  return getWindowKind() === 'mini' ? <MiniPlayerApp /> : <MainApp />;
+  return getWindowKind() === 'mini' ? <MiniPlayerApp /> : <MainWindowRoot />;
 }

--- a/src/app/BlockingMigrationGate.test.tsx
+++ b/src/app/BlockingMigrationGate.test.tsx
@@ -11,9 +11,16 @@ vi.mock('@/app/hooks/useMigrationOrchestrator', () => ({
   retryBlockingMigration: vi.fn(),
 }));
 
+vi.mock('@/app/startupSplash', () => ({
+  scheduleStartupSplashDismiss: vi.fn(),
+}));
+
+import { scheduleStartupSplashDismiss } from '@/app/startupSplash';
+
 describe('BlockingMigrationGate', () => {
   beforeEach(() => {
     useMigrationStore.setState({ phase: 'idle', step: null, lastError: null });
+    vi.mocked(scheduleStartupSplashDismiss).mockClear();
   });
 
   it('blocks the initial idle frame before the first inspect resolves', () => {
@@ -25,6 +32,7 @@ describe('BlockingMigrationGate', () => {
 
     expect(screen.queryByText('normal app')).toBeNull();
     expect(screen.getByText('migration.preparing')).toBeInTheDocument();
+    expect(scheduleStartupSplashDismiss).toHaveBeenCalledOnce();
   });
 
   it('does not mount normal application children while migration is blocking', () => {

--- a/src/app/BlockingMigrationGate.test.tsx
+++ b/src/app/BlockingMigrationGate.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BlockingMigrationGate from './BlockingMigrationGate';
+import { useMigrationStore } from '@/store/migrationStore';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/app/hooks/useMigrationOrchestrator', () => ({
+  retryBlockingMigration: vi.fn(),
+}));
+
+describe('BlockingMigrationGate', () => {
+  beforeEach(() => {
+    useMigrationStore.setState({ phase: 'idle', step: null, lastError: null });
+  });
+
+  it('blocks the initial idle frame before the first inspect resolves', () => {
+    render(
+      <BlockingMigrationGate>
+        <div>normal app</div>
+      </BlockingMigrationGate>,
+    );
+
+    expect(screen.queryByText('normal app')).toBeNull();
+    expect(screen.getByText('migration.preparing')).toBeInTheDocument();
+  });
+
+  it('does not mount normal application children while migration is blocking', () => {
+    useMigrationStore.setState({ phase: 'running', step: 'navidromeCanonical' });
+
+    render(
+      <BlockingMigrationGate>
+        <div>normal app</div>
+      </BlockingMigrationGate>,
+    );
+
+    expect(screen.queryByText('normal app')).toBeNull();
+    expect(screen.getByText('migration.migrating')).toBeInTheDocument();
+  });
+
+  it('mounts normal application children only after migration completes', () => {
+    useMigrationStore.setState({ phase: 'completed', step: null });
+
+    render(
+      <BlockingMigrationGate>
+        <div>normal app</div>
+      </BlockingMigrationGate>,
+    );
+
+    expect(screen.getByText('normal app')).toBeInTheDocument();
+  });
+});

--- a/src/app/BlockingMigrationGate.tsx
+++ b/src/app/BlockingMigrationGate.tsx
@@ -1,6 +1,7 @@
-import type { ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { retryBlockingMigration } from '@/app/hooks/useMigrationOrchestrator';
+import { scheduleStartupSplashDismiss } from '@/app/startupSplash';
 import { useMigrationStore } from '../store/migrationStore';
 
 function MigrationModal() {
@@ -32,6 +33,10 @@ function MigrationModal() {
   const activeProgress = isNavidromeCanonical
     ? null
     : isGenreTags ? genreTagsProgress : isScopeBrowseProjection ? scopeBrowseProjectionProgress : progress;
+
+  useEffect(() => {
+    scheduleStartupSplashDismiss();
+  }, []);
 
   const migratedRows = (inspect?.library.totalLegacyRows ?? 0) + (inspect?.analysis.totalLegacyRows ?? 0);
   return (

--- a/src/app/BlockingMigrationGate.tsx
+++ b/src/app/BlockingMigrationGate.tsx
@@ -12,19 +12,26 @@ function MigrationModal() {
   const scopeBrowseProjectionProgress = useMigrationStore(s => s.scopeBrowseProjectionProgress);
   const inspect = useMigrationStore(s => s.inspect);
   const error = useMigrationStore(s => s.lastError);
+  const isNavidromeCanonical = step === 'navidromeCanonical';
   const isGenreTags = step === 'genreTags';
   const isScopeBrowseProjection = step === 'scopeBrowseProjection';
-  const migrationTitle = isGenreTags
+  const migrationTitle = isNavidromeCanonical
+    ? t('migration.migrating')
+    : isGenreTags
     ? t('migration.genreTagsTitle')
     : isScopeBrowseProjection
       ? t('migration.scopeBrowseProjectionTitle')
       : t('migration.migrating');
-  const migrationBody = isGenreTags
+  const migrationBody = isNavidromeCanonical
+    ? t('migration.working')
+    : isGenreTags
     ? t('migration.genreTagsBody')
     : isScopeBrowseProjection
       ? t('migration.scopeBrowseProjectionBody')
       : (progress ? `${progress.stage} - ${progress.table}` : t('migration.working'));
-  const activeProgress = isGenreTags ? genreTagsProgress : isScopeBrowseProjection ? scopeBrowseProjectionProgress : progress;
+  const activeProgress = isNavidromeCanonical
+    ? null
+    : isGenreTags ? genreTagsProgress : isScopeBrowseProjection ? scopeBrowseProjectionProgress : progress;
 
   const migratedRows = (inspect?.library.totalLegacyRows ?? 0) + (inspect?.analysis.totalLegacyRows ?? 0);
   return (
@@ -46,11 +53,11 @@ function MigrationModal() {
         color: 'var(--text)',
       }}
       >
-        {phase === 'inspecting' && (
+        {(phase === 'idle' || phase === 'inspecting') && (
           <>
-            <h3>{isGenreTags ? t('migration.genreTagsTitle') : isScopeBrowseProjection ? t('migration.scopeBrowseProjectionTitle') : t('migration.preparing')}</h3>
+             <h3>{isNavidromeCanonical ? t('migration.preparing') : isGenreTags ? t('migration.genreTagsTitle') : isScopeBrowseProjection ? t('migration.scopeBrowseProjectionTitle') : t('migration.preparing')}</h3>
             <p style={{ color: 'var(--text-muted)' }}>
-              {isGenreTags ? t('migration.genreTagsBody') : isScopeBrowseProjection ? t('migration.scopeBrowseProjectionBody') : t('migration.preparingBody')}
+               {isNavidromeCanonical ? t('migration.preparingBody') : isGenreTags ? t('migration.genreTagsBody') : isScopeBrowseProjection ? t('migration.scopeBrowseProjectionBody') : t('migration.preparingBody')}
             </p>
           </>
         )}
@@ -72,7 +79,7 @@ function MigrationModal() {
         )}
         {phase === 'error' && (
           <>
-            <h3>{isGenreTags ? t('migration.genreTagsFailed') : isScopeBrowseProjection ? t('migration.scopeBrowseProjectionFailed') : t('migration.failed')}</h3>
+             <h3>{isNavidromeCanonical ? t('migration.failed') : isGenreTags ? t('migration.genreTagsFailed') : isScopeBrowseProjection ? t('migration.scopeBrowseProjectionFailed') : t('migration.failed')}</h3>
             <p style={{ color: 'var(--text-muted)' }}>{String(error ?? '').slice(0, 200)}</p>
             <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
               <button className="btn-primary" onClick={() => retryBlockingMigration()}>{t('migration.retry')}</button>
@@ -95,11 +102,6 @@ function MigrationModal() {
 
 export default function BlockingMigrationGate({ children }: { children: ReactNode }) {
   const phase = useMigrationStore(s => s.phase);
-  const isBlocking = phase === 'inspecting' || phase === 'running' || phase === 'error';
-  return (
-    <>
-      {children}
-      {isBlocking ? <MigrationModal /> : null}
-    </>
-  );
+  const isBlocking = phase !== 'completed';
+  return isBlocking ? <MigrationModal /> : children;
 }

--- a/src/app/MainApp.tsx
+++ b/src/app/MainApp.tsx
@@ -1,5 +1,4 @@
 import { initAudioListeners } from '@/features/playback/store/initAudioListeners';
-import '@/features/playback/store/playbackEngineBridgeRegister'; // installs the playback-engine bridge at boot
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router';
 import { preloadMiniPlayer as preloadMiniPlayerWindow } from '@/lib/api/miniPlayer';
@@ -33,14 +32,11 @@ import { useCoverArtPrefetch } from '../cover/useCoverArtPrefetch';
 import { useLibraryCoverBackfill } from '@/cover/useLibraryCoverBackfill';
 import { useCoverRevalidateScheduler } from '../cover/useCoverRevalidateScheduler';
 import { runCoverIdbUpgradeMigration } from '@/app/migrations/coverIdbUpgradeMigration';
-import { useMigrationOrchestrator } from '@/app/hooks/useMigrationOrchestrator';
 import { IS_WINDOWS } from '@/lib/util/platform';
 import TauriEventBridge from './TauriEventBridge';
 import AppShell from './AppShell';
 import ErrorBoundary from '@/app/ErrorBoundary';
-import BlockingMigrationGate from './BlockingMigrationGate';
 import RequireAuth from './RequireAuth';
-import { useMigrationStore } from '../store/migrationStore';
 import BenchmarkRunner from './BenchmarkRunner';
 
 const Login = lazy(() => import('@/features/auth/pages/Login'));
@@ -66,12 +62,8 @@ export default function MainApp() {
   const activeServerId = useAuthStore(s => s.activeServerId);
   const serverIdsKey = useAuthStore(s => s.servers.map(srv => srv.id).join(','));
   const masterEnabled = useLibraryIndexStore(s => s.masterEnabled);
-  const migrationPhase = useMigrationStore(s => s.phase);
-  const migrationReady = migrationPhase === 'completed';
   const startupQueueReconcileStartedRef = useRef(false);
-  useMigrationOrchestrator();
   useEffect(() => {
-    if (!migrationReady) return;
     const shouldReconcileStartupQueue = !startupQueueReconcileStartedRef.current;
     if (shouldReconcileStartupQueue) startupQueueReconcileStartedRef.current = true;
     void (async () => {
@@ -81,17 +73,16 @@ export default function MainApp() {
         await reconcileStartupPlayQueues();
       }
     })();
-  }, [activeServerId, serverIdsKey, masterEnabled, migrationReady]);
+  }, [activeServerId, serverIdsKey, masterEnabled]);
 
-  useLibraryAnalysisBackfill(migrationReady);
-  useCoverArtPrefetch(migrationReady);
-  useLibraryCoverBackfill(migrationReady);
-  useCoverRevalidateScheduler(migrationReady);
+  useLibraryAnalysisBackfill(true);
+  useCoverArtPrefetch(true);
+  useLibraryCoverBackfill(true);
+  useCoverRevalidateScheduler(true);
 
   useEffect(() => {
-    if (!migrationReady) return;
     void runCoverIdbUpgradeMigration();
-  }, [migrationReady]);
+  }, []);
 
   // Push playback state to mini window + handle control events.
   useEffect(() => {
@@ -103,22 +94,19 @@ export default function MainApp() {
   // a hang workaround — skip here to avoid double-building.
   const preloadMiniPlayer = useAuthStore(s => s.preloadMiniPlayer);
   useEffect(() => {
-    if (!migrationReady || IS_WINDOWS || !preloadMiniPlayer) return;
+    if (IS_WINDOWS || !preloadMiniPlayer) return;
     preloadMiniPlayerWindow().catch(() => {});
-  }, [preloadMiniPlayer, migrationReady]);
+  }, [preloadMiniPlayer]);
 
   useEffect(() => {
-    if (!migrationReady) return undefined;
     return initAudioListeners();
-  }, [migrationReady]);
+  }, []);
 
   useEffect(() => {
-    if (!migrationReady) return undefined;
     return initHotCachePrefetch();
-  }, [migrationReady]);
+  }, []);
 
   useEffect(() => {
-    if (!migrationReady) return undefined;
     void (async () => {
       await runLegacyOfflineFileMigration();
       const servers = useAuthStore.getState().servers;
@@ -137,12 +125,11 @@ export default function MainApp() {
       stopPinnedOfflineSync();
       stopOfflineResume();
     };
-  }, [migrationReady, serverIdsKey]);
+  }, [serverIdsKey]);
 
   useEffect(() => {
-    if (!migrationReady) return;
     useGlobalShortcutsStore.getState().registerAll();
-  }, [migrationReady]);
+  }, []);
 
   // ── Easter egg: Ctrl+Shift+Alt+N → export new albums image ──
   useEffect(() => {
@@ -194,31 +181,29 @@ export default function MainApp() {
   return (
     <WindowVisibilityProvider>
       <BrowserRouter>
-        <BlockingMigrationGate>
-          <PasteClipboardHandler />
-           <TauriEventBridge />
-          <BenchmarkRunner />
-          <Suspense fallback={null}>
-            <Routes>
-              <Route path="/login" element={<Login />} />
-              <Route
-                path="/*"
-                element={
-                  <RequireAuth>
-                    <ErrorBoundary>
-                      <DragDropProvider>
-                        <AppShell />
-                      </DragDropProvider>
-                    </ErrorBoundary>
-                  </RequireAuth>
-                }
-              />
-            </Routes>
-          </Suspense>
-          {exportPickerOpen && <ExportPickerModal onConfirm={handleExport} onClose={() => setExportPickerOpen(false)} />}
-          <ZipDownloadOverlay />
-          <FpsOverlay />
-        </BlockingMigrationGate>
+        <PasteClipboardHandler />
+        <TauriEventBridge />
+        <BenchmarkRunner />
+        <Suspense fallback={null}>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route
+              path="/*"
+              element={
+                <RequireAuth>
+                  <ErrorBoundary>
+                    <DragDropProvider>
+                      <AppShell />
+                    </DragDropProvider>
+                  </ErrorBoundary>
+                </RequireAuth>
+              }
+            />
+          </Routes>
+        </Suspense>
+        {exportPickerOpen && <ExportPickerModal onConfirm={handleExport} onClose={() => setExportPickerOpen(false)} />}
+        <ZipDownloadOverlay />
+        <FpsOverlay />
       </BrowserRouter>
     </WindowVisibilityProvider>
   );

--- a/src/app/hooks/useMigrationOrchestrator.test.ts
+++ b/src/app/hooks/useMigrationOrchestrator.test.ts
@@ -9,6 +9,15 @@ const libraryGenreTagsInspectMock = vi.fn();
 const libraryGenreTagsRunMock = vi.fn();
 const libraryScopeBrowseProjectionInspectMock = vi.fn();
 const libraryScopeBrowseProjectionRunMock = vi.fn();
+const libraryNavidromeCanonicalInspectMock = vi.fn();
+const bindIndexedServerForMigrationMock = vi.fn();
+const enqueueLibrarySyncMock = vi.fn();
+const libraryNavidromeCanonicalRewriteMock = vi.fn();
+const libraryNavidromeCanonicalAckFrontendMock = vi.fn();
+const libraryNavidromeCanonicalFinalizeMock = vi.fn();
+const rewriteNavidromeCanonicalFrontendStateMock = vi.fn();
+const audioStopMock = vi.fn();
+const analysisDeleteAllForServerMock = vi.fn();
 const rewriteFrontendStoreKeysMock = vi.fn(async (_servers: unknown) => undefined);
 
 vi.mock('@tauri-apps/api/event', () => ({
@@ -25,6 +34,31 @@ vi.mock('@/lib/api/library', () => ({
   libraryGenreTagsRun: () => libraryGenreTagsRunMock(),
   libraryScopeBrowseProjectionInspect: () => libraryScopeBrowseProjectionInspectMock(),
   libraryScopeBrowseProjectionRun: () => libraryScopeBrowseProjectionRunMock(),
+  libraryNavidromeCanonicalInspect: () => libraryNavidromeCanonicalInspectMock(),
+  libraryNavidromeCanonicalRewrite: (...args: unknown[]) => libraryNavidromeCanonicalRewriteMock(...args),
+  libraryNavidromeCanonicalAckFrontend: (...args: unknown[]) => libraryNavidromeCanonicalAckFrontendMock(...args),
+  libraryNavidromeCanonicalFinalize: (...args: unknown[]) => libraryNavidromeCanonicalFinalizeMock(...args),
+}));
+
+vi.mock('@/lib/library/librarySession', () => ({
+  bindIndexedServerForMigration: (...args: unknown[]) => bindIndexedServerForMigrationMock(...args),
+}));
+
+vi.mock('@/lib/library/librarySyncQueue', () => ({
+  enqueueLibrarySync: (...args: unknown[]) => enqueueLibrarySyncMock(...args),
+}));
+
+vi.mock('@/lib/api/audio', () => ({ audioStop: (...args: unknown[]) => audioStopMock(...args) }));
+vi.mock('@/lib/api/analysis', () => ({
+  analysisDeleteAllForServer: (...args: unknown[]) => analysisDeleteAllForServerMock(...args),
+}));
+vi.mock('@/cover/imageCache', () => ({ clearImageCache: vi.fn() }));
+vi.mock('@/lib/api/coverCache', () => ({ coverCacheClearServer: vi.fn() }));
+vi.mock('@/features/lyrics/utils/lyricsPersistentCache', () => ({ clearLyricsCache: vi.fn() }));
+vi.mock('@/features/home/store/homeFeedCache', () => ({ clearHomeFeedCache: vi.fn() }));
+vi.mock('@/features/home/store/becauseYouLikeCache', () => ({ clearBecauseYouLikeCache: vi.fn() }));
+vi.mock('@/app/migrations/navidromeCanonicalFrontend', () => ({
+  rewriteNavidromeCanonicalFrontendState: (...args: unknown[]) => rewriteNavidromeCanonicalFrontendStateMock(...args),
 }));
 
 vi.mock('@/utils/server/rewriteFrontendStoreKeys', () => ({
@@ -44,6 +78,24 @@ describe('useMigrationOrchestrator', () => {
     libraryGenreTagsRunMock.mockReset();
     libraryScopeBrowseProjectionInspectMock.mockReset();
     libraryScopeBrowseProjectionRunMock.mockReset();
+    libraryNavidromeCanonicalInspectMock.mockReset().mockResolvedValue({
+      serverId: 'a.test',
+      state: 'not_applicable',
+      canonicalVersion: 1,
+      probeKind: null,
+      probeOldId: null,
+      probeNewId: null,
+      lastError: null,
+      mappings: [],
+    });
+    bindIndexedServerForMigrationMock.mockReset().mockResolvedValue('bound');
+    enqueueLibrarySyncMock.mockReset().mockResolvedValue(undefined);
+    libraryNavidromeCanonicalRewriteMock.mockReset();
+    libraryNavidromeCanonicalAckFrontendMock.mockReset();
+    libraryNavidromeCanonicalFinalizeMock.mockReset();
+    rewriteNavidromeCanonicalFrontendStateMock.mockReset().mockResolvedValue(undefined);
+    audioStopMock.mockReset().mockResolvedValue(undefined);
+    analysisDeleteAllForServerMock.mockReset().mockResolvedValue({ analysisTracks: 0, waveforms: 0, loudness: 0 });
     libraryGenreTagsInspectMock.mockResolvedValue({ needed: false, totalTracks: 0, doneTracks: 0 });
     libraryGenreTagsRunMock.mockResolvedValue(undefined);
     libraryScopeBrowseProjectionInspectMock.mockResolvedValue({ needed: false, totalTracks: 0, doneTracks: 0 });
@@ -67,6 +119,7 @@ describe('useMigrationOrchestrator', () => {
       genreTagsProgress: null,
       scopeBrowseProjectionInspect: null,
       scopeBrowseProjectionProgress: null,
+      navidromeCanonical: null,
       lastError: null,
     });
     (globalThis as Record<string, unknown>)[REAL_MIGRATION_TEST_OVERRIDE] = true;
@@ -231,5 +284,94 @@ describe('useMigrationOrchestrator', () => {
     await waitFor(() => {
       expect(useMigrationStore.getState().phase).toBe('completed');
     });
+  });
+
+  it('keeps normal startup blocked through rewrite, frontend persistence, full sync, and finalize', async () => {
+    migrationInspectMock.mockResolvedValue({
+      needsMigration: false, hasSkippedUnknownServerRows: false, canRun: true, warnings: [],
+      unmappedEmptyBucket: false,
+      library: { totalLegacyRows: 0, skippedUnknownServerRows: 0, tables: {} },
+      analysis: { totalLegacyRows: 0, skippedUnknownServerRows: 0, tables: {} },
+      mappings: [{ legacyId: 'legacy-a', indexKey: 'a.test' }],
+    });
+    const mapping = { entityKind: 'track', oldId: 'old', newId: 'new' };
+    libraryNavidromeCanonicalInspectMock
+      .mockResolvedValueOnce({
+        serverId: 'a.test', state: 'required', canonicalVersion: 1,
+        probeKind: 'track', probeOldId: 'old', probeNewId: 'new', lastError: null,
+        mappings: [mapping],
+      })
+      .mockResolvedValueOnce({
+        serverId: 'a.test', state: 'resyncing', canonicalVersion: 1,
+        probeKind: 'track', probeOldId: 'old', probeNewId: 'new', lastError: null,
+        mappings: [mapping],
+      });
+    libraryNavidromeCanonicalRewriteMock.mockResolvedValue({
+      serverId: 'a.test', state: 'frontend', canonicalVersion: 1,
+      probeKind: 'track', probeOldId: 'old', probeNewId: 'new', lastError: null,
+      mappings: [mapping],
+    });
+    libraryNavidromeCanonicalAckFrontendMock.mockResolvedValue({
+      serverId: 'a.test', state: 'resyncing', canonicalVersion: 1,
+      probeKind: 'track', probeOldId: 'old', probeNewId: 'new', lastError: null,
+      mappings: [mapping],
+    });
+    libraryNavidromeCanonicalFinalizeMock.mockResolvedValue({
+      serverId: 'a.test', state: 'ready', canonicalVersion: 1,
+      probeKind: 'track', probeOldId: 'old', probeNewId: 'new', lastError: null,
+      mappings: [],
+    });
+
+    renderHook(() => useMigrationOrchestrator());
+
+    await waitFor(() => expect(useMigrationStore.getState().phase).toBe('completed'));
+    expect(libraryNavidromeCanonicalRewriteMock).toHaveBeenCalledWith('a.test');
+    expect(rewriteNavidromeCanonicalFrontendStateMock).toHaveBeenCalled();
+    expect(analysisDeleteAllForServerMock).toHaveBeenCalledWith('a.test');
+    expect(libraryNavidromeCanonicalAckFrontendMock).toHaveBeenCalledWith('a.test');
+    expect(enqueueLibrarySyncMock).toHaveBeenCalledWith({ serverId: 'a.test', kind: 'full' });
+    expect(libraryNavidromeCanonicalFinalizeMock).toHaveBeenCalledWith('a.test');
+  });
+
+  it('keeps the gate in error when the required full sync fails', async () => {
+    migrationInspectMock.mockResolvedValue({
+      needsMigration: false, hasSkippedUnknownServerRows: false, canRun: true, warnings: [],
+      unmappedEmptyBucket: false,
+      library: { totalLegacyRows: 0, skippedUnknownServerRows: 0, tables: {} },
+      analysis: { totalLegacyRows: 0, skippedUnknownServerRows: 0, tables: {} },
+      mappings: [{ legacyId: 'legacy-a', indexKey: 'a.test' }],
+    });
+    libraryNavidromeCanonicalInspectMock.mockResolvedValue({
+      serverId: 'a.test', state: 'resyncing', canonicalVersion: 1,
+      probeKind: null, probeOldId: null, probeNewId: null, lastError: null, mappings: [],
+    });
+    enqueueLibrarySyncMock.mockRejectedValue(new Error('sync failed'));
+
+    renderHook(() => useMigrationOrchestrator());
+
+    await waitFor(() => expect(useMigrationStore.getState().phase).toBe('error'));
+    expect(useMigrationStore.getState().step).toBe('navidromeCanonical');
+    expect(useMigrationStore.getState().lastError).toBe('sync failed');
+    expect(libraryNavidromeCanonicalFinalizeMock).not.toHaveBeenCalled();
+  });
+
+  it('allows offline startup for a durable terminal canonical state', async () => {
+    migrationInspectMock.mockResolvedValue({
+      needsMigration: false, hasSkippedUnknownServerRows: false, canRun: true, warnings: [],
+      unmappedEmptyBucket: false,
+      library: { totalLegacyRows: 0, skippedUnknownServerRows: 0, tables: {} },
+      analysis: { totalLegacyRows: 0, skippedUnknownServerRows: 0, tables: {} },
+      mappings: [{ legacyId: 'legacy-a', indexKey: 'a.test' }],
+    });
+    bindIndexedServerForMigrationMock.mockResolvedValue('offline');
+    libraryNavidromeCanonicalInspectMock.mockResolvedValue({
+      serverId: 'a.test', state: 'ready', canonicalVersion: 1,
+      probeKind: null, probeOldId: null, probeNewId: null, lastError: null, mappings: [],
+    });
+
+    renderHook(() => useMigrationOrchestrator());
+
+    await waitFor(() => expect(useMigrationStore.getState().phase).toBe('completed'));
+    expect(rewriteNavidromeCanonicalFrontendStateMock).toHaveBeenCalled();
   });
 });

--- a/src/app/hooks/useMigrationOrchestrator.test.ts
+++ b/src/app/hooks/useMigrationOrchestrator.test.ts
@@ -333,6 +333,47 @@ describe('useMigrationOrchestrator', () => {
     expect(libraryNavidromeCanonicalFinalizeMock).toHaveBeenCalledWith('a.test');
   });
 
+  it('resumes a restart after native commit by replaying frontend persistence', async () => {
+    migrationInspectMock.mockResolvedValue({
+      needsMigration: false, hasSkippedUnknownServerRows: false, canRun: true, warnings: [],
+      unmappedEmptyBucket: false,
+      library: { totalLegacyRows: 0, skippedUnknownServerRows: 0, tables: {} },
+      analysis: { totalLegacyRows: 0, skippedUnknownServerRows: 0, tables: {} },
+      mappings: [{ legacyId: 'legacy-a', indexKey: 'a.test' }],
+    });
+    const mapping = { entityKind: 'track', oldId: 'old', newId: 'new' };
+    libraryNavidromeCanonicalInspectMock
+      .mockResolvedValueOnce({
+        serverId: 'a.test', state: 'frontend', canonicalVersion: 1,
+        probeKind: 'track', probeOldId: 'old', probeNewId: 'new', lastError: null,
+        mappings: [mapping],
+      })
+      .mockResolvedValueOnce({
+        serverId: 'a.test', state: 'resyncing', canonicalVersion: 1,
+        probeKind: 'track', probeOldId: 'old', probeNewId: 'new', lastError: null,
+        mappings: [mapping],
+      });
+    libraryNavidromeCanonicalAckFrontendMock.mockResolvedValue({
+      serverId: 'a.test', state: 'resyncing', canonicalVersion: 1,
+      probeKind: 'track', probeOldId: 'old', probeNewId: 'new', lastError: null,
+      mappings: [mapping],
+    });
+    libraryNavidromeCanonicalFinalizeMock.mockResolvedValue({
+      serverId: 'a.test', state: 'ready', canonicalVersion: 1,
+      probeKind: 'track', probeOldId: 'old', probeNewId: 'new', lastError: null,
+      mappings: [],
+    });
+
+    renderHook(() => useMigrationOrchestrator());
+
+    await waitFor(() => expect(useMigrationStore.getState().phase).toBe('completed'));
+    expect(libraryNavidromeCanonicalRewriteMock).not.toHaveBeenCalled();
+    expect(rewriteNavidromeCanonicalFrontendStateMock).toHaveBeenCalledTimes(2);
+    expect(libraryNavidromeCanonicalAckFrontendMock).toHaveBeenCalledWith('a.test');
+    expect(enqueueLibrarySyncMock).toHaveBeenCalledWith({ serverId: 'a.test', kind: 'full' });
+    expect(libraryNavidromeCanonicalFinalizeMock).toHaveBeenCalledWith('a.test');
+  });
+
   it('keeps the gate in error when the required full sync fails', async () => {
     migrationInspectMock.mockResolvedValue({
       needsMigration: false, hasSkippedUnknownServerRows: false, canRun: true, warnings: [],
@@ -352,6 +393,9 @@ describe('useMigrationOrchestrator', () => {
     await waitFor(() => expect(useMigrationStore.getState().phase).toBe('error'));
     expect(useMigrationStore.getState().step).toBe('navidromeCanonical');
     expect(useMigrationStore.getState().lastError).toBe('sync failed');
+    expect(rewriteNavidromeCanonicalFrontendStateMock).toHaveBeenCalledOnce();
+    expect(analysisDeleteAllForServerMock).toHaveBeenCalledWith('a.test');
+    expect(enqueueLibrarySyncMock).toHaveBeenCalledWith({ serverId: 'a.test', kind: 'full' });
     expect(libraryNavidromeCanonicalFinalizeMock).not.toHaveBeenCalled();
   });
 

--- a/src/app/hooks/useMigrationOrchestrator.ts
+++ b/src/app/hooks/useMigrationOrchestrator.ts
@@ -3,6 +3,10 @@ import { listen } from '@tauri-apps/api/event';
 import {
   libraryGenreTagsInspect,
   libraryGenreTagsRun,
+  libraryNavidromeCanonicalAckFrontend,
+  libraryNavidromeCanonicalFinalize,
+  libraryNavidromeCanonicalInspect,
+  libraryNavidromeCanonicalRewrite,
   libraryScopeBrowseProjectionInspect,
   libraryScopeBrowseProjectionRun,
 } from '@/lib/api/library';
@@ -11,6 +15,19 @@ import { useAuthStore } from '@/store/authStore';
 import { useMigrationStore } from '@/store/migrationStore';
 import { serverIndexKeyFromUrl } from '@/lib/server/serverIndexKey';
 import { rewriteFrontendStoreKeys } from '@/utils/server/rewriteFrontendStoreKeys';
+import { bindIndexedServerForMigration } from '@/lib/library/librarySession';
+import { enqueueLibrarySync } from '@/lib/library/librarySyncQueue';
+import { serverIndexKeyForProfile } from '@/lib/server/serverIndexKey';
+import { rewriteNavidromeCanonicalFrontendState } from '@/app/migrations/navidromeCanonicalFrontend';
+import { useOfflineJobStore } from '@/features/offline/store/offlineJobStore';
+import { clearOfflinePinTasks } from '@/features/offline/utils/offlinePinQueue';
+import { audioStop } from '@/lib/api/audio';
+import { clearImageCache } from '@/cover/imageCache';
+import { coverCacheClearServer } from '@/lib/api/coverCache';
+import { clearLyricsCache } from '@/features/lyrics/utils/lyricsPersistentCache';
+import { clearHomeFeedCache } from '@/features/home/store/homeFeedCache';
+import { clearBecauseYouLikeCache } from '@/features/home/store/becauseYouLikeCache';
+import { analysisDeleteAllForServer } from '@/lib/api/analysis';
 
 const MIGRATION_DONE_FLAG = 'psysonic-server-key-migration-v1';
 let migrationInFlight: Promise<void> | null = null;
@@ -94,6 +111,75 @@ async function runScopeBrowseProjectionPhase(): Promise<void> {
   state.setScopeBrowseProjectionProgress(null);
 }
 
+async function runNavidromeCanonicalPhase(): Promise<void> {
+  const state = useMigrationStore.getState();
+  const servers = useAuthStore.getState().servers;
+  if (servers.length !== 1) {
+    const existing = state.navidromeCanonical;
+    if (existing && existing.state !== 'legacy' && existing.state !== 'ready') {
+      state.setStep('navidromeCanonical');
+      state.setPhase('error');
+      throw new Error('Canonical-ID migration requires exactly one configured server.');
+    }
+    return;
+  }
+  const server = servers[0]!;
+  const serverId = serverIndexKeyForProfile(server);
+  if (!serverId) throw new Error('The Navidrome migration requires a stable server index key.');
+
+  const bound = await bindIndexedServerForMigration(server);
+  let migration = await libraryNavidromeCanonicalInspect(serverId);
+  state.setNavidromeCanonical(migration);
+  if (bound !== 'bound' && !['legacy', 'not_applicable', 'ready'].includes(migration.state)) {
+    throw new Error('The configured server must be reachable before migration.');
+  }
+  if (migration.state === 'ready') {
+    await rewriteNavidromeCanonicalFrontendState(migration);
+    return;
+  }
+  if (migration.state === 'not_applicable' || migration.state === 'legacy') return;
+
+  state.setStep('navidromeCanonical');
+  state.setPhase('running');
+  if (migration.state === 'required' || migration.state === 'rewriting') {
+    useOfflineJobStore.getState().cancelAllDownloads();
+    clearOfflinePinTasks();
+    await audioStop().catch(() => {});
+    migration = await libraryNavidromeCanonicalRewrite(serverId);
+    state.setNavidromeCanonical(migration);
+  }
+  if (migration.state === 'frontend') {
+    await rewriteNavidromeCanonicalFrontendState(migration);
+    await analysisDeleteAllForServer(serverId);
+    await Promise.all([
+      clearImageCache(),
+      clearLyricsCache(),
+      coverCacheClearServer(serverId),
+    ]);
+    clearHomeFeedCache();
+    clearBecauseYouLikeCache();
+    migration = await libraryNavidromeCanonicalAckFrontend(serverId);
+    state.setNavidromeCanonical(migration);
+  }
+  if (migration.state === 'resyncing') {
+    await rewriteNavidromeCanonicalFrontendState(migration);
+    await analysisDeleteAllForServer(serverId);
+    await enqueueLibrarySync({ serverId, kind: 'full' });
+    migration = await libraryNavidromeCanonicalInspect(serverId);
+    state.setNavidromeCanonical(migration);
+    if (migration.state === 'legacy') {
+      state.setStep(null);
+      return;
+    }
+    migration = await libraryNavidromeCanonicalFinalize(serverId);
+    state.setNavidromeCanonical(migration);
+  }
+  if (migration.state !== 'ready') {
+    throw new Error(migration.lastError ?? `Canonical-ID migration stopped in ${migration.state}`);
+  }
+  state.setStep(null);
+}
+
 async function runOrchestrator(force = false): Promise<void> {
   if (migrationInFlight) {
     await migrationInFlight;
@@ -113,11 +199,18 @@ async function runOrchestrator(force = false): Promise<void> {
       state.setPhase('completed');
       return;
     }
+    if (servers.length !== 1) {
+      state.setStep('navidromeCanonical');
+      state.setError('Canonical-ID preflight requires exactly one configured server.');
+      state.setPhase('error');
+      return;
+    }
     const mappings = buildMappings();
     const hasDoneFlag = localStorage.getItem(MIGRATION_DONE_FLAG) === '1';
     state.setError(null);
     state.setProgress(null);
     state.setGenreTagsProgress(null);
+    state.setNavidromeCanonical(null);
     state.setStep('serverIndex');
     state.setPhase(force ? 'inspecting' : 'idle');
     let inspect = null as Awaited<ReturnType<typeof migrationInspect>> | null;
@@ -127,6 +220,7 @@ async function runOrchestrator(force = false): Promise<void> {
       state.setNeedsMigration(inspect.needsMigration);
       skippedLogged = logSkippedUnknownRowsOnce(inspect, skippedLogged);
       if (!inspect.needsMigration) {
+        await runNavidromeCanonicalPhase();
         await runGenreTagsPhase();
         await runScopeBrowseProjectionPhase();
         state.setPhase('completed');
@@ -142,6 +236,7 @@ async function runOrchestrator(force = false): Promise<void> {
     if (!inspect.needsMigration) {
       await rewriteFrontendStoreKeys(servers);
       localStorage.setItem(MIGRATION_DONE_FLAG, '1');
+      await runNavidromeCanonicalPhase();
       await runGenreTagsPhase();
       await runScopeBrowseProjectionPhase();
       state.setPhase('completed');
@@ -158,6 +253,7 @@ async function runOrchestrator(force = false): Promise<void> {
     logSkippedUnknownRowsOnce(after, skippedLogged);
     if (!after.needsMigration) {
       localStorage.setItem(MIGRATION_DONE_FLAG, '1');
+        await runNavidromeCanonicalPhase();
         await runGenreTagsPhase();
         await runScopeBrowseProjectionPhase();
       state.setPhase('completed');
@@ -207,6 +303,10 @@ export function retryGenreTagsMigration(): void {
 
 export function retryBlockingMigration(): void {
   const step = useMigrationStore.getState().step;
+  if (step === 'navidromeCanonical') {
+    void runOrchestrator(true);
+    return;
+  }
   if (step === 'genreTags') {
     retryGenreTagsMigration();
     return;

--- a/src/app/migrations/navidromeCanonicalFrontend.test.ts
+++ b/src/app/migrations/navidromeCanonicalFrontend.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CanonicalMigrationDto } from '@/lib/api/library';
+import { useAuthStore } from '@/store/authStore';
+import { useLocalPlaybackStore } from '@/store/localPlaybackStore';
+import { useOfflineStore } from '@/features/offline';
+import { useDeviceSyncStore } from '@/features/deviceSync';
+import { usePlaylistFolderStore } from '@/features/playlist/store/playlistFolderStore';
+import { usePlaylistStore } from '@/features/playlist/store/playlistStore';
+import { usePlayerStore } from '@/features/playback/store/playerStore';
+import { rewriteNavidromeCanonicalFrontendState } from './navidromeCanonicalFrontend';
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+}));
+
+const OLD = {
+  artist: 'e3b7fc2ae9447bbec37a13bf916e3cf6',
+  album: 'e3b7fc2ae9447bbec37a13bf916e3cf6',
+  track: 'e3b7fc2ae9447bbec37a13bf916e3cf6',
+  folder: 'e3b7fc2ae9447bbec37a13bf916e3cf6',
+};
+
+const NEW = {
+  artist: '6VHl3uR4kss6sUPKA8Cwnk',
+  album: '6VHl3uR4kss6sUPKA8Cwnk',
+  track: '6VHl3uR4kss6sUPKA8Cwnk',
+  folder: '6VHl3uR4kss6sUPKA8Cwnk',
+};
+
+const migration: CanonicalMigrationDto = {
+  serverId: 'music.test',
+  state: 'frontend',
+  canonicalVersion: 1,
+  probeKind: 'track',
+  probeOldId: OLD.track,
+  probeNewId: NEW.track,
+  lastError: null,
+  mappings: (Object.keys(OLD) as Array<keyof typeof OLD>).map(entityKind => ({
+    entityKind,
+    oldId: OLD[entityKind],
+    newId: NEW[entityKind],
+  })),
+};
+
+describe('rewriteNavidromeCanonicalFrontendState', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    let manifest: unknown = null;
+    invokeMock.mockReset().mockImplementation((command: string, args?: Record<string, unknown>) => {
+      if (command === 'read_device_manifest') return Promise.resolve(manifest);
+      if (command === 'write_device_manifest') {
+        manifest = {
+          version: 3,
+          ownerServerIndexKey: args?.ownerServerIndexKey,
+          sources: args?.sources,
+        };
+      }
+      return Promise.resolve(undefined);
+    });
+    useAuthStore.setState({
+      servers: [{ id: 'profile', name: 'Music', url: 'https://music.test', username: 'u', password: 'p' }],
+      activeServerId: 'profile',
+      musicFolders: [{ id: OLD.folder, name: 'All' }],
+      musicFoldersByServer: { profile: [{ id: OLD.folder, name: 'All' }] },
+      libraryBrowseSelectionByServer: { profile: [OLD.folder] },
+      musicLibraryFilterByServer: { profile: OLD.folder },
+      musicLibrarySelectionByServer: { profile: [OLD.folder] },
+      skipStarManualSkipCountsByKey: { [`profile\u001f${OLD.track}`]: 2 },
+    });
+    useLocalPlaybackStore.setState({
+      entries: {
+        [`music.test:${OLD.track}`]: {
+          serverIndexKey: 'music.test',
+          trackId: OLD.track,
+          localPath: `/music/${OLD.track}.flac`,
+          layoutFingerprint: 'layout',
+          sizeBytes: 1,
+          tier: 'library',
+          cachedAt: 1,
+          pinSource: { kind: 'album', sourceId: OLD.album },
+          suffix: 'flac',
+        },
+      },
+    });
+    useOfflineStore.setState({
+      albums: {
+        [`music.test:${OLD.album}`]: {
+          id: OLD.album,
+          serverId: 'music.test',
+          name: 'Album',
+          artist: 'Artist',
+          coverArt: `al-${OLD.album}_abcdef`,
+          trackIds: [OLD.track],
+          type: 'album',
+        },
+      },
+    });
+    useDeviceSyncStore.setState({
+      targetDir: '/device',
+      sources: [{ type: 'album', id: OLD.album, name: 'Album', serverIndexKey: 'music.test' }],
+      legacySources: [{ type: 'artist', id: OLD.artist, name: 'Artist' }],
+      checkedIds: [],
+      pendingDeletion: [],
+      deviceFilePaths: [],
+      scanning: false,
+    });
+    usePlaylistFolderStore.setState({
+      byServer: {
+        profile: {
+          folders: [{ id: 'folder', name: 'Folder', order: 0, collapsed: false }],
+          assignments: { [OLD.album]: 'folder' },
+        },
+      },
+      groupView: true,
+    });
+    usePlaylistStore.setState({
+      playlists: [{
+        id: OLD.album,
+        serverId: 'profile',
+        name: 'Playlist',
+        songCount: 1,
+        duration: 1,
+        created: '',
+        changed: '',
+      }],
+      recentIds: [`profile:${OLD.album}`],
+      lastModified: { [`profile:${OLD.album}`]: 1 },
+    });
+    usePlayerStore.setState({
+      queueServerId: 'music.test',
+      queueItems: [{ serverId: 'music.test', trackId: OLD.track }],
+      currentTrack: {
+        id: OLD.track,
+        title: 'Track',
+        artist: 'Artist',
+        album: 'Album',
+        albumId: OLD.album,
+        artistId: OLD.artist,
+        duration: 1,
+        coverArt: `mf-${OLD.track}`,
+        serverId: 'music.test',
+      },
+    });
+    localStorage.setItem('psysonic-player', JSON.stringify({
+      state: {
+        queueServerId: 'music.test',
+        queueItems: [{ serverId: 'music.test', trackId: OLD.track }],
+        currentTrack: {
+          id: OLD.track,
+          title: 'Track',
+          artist: 'Artist',
+          album: 'Album',
+          albumId: OLD.album,
+          artistId: OLD.artist,
+          duration: 1,
+          coverArt: `mf-${OLD.track}`,
+          serverId: 'music.test',
+        },
+      },
+      version: 0,
+    }));
+    localStorage.setItem('psysonic_shuffle_mode', JSON.stringify({
+      enabled: true,
+      originalOrder: [JSON.stringify(['music.test', OLD.track])],
+    }));
+    localStorage.setItem('psysonic_radio_favorites', JSON.stringify([`profile:${OLD.album}`]));
+    localStorage.setItem('psysonic_radio_order', JSON.stringify([`profile:${OLD.album}`]));
+    localStorage.setItem(
+      `psy_new_releases_unread_seen_v2:${JSON.stringify([['profile', [OLD.folder]]])}`,
+      JSON.stringify([OLD.album]),
+    );
+  });
+
+  it('rewrites preserved state and can rerun after a crash', async () => {
+    await rewriteNavidromeCanonicalFrontendState(migration);
+    await rewriteNavidromeCanonicalFrontendState(migration);
+
+    expect(useAuthStore.getState().musicFoldersByServer.profile?.[0]?.id).toBe(NEW.folder);
+    expect(useLocalPlaybackStore.getState().entries[`music.test:${NEW.track}`]?.pinSource?.sourceId)
+      .toBe(NEW.album);
+    expect(useOfflineStore.getState().albums[`music.test:${NEW.album}`]).toMatchObject({
+      id: NEW.album,
+      trackIds: [NEW.track],
+      coverArt: `al-${NEW.album}_abcdef`,
+    });
+    expect(useDeviceSyncStore.getState().sources.map(source => source.id)).toEqual([NEW.album, NEW.artist]);
+    expect(useDeviceSyncStore.getState().legacySources).toEqual([]);
+    expect(usePlaylistFolderStore.getState().byServer.profile?.assignments)
+      .toEqual({ [NEW.album]: 'folder' });
+    expect(usePlaylistStore.getState().playlists[0]?.id).toBe(NEW.album);
+
+    const player = JSON.parse(localStorage.getItem('psysonic-player') ?? '{}');
+    expect(player.state.queueItems[0].trackId).toBe(NEW.track);
+    expect(player.state.currentTrack).toMatchObject({
+      id: NEW.track,
+      albumId: NEW.album,
+      artistId: NEW.artist,
+      coverArt: `mf-${NEW.track}`,
+    });
+    expect(invokeMock).toHaveBeenCalledWith('write_device_manifest', {
+      destDir: '/device',
+      ownerServerIndexKey: 'music.test',
+      sources: [
+        { type: 'album', id: NEW.album, name: 'Album', serverIndexKey: 'music.test' },
+        { type: 'artist', id: NEW.artist, name: 'Artist', serverIndexKey: 'music.test' },
+      ],
+    });
+    expect(localStorage.getItem('psysonic-hot-cache')).toBeNull();
+    expect(JSON.parse(localStorage.getItem(
+      `psy_new_releases_unread_seen_v2:${JSON.stringify([['profile', [NEW.folder]]])}`,
+    ) ?? '[]')).toEqual([NEW.album]);
+  });
+});

--- a/src/app/migrations/navidromeCanonicalFrontend.ts
+++ b/src/app/migrations/navidromeCanonicalFrontend.ts
@@ -1,0 +1,564 @@
+import { invoke } from '@tauri-apps/api/core';
+import type {
+  CanonicalIdMappingDto,
+  CanonicalMigrationDto,
+} from '@/lib/api/library';
+import type {
+  InternetRadioStation,
+  SubsonicOpenArtistRef,
+  SubsonicSong,
+} from '@/lib/api/subsonicTypes';
+import type { Track } from '@/lib/media/trackTypes';
+import { canonicalNavidromeArtworkId, canonicalNavidromeId } from '@/lib/server/navidromeCanonicalId';
+import { resolveStorageServerIndexKey, serverIndexKeyForProfile } from '@/lib/server/serverIndexKey';
+import { useAuthStore } from '@/store/authStore';
+import { useLocalPlaybackStore, type LocalPlaybackEntry, type PinSource } from '@/store/localPlaybackStore';
+import { usePlayerStore } from '@/features/playback/store/playerStore';
+import { useOfflineStore, type OfflineAlbumMeta } from '@/features/offline';
+import { useDeviceSyncStore, type DeviceSyncSource } from '@/features/deviceSync';
+import type { DeviceSyncManifest, LegacyDeviceSyncSource } from '@/features/deviceSync/store/deviceSyncStore';
+import { usePlaylistFolderStore } from '@/features/playlist/store/playlistFolderStore';
+import { usePlaylistStore } from '@/features/playlist/store/playlistStore';
+import { NEW_RELEASES_UNREAD_STORAGE_PREFIX } from '@/features/sidebar/utils/sidebarHelpers';
+import { setShuffleOriginalOrder } from '@/features/playback/store/shuffleModeActions';
+
+type EntityKind = 'artist' | 'album' | 'track' | 'folder';
+type EntityMaps = Record<EntityKind, Map<string, string>>;
+
+const PLAYER_KEY = 'psysonic-player';
+const SHUFFLE_KEY = 'psysonic_shuffle_mode';
+const PLAYLIST_KEY = 'psysonic_playlists_recent';
+const RADIO_KEYS = ['psysonic_radio_favorites', 'psysonic_radio_order'] as const;
+
+function buildMaps(mappings: readonly CanonicalIdMappingDto[]): EntityMaps {
+  const maps: EntityMaps = {
+    artist: new Map(),
+    album: new Map(),
+    track: new Map(),
+    folder: new Map(),
+  };
+  for (const mapping of mappings) {
+    const kind = mapping.entityKind as EntityKind;
+    if (maps[kind]) maps[kind].set(mapping.oldId, mapping.newId);
+  }
+  return maps;
+}
+
+function mapId(maps: EntityMaps, kind: EntityKind, value: string | undefined): string | undefined {
+  return value ? maps[kind].get(value) ?? canonicalNavidromeId(value) : value;
+}
+
+function rewriteArtistRefs(
+  refs: SubsonicOpenArtistRef[] | undefined,
+  maps: EntityMaps,
+): SubsonicOpenArtistRef[] | undefined {
+  return refs?.map(ref => ({ ...ref, id: mapId(maps, 'artist', ref.id) }));
+}
+
+function rewriteTrack<T extends Track | SubsonicSong>(track: T, maps: EntityMaps): T {
+  const song = track as SubsonicSong;
+  return {
+    ...track,
+    id: mapId(maps, 'track', track.id)!,
+    albumId: mapId(maps, 'album', track.albumId)!,
+    artistId: mapId(maps, 'artist', track.artistId),
+    artists: rewriteArtistRefs(track.artists, maps),
+    coverArt: track.coverArt ? canonicalNavidromeArtworkId(track.coverArt) : undefined,
+    ...(song.albumArtists ? { albumArtists: rewriteArtistRefs(song.albumArtists, maps) } : {}),
+    ...(song.contributors ? {
+      contributors: song.contributors.map(contributor => ({
+        ...contributor,
+        artist: {
+          ...contributor.artist,
+          id: mapId(maps, 'artist', contributor.artist.id),
+        },
+      })),
+    } : {}),
+  };
+}
+
+function rewritePinSource(source: PinSource | undefined, maps: EntityMaps): PinSource | undefined {
+  if (!source) return undefined;
+  const kind: EntityKind = source.kind === 'track' ? 'track' : 'album';
+  return { ...source, sourceId: mapId(maps, kind, source.sourceId)! };
+}
+
+function rewriteOwnedKey(value: string, ownerId: string): string {
+  const prefix = `${ownerId}:`;
+  if (!value.startsWith(prefix)) return value;
+  return `${prefix}${canonicalNavidromeId(value.slice(prefix.length))}`;
+}
+
+function isOwnedBy(value: string | null | undefined, owners: ReadonlySet<string>): boolean {
+  return Boolean(value && owners.has(value));
+}
+
+function readJson(key: string): unknown {
+  const raw = localStorage.getItem(key);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    throw new Error(`Malformed persisted state in ${key}`);
+  }
+}
+
+function rewriteRawPlayerState(owners: ReadonlySet<string>, maps: EntityMaps): void {
+  const root = readJson(PLAYER_KEY) as { state?: Record<string, unknown>; version?: number } | null;
+  if (!root?.state) return;
+  const state = root.state;
+  const currentTrack = state.currentTrack as Track | null | undefined;
+  if (currentTrack && (isOwnedBy(currentTrack.serverId, owners)
+    || (!currentTrack.serverId && isOwnedBy(state.queueServerId as string | undefined, owners)))) {
+    if (currentTrack) state.currentTrack = rewriteTrack(currentTrack, maps);
+  }
+  if (Array.isArray(state.queueItems)) {
+    state.queueItems = state.queueItems.map((item: unknown) => {
+      const ref = item as { serverId?: string; trackId?: string };
+      return isOwnedBy(ref.serverId, owners) && typeof ref.trackId === 'string'
+        ? { ...ref, trackId: mapId(maps, 'track', ref.trackId) }
+        : ref;
+    });
+  }
+  if (Array.isArray(state.queueRefs) && isOwnedBy(state.queueServerId as string | undefined, owners)) {
+    state.queueRefs = state.queueRefs.map((id: unknown) => (
+      typeof id === 'string' ? mapId(maps, 'track', id) : id
+    ));
+  }
+  if (Array.isArray(state.queue) && isOwnedBy(state.queueServerId as string | undefined, owners)) {
+    state.queue = state.queue.map((track: unknown) => rewriteTrack(track as Track, maps));
+  }
+  localStorage.setItem(PLAYER_KEY, JSON.stringify(root));
+}
+
+function rewriteShuffleState(serverId: string, maps: EntityMaps): void {
+  const snapshot = readJson(SHUFFLE_KEY) as { enabled?: boolean; originalOrder?: unknown[] } | null;
+  if (!snapshot?.originalOrder) return;
+  snapshot.originalOrder = snapshot.originalOrder.map(value => {
+    if (typeof value !== 'string') return value;
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (!Array.isArray(parsed) || parsed.length !== 2 || parsed[0] !== serverId || typeof parsed[1] !== 'string') {
+        return value;
+      }
+      return JSON.stringify([serverId, mapId(maps, 'track', parsed[1])]);
+    } catch {
+      return mapId(maps, 'track', value);
+    }
+  });
+  setShuffleOriginalOrder(snapshot.originalOrder.filter((value): value is string => typeof value === 'string'));
+  localStorage.setItem(SHUFFLE_KEY, JSON.stringify(snapshot));
+}
+
+function rewriteRadioState(profileId: string): void {
+  for (const key of RADIO_KEYS) {
+    const values = readJson(key);
+    if (!Array.isArray(values)) continue;
+    localStorage.setItem(key, JSON.stringify([
+      ...new Set(values.map(value => typeof value === 'string' ? rewriteOwnedKey(value, profileId) : value)),
+    ]));
+  }
+}
+
+function rewriteAuthStore(profileId: string, maps: EntityMaps): void {
+  useAuthStore.setState(state => {
+    const rewriteFolders = (folders: typeof state.musicFolders) => folders.map(folder => ({
+      ...folder,
+      id: mapId(maps, 'folder', folder.id)!,
+    }));
+    const rewriteSelection = (values: string[]) => values.map(id => mapId(maps, 'folder', id)!);
+    const filter = state.musicLibraryFilterByServer[profileId];
+    const skipStarManualSkipCountsByKey: Record<string, number> = {};
+    for (const [key, count] of Object.entries(state.skipStarManualSkipCountsByKey)) {
+      const separator = key.indexOf('\u001f');
+      const owner = separator < 0 ? '' : key.slice(0, separator);
+      const trackId = separator < 0 ? key : key.slice(separator + 1);
+      const nextKey = owner === profileId
+        ? `${owner}\u001f${mapId(maps, 'track', trackId)}`
+        : key;
+      skipStarManualSkipCountsByKey[nextKey] = Math.max(skipStarManualSkipCountsByKey[nextKey] ?? 0, count);
+    }
+    return {
+      musicFolders: state.activeServerId === profileId
+        ? rewriteFolders(state.musicFolders)
+        : state.musicFolders,
+      musicFoldersByServer: {
+        ...state.musicFoldersByServer,
+        [profileId]: rewriteFolders(state.musicFoldersByServer[profileId] ?? []),
+      },
+      libraryBrowseSelectionByServer: {
+        ...state.libraryBrowseSelectionByServer,
+        [profileId]: rewriteSelection(state.libraryBrowseSelectionByServer[profileId] ?? []),
+      },
+      musicLibraryFilterByServer: {
+        ...state.musicLibraryFilterByServer,
+        [profileId]: filter && filter !== 'all' ? mapId(maps, 'folder', filter)! : 'all',
+      },
+      musicLibrarySelectionByServer: {
+        ...state.musicLibrarySelectionByServer,
+        [profileId]: rewriteSelection(state.musicLibrarySelectionByServer[profileId] ?? []),
+      },
+      skipStarManualSkipCountsByKey,
+    };
+  });
+}
+
+function rewriteLocalPlaybackStore(serverId: string, maps: EntityMaps): void {
+  useLocalPlaybackStore.setState(state => {
+    const entries: Record<string, LocalPlaybackEntry> = {};
+    for (const entry of Object.values(state.entries)) {
+      const next = entry.serverIndexKey === serverId
+        ? {
+          ...entry,
+          trackId: mapId(maps, 'track', entry.trackId)!,
+          pinSource: rewritePinSource(entry.pinSource, maps),
+        }
+        : entry;
+      const key = `${next.serverIndexKey}:${next.trackId}`;
+      const existing = entries[key];
+      if (existing && existing.localPath !== next.localPath) {
+        throw new Error(`Local playback collision at ${key}`);
+      }
+      if (!existing) {
+        entries[key] = next;
+        continue;
+      }
+      const tierPriority = { ephemeral: 0, 'favorite-auto': 1, library: 2 } as const;
+      const winner = tierPriority[existing.tier] > tierPriority[next.tier]
+        || (tierPriority[existing.tier] === tierPriority[next.tier] && existing.cachedAt >= next.cachedAt)
+        ? existing
+        : next;
+      const other = winner === existing ? next : existing;
+      entries[key] = {
+        ...winner,
+        lastPlayedAt: Math.max(winner.lastPlayedAt ?? 0, other.lastPlayedAt ?? 0) || undefined,
+        pinSource: winner.pinSource ?? other.pinSource,
+      };
+    }
+    return { entries };
+  });
+}
+
+function offlineAlbumKind(meta: OfflineAlbumMeta): EntityKind {
+  return meta.type === 'track' ? 'track' : 'album';
+}
+
+function rewriteOfflineStore(serverId: string, maps: EntityMaps): void {
+  useOfflineStore.setState(state => {
+    const albums: Record<string, OfflineAlbumMeta> = {};
+    for (const meta of Object.values(state.albums)) {
+      const next = meta.serverId === serverId
+        ? {
+          ...meta,
+          id: mapId(maps, offlineAlbumKind(meta), meta.id)!,
+          trackIds: meta.trackIds.map(id => mapId(maps, 'track', id)!),
+          coverArt: meta.coverArt ? canonicalNavidromeArtworkId(meta.coverArt) : undefined,
+        }
+        : meta;
+      const key = `${next.serverId}:${next.id}`;
+      const existing = albums[key];
+      albums[key] = existing
+        ? { ...next, ...existing, trackIds: [...new Set([...existing.trackIds, ...next.trackIds])] }
+        : next;
+    }
+    return { albums };
+  });
+}
+
+function rewriteDeviceSource(source: DeviceSyncSource, serverId: string, maps: EntityMaps): DeviceSyncSource {
+  if (source.serverIndexKey !== serverId) return source;
+  const kind = source.type === 'artist' ? 'artist' : source.type === 'album' ? 'album' : null;
+  return { ...source, id: kind ? mapId(maps, kind, source.id)! : canonicalNavidromeId(source.id) };
+}
+
+function rewriteLegacyDeviceSource(source: LegacyDeviceSyncSource, serverId: string, maps: EntityMaps): DeviceSyncSource {
+  return rewriteDeviceSource({ ...source, serverIndexKey: serverId }, serverId, maps);
+}
+
+function dedupeDeviceSources(sources: DeviceSyncSource[]): DeviceSyncSource[] {
+  return [...new Map(sources.map(source => [
+    JSON.stringify([source.serverIndexKey, source.type, source.id]),
+    source,
+  ])).values()];
+}
+
+function rewriteDeviceSyncStore(serverId: string, maps: EntityMaps): DeviceSyncSource[] {
+  const state = useDeviceSyncStore.getState();
+  const sources = dedupeDeviceSources([
+    ...state.sources.map(source => rewriteDeviceSource(source, serverId, maps)),
+    ...state.legacySources.map(source => rewriteLegacyDeviceSource(source, serverId, maps)),
+  ]);
+  useDeviceSyncStore.setState({ sources, legacySources: [], checkedIds: [], pendingDeletion: [] });
+  return sources;
+}
+
+function rewritePlaylistStores(profileId: string): void {
+  usePlaylistStore.setState(state => ({
+    playlists: [...new Map(state.playlists.map(playlist => {
+      const next = playlist.serverId === profileId ? {
+          ...playlist,
+          id: canonicalNavidromeId(playlist.id),
+          coverArt: playlist.coverArt ? canonicalNavidromeArtworkId(playlist.coverArt) : undefined,
+        } : playlist;
+      return [`${next.serverId ?? ''}:${next.id}`, next] as const;
+    })).values()],
+    recentIds: [...new Set(state.recentIds.map(key => rewriteOwnedKey(key, profileId)))],
+    lastModified: Object.entries(state.lastModified).reduce<Record<string, number>>((next, [key, value]) => {
+      const rewritten = rewriteOwnedKey(key, profileId);
+      next[rewritten] = Math.max(next[rewritten] ?? 0, value);
+      return next;
+    }, {}),
+  }));
+  usePlaylistFolderStore.setState(state => {
+    const owned = state.byServer[profileId];
+    if (!owned) return state;
+    const assignments: Record<string, string> = {};
+    for (const [playlistId, folderId] of Object.entries(owned.assignments)) {
+      const rewritten = canonicalNavidromeId(playlistId);
+      if (assignments[rewritten] && assignments[rewritten] !== folderId) {
+        throw new Error(`Playlist folder collision at ${rewritten}`);
+      }
+      assignments[rewritten] = folderId;
+    }
+    return { byServer: { ...state.byServer, [profileId]: { ...owned, assignments } } };
+  });
+}
+
+function rewriteLivePlayer(profileId: string, owners: ReadonlySet<string>, maps: EntityMaps): void {
+  usePlayerStore.setState(state => ({
+    currentTrack: state.currentTrack && (isOwnedBy(state.currentTrack.serverId, owners)
+      || (!state.currentTrack.serverId && isOwnedBy(state.queueServerId, owners)))
+      ? rewriteTrack(state.currentTrack, maps)
+      : state.currentTrack,
+    queueItems: state.queueItems.map(item => isOwnedBy(item.serverId, owners)
+      ? { ...item, trackId: mapId(maps, 'track', item.trackId)! }
+      : item),
+    currentRadio: state.currentRadio?.serverId === profileId
+      ? {
+        ...state.currentRadio,
+        id: canonicalNavidromeId(state.currentRadio.id),
+        coverArt: state.currentRadio.coverArt
+          ? canonicalNavidromeArtworkId(state.currentRadio.coverArt)
+          : undefined,
+      } satisfies InternetRadioStation
+      : state.currentRadio,
+  }));
+}
+
+async function rewriteKnownDeviceManifest(serverId: string, sources: DeviceSyncSource[], maps: EntityMaps): Promise<void> {
+  const targetDir = useDeviceSyncStore.getState().targetDir;
+  if (!targetDir) return;
+  const manifest = await invoke<DeviceSyncManifest | null>('read_device_manifest', { destDir: targetDir });
+  const manifestOwner = manifest?.ownerServerIndexKey
+    ? resolveStorageServerIndexKey(manifest.ownerServerIndexKey)
+    : null;
+  if (manifestOwner && manifestOwner !== serverId) {
+    throw new Error('Device Sync manifest belongs to another server');
+  }
+  const manifestSources = Array.isArray(manifest?.sources)
+    ? manifest.sources.flatMap(source => {
+      if (!source || typeof source !== 'object') return [];
+      const candidate = source as Partial<DeviceSyncSource>;
+      if ((candidate.type !== 'album' && candidate.type !== 'playlist' && candidate.type !== 'artist')
+        || typeof candidate.id !== 'string' || typeof candidate.name !== 'string') return [];
+      const owned = { ...candidate, serverIndexKey: serverId } as DeviceSyncSource;
+      return [rewriteDeviceSource(owned, serverId, maps)];
+    })
+    : [];
+  const nextSources = dedupeDeviceSources([...sources, ...manifestSources]);
+  if (!manifest && nextSources.length === 0) return;
+  await invoke('write_device_manifest', {
+    destDir: targetDir,
+    ownerServerIndexKey: serverId,
+    sources: nextSources,
+  });
+  const written = await invoke<DeviceSyncManifest | null>('read_device_manifest', { destDir: targetDir });
+  if (written?.ownerServerIndexKey !== serverId || !Array.isArray(written.sources)) {
+    throw new Error('Device Sync manifest verification failed');
+  }
+  assertCanonicalDeviceSources(written.sources, serverId);
+}
+
+function assertCanonicalId(value: string | undefined, label: string): void {
+  if (value && canonicalNavidromeId(value) !== value) throw new Error(`Legacy ${label} remains in frontend persistence`);
+}
+
+function assertCanonicalArtwork(value: string | undefined): void {
+  if (value && canonicalNavidromeArtworkId(value) !== value) throw new Error('Legacy artwork ID remains in frontend persistence');
+}
+
+function assertCanonicalTrack(track: Track | SubsonicSong): void {
+  assertCanonicalId(track.id, 'track ID');
+  assertCanonicalId(track.albumId, 'album ID');
+  assertCanonicalId(track.artistId, 'artist ID');
+  track.artists?.forEach(artist => assertCanonicalId(artist.id, 'artist ID'));
+  assertCanonicalArtwork(track.coverArt);
+}
+
+function assertCanonicalDeviceSources(values: unknown[], serverId: string): void {
+  for (const value of values) {
+    const source = value as Partial<DeviceSyncSource>;
+    if (source.serverIndexKey !== serverId) throw new Error('Device Sync source owner mismatch');
+    assertCanonicalId(source.id, 'Device Sync source ID');
+  }
+}
+
+function verifyFrontendState(profileId: string, serverId: string): void {
+  const owners = new Set([profileId, serverId]);
+  const auth = useAuthStore.getState();
+  auth.musicFoldersByServer[profileId]?.forEach(folder => assertCanonicalId(folder.id, 'folder ID'));
+  auth.libraryBrowseSelectionByServer[profileId]?.forEach(id => assertCanonicalId(id, 'folder ID'));
+  auth.musicLibrarySelectionByServer[profileId]?.forEach(id => assertCanonicalId(id, 'folder ID'));
+  const filter = auth.musicLibraryFilterByServer[profileId];
+  if (filter && filter !== 'all') assertCanonicalId(filter, 'folder ID');
+  for (const key of Object.keys(auth.skipStarManualSkipCountsByKey)) {
+    const separator = key.indexOf('\u001f');
+    if (key.slice(0, separator) === profileId) assertCanonicalId(key.slice(separator + 1), 'track ID');
+  }
+  Object.values(useLocalPlaybackStore.getState().entries).forEach(entry => {
+    if (entry.serverIndexKey !== serverId) return;
+    assertCanonicalId(entry.trackId, 'track ID');
+    assertCanonicalId(entry.pinSource?.sourceId, 'pin source ID');
+  });
+  Object.values(useOfflineStore.getState().albums).forEach(meta => {
+    if (meta.serverId !== serverId) return;
+    assertCanonicalId(meta.id, 'offline source ID');
+    meta.trackIds.forEach(id => assertCanonicalId(id, 'track ID'));
+    assertCanonicalArtwork(meta.coverArt);
+  });
+  const device = useDeviceSyncStore.getState();
+  assertCanonicalDeviceSources(device.sources, serverId);
+  if (device.legacySources.length > 0) throw new Error('Ownerless Device Sync sources remain');
+  usePlaylistStore.getState().playlists.forEach(playlist => {
+    if (playlist.serverId !== profileId) return;
+    assertCanonicalId(playlist.id, 'playlist ID');
+    assertCanonicalArtwork(playlist.coverArt);
+  });
+  for (const id of Object.keys(usePlaylistFolderStore.getState().byServer[profileId]?.assignments ?? {})) {
+    assertCanonicalId(id, 'playlist ID');
+  }
+  const player = usePlayerStore.getState();
+  if (player.currentTrack && isOwnedBy(player.currentTrack.serverId, owners)) {
+    assertCanonicalTrack(player.currentTrack);
+  }
+  player.queueItems.filter(item => isOwnedBy(item.serverId, owners))
+    .forEach(item => assertCanonicalId(item.trackId, 'track ID'));
+
+  const persistedPlayer = readJson(PLAYER_KEY) as { state?: Record<string, unknown> } | null;
+  const persistedState = persistedPlayer?.state;
+  const persistedCurrent = persistedState?.currentTrack as Track | null | undefined;
+  if (persistedCurrent && (isOwnedBy(persistedCurrent.serverId, owners)
+    || (!persistedCurrent.serverId && isOwnedBy(persistedState?.queueServerId as string | undefined, owners)))) {
+    assertCanonicalTrack(persistedCurrent);
+  }
+  if (Array.isArray(persistedState?.queueItems)) {
+    persistedState.queueItems.forEach(item => {
+      const ref = item as { serverId?: string; trackId?: string };
+      if (isOwnedBy(ref.serverId, owners)) assertCanonicalId(ref.trackId, 'track ID');
+    });
+  }
+
+  const shuffle = readJson(SHUFFLE_KEY) as { originalOrder?: unknown[] } | null;
+  shuffle?.originalOrder?.forEach(value => {
+    if (typeof value !== 'string') return;
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (Array.isArray(parsed) && parsed.length === 2 && isOwnedBy(parsed[0] as string, owners)) {
+        assertCanonicalId(parsed[1] as string, 'shuffle track ID');
+      }
+    } catch {
+      assertCanonicalId(value, 'shuffle track ID');
+    }
+  });
+
+  for (const key of RADIO_KEYS) {
+    const values = readJson(key);
+    if (!Array.isArray(values)) continue;
+    for (const value of values) {
+      if (typeof value === 'string' && value.startsWith(`${profileId}:`)) {
+        assertCanonicalId(value.slice(profileId.length + 1), 'radio ID');
+      }
+    }
+  }
+
+  const persistedPlaylists = readJson(PLAYLIST_KEY) as { state?: {
+    playlists?: Array<{ id?: string; serverId?: string; coverArt?: string }>;
+    recentIds?: string[];
+    lastModified?: Record<string, number>;
+  } } | null;
+  for (const playlist of persistedPlaylists?.state?.playlists ?? []) {
+    if (playlist.serverId !== profileId) continue;
+    assertCanonicalId(playlist.id, 'playlist ID');
+    assertCanonicalArtwork(playlist.coverArt);
+  }
+  for (const key of [
+    ...(persistedPlaylists?.state?.recentIds ?? []),
+    ...Object.keys(persistedPlaylists?.state?.lastModified ?? {}),
+  ]) {
+    if (key.startsWith(`${profileId}:`)) assertCanonicalId(key.slice(profileId.length + 1), 'playlist ID');
+  }
+}
+
+function rewriteNewReleasesSeenState(profileId: string, maps: EntityMaps): void {
+  const prefix = `${NEW_RELEASES_UNREAD_STORAGE_PREFIX}:`;
+  const rewrites: Array<[string, string, string[]]> = [];
+  for (let index = 0; index < localStorage.length; index += 1) {
+    const key = localStorage.key(index);
+    if (!key?.startsWith(prefix)) continue;
+    const suffix = key.slice(prefix.length);
+    let fingerprint: unknown;
+    try { fingerprint = JSON.parse(suffix); } catch { continue; }
+    if (!Array.isArray(fingerprint)) continue;
+    const nextFingerprint = fingerprint.map(entry => {
+      if (!Array.isArray(entry) || entry[0] !== profileId || !Array.isArray(entry[1])) return entry;
+      return [entry[0], entry[1].map(id => typeof id === 'string' ? mapId(maps, 'folder', id) : id)];
+    });
+    const ids = readJson(key);
+    if (!Array.isArray(ids)) continue;
+    rewrites.push([
+      key,
+      `${prefix}${JSON.stringify(nextFingerprint)}`,
+      ids.flatMap(id => typeof id === 'string' ? [canonicalNavidromeId(id)] : []),
+    ]);
+  }
+  for (const [oldKey, newKey, ids] of rewrites) {
+    const existing = readJson(newKey);
+    const merged = [...new Set([...(Array.isArray(existing) ? existing : []), ...ids])];
+    localStorage.setItem(newKey, JSON.stringify(merged));
+    if (oldKey !== newKey) localStorage.removeItem(oldKey);
+  }
+}
+
+export async function rewriteNavidromeCanonicalFrontendState(
+  migration: CanonicalMigrationDto,
+): Promise<void> {
+  const maps = buildMaps(migration.mappings);
+  const serverId = migration.serverId;
+  const matchingServer = useAuthStore.getState().servers.find(
+    server => serverIndexKeyForProfile(server) === serverId,
+  );
+  if (!matchingServer) throw new Error(`No configured server owns migration scope ${serverId}`);
+  const profileId = matchingServer.id;
+  const owners = new Set([profileId, serverId]);
+
+  rewriteRawPlayerState(owners, maps);
+  rewriteShuffleState(serverId, maps);
+  rewriteRadioState(profileId);
+  rewriteAuthStore(profileId, maps);
+  rewriteLocalPlaybackStore(serverId, maps);
+  rewriteOfflineStore(serverId, maps);
+  const deviceSources = rewriteDeviceSyncStore(serverId, maps);
+  rewritePlaylistStores(profileId);
+  rewriteNewReleasesSeenState(profileId, maps);
+  rewriteLivePlayer(profileId, owners, maps);
+  if (migration.state === 'ready') {
+    await rewriteKnownDeviceManifest(serverId, deviceSources, maps).catch(() => {});
+  } else {
+    await rewriteKnownDeviceManifest(serverId, deviceSources, maps);
+  }
+  localStorage.removeItem('psysonic-hot-cache');
+  localStorage.setItem('psysonic-local-playback-migrated-v1', '1');
+
+  verifyFrontendState(profileId, serverId);
+  if (!readJson(PLAYLIST_KEY)) throw new Error('Playlist persistence verification failed');
+}

--- a/src/app/seamRegistration.smoke.test.ts
+++ b/src/app/seamRegistration.smoke.test.ts
@@ -4,8 +4,9 @@ import { describe, expect, it } from 'vitest';
 //
 // The three core↔feature seams each start at a safe *neutral default* and are
 // switched to the real implementation as a MODULE-LOAD side effect — not a render
-// step. Importing the real app entry module runs exactly that wiring:
-//   - MainApp side-effect-imports `playbackEngineBridgeRegister`         → playback bridge
+// step. Importing the real app entry plus the post-migration playback registrar runs
+// exactly that wiring:
+//   - App dynamically imports `playbackEngineBridgeRegister` after migrations
 //   - MainApp imports the `@/features/offline` barrel (`export *`)        → media resolver
 //   - MainApp imports AppShell, which imports the `@/features/orbit` barrel → orbit runtime
 //
@@ -16,6 +17,7 @@ import { describe, expect, it } from 'vitest';
 // path is hit). Registration is import-time, so mounting the (heavy) component tree
 // would add flakiness without covering anything the import does not.
 import '@/app/MainApp';
+import '@/features/playback/store/playbackEngineBridgeRegister';
 
 import { isMediaResolverRegistered } from '@/store/mediaResolver';
 import { isOrbitRuntimeRegistered } from '@/store/orbitRuntime';

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -214,6 +214,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Performance benchmark CLI and faster scoped library browsing (PR #1382)',
       'Startup window controls and lifecycle race fixes (PR #1392)',
       'AIFF/AIF/AIFC playback across streamed, cached, and local sources (PR #1396)',
+      'Navidrome canonical-ID migration before app startup (PR #1409)',
     ],
   },
   {

--- a/src/generated/bindings.ts
+++ b/src/generated/bindings.ts
@@ -97,6 +97,10 @@ export const commands = {
 	libraryGetRecentPlaySessions: (limit: number | null, sinceMs: number | null) => typedError<PlaySessionDayTrackDto[], string>(__TAURI_INVOKE("library_get_recent_play_sessions", { limit, sinceMs })),
 	libraryPurgeServer: (serverId: string, includeAnalysis: boolean | null, includeOffline: boolean | null) => typedError<PurgeReportDto, string>(__TAURI_INVOKE("library_purge_server", { serverId, includeAnalysis, includeOffline })),
 	libraryMigrateServerIndexKeys: (mappings: LibraryServerKeyMigrationDto[]) => typedError<null, string>(__TAURI_INVOKE("library_migrate_server_index_keys", { mappings })),
+	libraryNavidromeCanonicalInspect: (serverId: string) => typedError<CanonicalMigrationDto, string>(__TAURI_INVOKE("library_navidrome_canonical_inspect", { serverId })),
+	libraryNavidromeCanonicalRewrite: (serverId: string) => typedError<CanonicalMigrationDto, string>(__TAURI_INVOKE("library_navidrome_canonical_rewrite", { serverId })),
+	libraryNavidromeCanonicalAckFrontend: (serverId: string) => typedError<CanonicalMigrationDto, string>(__TAURI_INVOKE("library_navidrome_canonical_ack_frontend", { serverId })),
+	libraryNavidromeCanonicalFinalize: (serverId: string) => typedError<CanonicalMigrationDto, string>(__TAURI_INVOKE("library_navidrome_canonical_finalize", { serverId })),
 	libraryDeleteServerData: (serverId: string) => typedError<null, string>(__TAURI_INVOKE("library_delete_server_data", { serverId })),
 	audioPause: () => __TAURI_INVOKE<void>("audio_pause"),
 	/**
@@ -872,6 +876,23 @@ export type BandsintownEvent = {
 	url: string,
 	on_sale_datetime: string,
 	lineup: string[],
+};
+
+export type CanonicalIdMappingDto = {
+	entityKind: string,
+	oldId: string,
+	newId: string,
+};
+
+export type CanonicalMigrationDto = {
+	serverId: string,
+	state: string,
+	canonicalVersion: number,
+	probeKind: string | null,
+	probeOldId: string | null,
+	probeNewId: string | null,
+	lastError: string | null,
+	mappings: CanonicalIdMappingDto[],
 };
 
 /**  Min/max `year` from indexed tracks for a server (Albums year filter UI). */

--- a/src/lib/api/library.ts
+++ b/src/lib/api/library.ts
@@ -14,3 +14,4 @@ export * from './library/scopeReads';
 export * from './library/sync';
 export * from './library/stats';
 export * from './library/events';
+export * from './library/canonicalMigration';

--- a/src/lib/api/library/canonicalMigration.ts
+++ b/src/lib/api/library/canonicalMigration.ts
@@ -1,0 +1,44 @@
+import { commands } from '@/generated/bindings';
+import type { CanonicalMigrationDto } from '@/generated/bindings';
+import { serverIndexKeyForId } from './internal';
+
+async function unwrapCanonicalMigration(
+  result: Awaited<ReturnType<typeof commands.libraryNavidromeCanonicalInspect>>,
+): Promise<CanonicalMigrationDto> {
+  if (result.status === 'error') throw new Error(result.error);
+  return result.data;
+}
+
+export async function libraryNavidromeCanonicalInspect(
+  serverId: string,
+): Promise<CanonicalMigrationDto> {
+  return unwrapCanonicalMigration(
+    await commands.libraryNavidromeCanonicalInspect(serverIndexKeyForId(serverId)),
+  );
+}
+
+export async function libraryNavidromeCanonicalRewrite(
+  serverId: string,
+): Promise<CanonicalMigrationDto> {
+  return unwrapCanonicalMigration(
+    await commands.libraryNavidromeCanonicalRewrite(serverIndexKeyForId(serverId)),
+  );
+}
+
+export async function libraryNavidromeCanonicalAckFrontend(
+  serverId: string,
+): Promise<CanonicalMigrationDto> {
+  return unwrapCanonicalMigration(
+    await commands.libraryNavidromeCanonicalAckFrontend(serverIndexKeyForId(serverId)),
+  );
+}
+
+export async function libraryNavidromeCanonicalFinalize(
+  serverId: string,
+): Promise<CanonicalMigrationDto> {
+  return unwrapCanonicalMigration(
+    await commands.libraryNavidromeCanonicalFinalize(serverIndexKeyForId(serverId)),
+  );
+}
+
+export type { CanonicalIdMappingDto, CanonicalMigrationDto } from '@/generated/bindings';

--- a/src/lib/library/librarySession.ts
+++ b/src/lib/library/librarySession.ts
@@ -175,6 +175,11 @@ export async function bindIndexedServer(server: ServerProfile): Promise<BindServ
   }
 }
 
+/** Bind one server without queuing ordinary startup sync work. */
+export async function bindIndexedServerForMigration(server: ServerProfile): Promise<BindServerResult> {
+  return bindIndexedServer(server);
+}
+
 /** Bind + kick off initial sync for one indexed server. */
 export async function bootstrapIndexedServer(server: ServerProfile): Promise<BindServerResult> {
   const bound = await bindIndexedServer(server);

--- a/src/lib/server/navidromeCanonicalId.test.ts
+++ b/src/lib/server/navidromeCanonicalId.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalNavidromeArtworkId,
+  canonicalNavidromeId,
+} from './navidromeCanonicalId';
+
+describe('canonicalNavidromeId', () => {
+  it.each([
+    ['5cLJPkLA5DK2BADhoeotPk', '5cLJPkLA5DK2BADhoeotPk'],
+    ['zzzzzzzzzzzzzzzzzzzzzz', '3LyqmwQBm5IRqlVjNYASwb'],
+    ['e3b7fc2ae9447bbec37a13bf916e3cf6', '6VHl3uR4kss6sUPKA8Cwnk'],
+    ['f47ac10b-58cc-4372-a567-0e02b2c3d479', '7rke2SAWaicSeSYzkhww6R'],
+  ])('matches the upstream vector %s', (input, expected) => {
+    expect(canonicalNavidromeId(input)).toBe(expected);
+  });
+
+  it('preserves structured artwork suffixes', () => {
+    const oldId = 'e3b7fc2ae9447bbec37a13bf916e3cf6';
+    const newId = '6VHl3uR4kss6sUPKA8Cwnk';
+    expect(canonicalNavidromeArtworkId(`mf-${oldId}_60fc987f`))
+      .toBe(`mf-${newId}_60fc987f`);
+    expect(canonicalNavidromeArtworkId(`dc-${oldId}:2_60fc987f`))
+      .toBe(`dc-${newId}:2_60fc987f`);
+  });
+});

--- a/src/lib/server/navidromeCanonicalId.ts
+++ b/src/lib/server/navidromeCanonicalId.ts
@@ -1,0 +1,79 @@
+import md5 from 'md5';
+
+const BASE62_DIGITS = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const U128_MAX = (1n << 128n) - 1n;
+
+function decodeBase62(value: string): bigint | null {
+  let decoded = 0n;
+  for (const character of value) {
+    const digit = BASE62_DIGITS.indexOf(character);
+    if (digit < 0) return null;
+    decoded = decoded * 62n + BigInt(digit);
+  }
+  return decoded;
+}
+
+function encodeBase62(value: bigint): string {
+  let remaining = value;
+  const encoded = Array<string>(22).fill('0');
+  let index = encoded.length;
+  while (remaining > 0n) {
+    index -= 1;
+    encoded[index] = BASE62_DIGITS[Number(remaining % 62n)]!;
+    remaining /= 62n;
+  }
+  return encoded.join('');
+}
+
+function hexToBigInt(value: string): bigint | null {
+  if (!/^[0-9a-fA-F]{32}$/.test(value)) return null;
+  return BigInt(`0x${value}`);
+}
+
+/** Exact TypeScript port of Navidrome's uniform canonical-ID migration helper. */
+export function canonicalNavidromeId(value: string): string {
+  let decoded: bigint | null = null;
+  if (value.length === 22) {
+    decoded = decodeBase62(value);
+    if (decoded === null) return value;
+    if (decoded <= U128_MAX) return value;
+    decoded = hexToBigInt(md5(value));
+  } else if (value.length === 32) {
+    decoded = hexToBigInt(value);
+  } else if (
+    value.length === 36
+    && value[8] === '-'
+    && value[13] === '-'
+    && value[18] === '-'
+    && value[23] === '-'
+  ) {
+    decoded = hexToBigInt(value.replace(/-/g, ''));
+  }
+  return decoded === null ? value : encodeBase62(decoded);
+}
+
+function splitUpdateToken(value: string): [string, string | null] {
+  const separator = value.lastIndexOf('_');
+  if (separator < 0) return [value, null];
+  const token = value.slice(separator + 1);
+  return token.length > 0 && /^[0-9a-fA-F]+$/.test(token)
+    ? [value.slice(0, separator), token]
+    : [value, null];
+}
+
+/** Rewrite only the entity-bearing payload of a Navidrome artwork ID. */
+export function canonicalNavidromeArtworkId(value: string): string {
+  const prefix = ['mf-', 'al-', 'ar-', 'pl-', 'dc-', 'ra-']
+    .find(candidate => value.startsWith(candidate));
+  if (!prefix) return canonicalNavidromeId(value);
+
+  const [payload, updateToken] = splitUpdateToken(value.slice(prefix.length));
+  let rewritten = canonicalNavidromeId(payload);
+  if (prefix === 'dc-') {
+    const separator = payload.indexOf(':');
+    rewritten = separator < 0
+      ? payload
+      : `${canonicalNavidromeId(payload.slice(0, separator))}${payload.slice(separator)}`;
+  }
+  return `${prefix}${rewritten}${updateToken ? `_${updateToken}` : ''}`;
+}

--- a/src/store/migrationStore.ts
+++ b/src/store/migrationStore.ts
@@ -1,9 +1,17 @@
 import { create } from 'zustand';
-import type { GenreTagsInspectDto, ScopeBrowseProjectionInspectDto } from '@/lib/api/library';
+import type {
+  CanonicalMigrationDto,
+  GenreTagsInspectDto,
+  ScopeBrowseProjectionInspectDto,
+} from '@/lib/api/library';
 import type { MigrationInspectReport, MigrationProgressEvent } from '@/lib/api/migration';
 
 export type MigrationPhase = 'idle' | 'inspecting' | 'running' | 'completed' | 'error';
-export type MigrationStep = 'serverIndex' | 'genreTags' | 'scopeBrowseProjection';
+export type MigrationStep =
+  | 'serverIndex'
+  | 'navidromeCanonical'
+  | 'genreTags'
+  | 'scopeBrowseProjection';
 
 export interface GenreTagsProgressEvent {
   done: number;
@@ -20,6 +28,7 @@ interface MigrationState {
   genreTagsProgress: GenreTagsProgressEvent | null;
   scopeBrowseProjectionInspect: ScopeBrowseProjectionInspectDto | null;
   scopeBrowseProjectionProgress: GenreTagsProgressEvent | null;
+  navidromeCanonical: CanonicalMigrationDto | null;
   lastError: string | null;
   setPhase: (phase: MigrationPhase) => void;
   setStep: (step: MigrationStep | null) => void;
@@ -30,6 +39,7 @@ interface MigrationState {
   setGenreTagsProgress: (event: GenreTagsProgressEvent | null) => void;
   setScopeBrowseProjectionInspect: (report: ScopeBrowseProjectionInspectDto | null) => void;
   setScopeBrowseProjectionProgress: (event: GenreTagsProgressEvent | null) => void;
+  setNavidromeCanonical: (report: CanonicalMigrationDto | null) => void;
   setError: (error: string | null) => void;
 }
 
@@ -43,6 +53,7 @@ export const useMigrationStore = create<MigrationState>(set => ({
   genreTagsProgress: null,
   scopeBrowseProjectionInspect: null,
   scopeBrowseProjectionProgress: null,
+  navidromeCanonical: null,
   lastError: null,
   setPhase: phase => set({ phase }),
   setStep: step => set({ step }),
@@ -53,5 +64,6 @@ export const useMigrationStore = create<MigrationState>(set => ({
   setGenreTagsProgress: genreTagsProgress => set({ genreTagsProgress }),
   setScopeBrowseProjectionInspect: scopeBrowseProjectionInspect => set({ scopeBrowseProjectionInspect }),
   setScopeBrowseProjectionProgress: scopeBrowseProjectionProgress => set({ scopeBrowseProjectionProgress }),
+  setNavidromeCanonical: navidromeCanonical => set({ navidromeCanonical }),
   setError: lastError => set({ lastError }),
 }));


### PR DESCRIPTION
## Summary
- add a durable schema-27 Navidrome canonical-ID migration with journaled library and analysis rewrites
- block normal UI, playback bridges, sync, and offline writers until inspection, rewrite, full-sync acknowledgement, and final verification complete
- fail closed when canonical namespace probing is inconclusive or more than one server is configured
- dismiss the startup splash when the blocking migration modal owns the screen

## User impact
Existing single-server Navidrome libraries migrate old 32-hex entity IDs before the app becomes interactive, preventing mixed legacy/canonical IDs from reaching browse, playback, cache, and analysis paths. Unsupported multi-server preflight remains visibly blocked with a retryable error instead of entering a partial runtime state.

## Verification
- `nix develop . -c bash -lc 'npm run lint'`
- `nix develop . -c bash -lc 'npm run dep:check'`
- `nix develop . -c bash -lc 'npm test'` (555 files, 4053 tests)
- `nix develop . -c bash -lc 'npm run prebuild:release-notes'`
- `nix develop . -c bash -lc 'npx tsc --noEmit'`
- `nix develop . -c bash -lc 'npx vitest run --coverage && bash scripts/check-frontend-hot-path-coverage.sh'`
- `nix develop . -c bash -lc 'cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings'`
- Rust workspace tests: 778 passed; two pre-existing wall-clock budget tests failed only during the parallel full-suite run, then passed individually in 0.11s and 0.08s
- direct `./dev.sh run` visual smoke: blocking error modal dismisses splash; completed one-server profile mounts sidebar, content, navigation, and player bar
- restart coverage: file-backed reopen after journal and native commit; orchestrator resume from `frontend` and failed `resyncing` full-sync retry

## Runtime benchmark
- Applicability: required (startup gate, SQLite migration, shared app shell)
- Baseline: `c2c896994eeb196cf1697b7207824701ef338469` / report `2026-08-13T19-26-45-019Z`
- Final code: `2a0eee06d80d26c7d3b0ab29cc4bb44381367cb6` / report `2026-08-13T19-23-56-585Z`
- Current PR head: `5b941e6b` (release notes and restart tests after the measured code SHA; no production runtime changes)
- Command: `psysonic benchmark run --scenario all-pages --runs 2 --profile realistic --json`
- Environment: Linux WebKit `Version/60.5`, viewport `1275x694` at DPR 2, one selected/configured server, scope fingerprint `[[\"mqtevms0vhsd2eqnzo\",[\"1\"]]]`
- Result: final comparable warmed reports had no errors, wrong routes, or timeouts; Home readiness `319 -> 322 ms`, Albums `99 -> 0 ms`, Artists `89 -> 0 ms`, Tracks `131 -> 0 ms`, Favourites `150 -> 0 ms`
- Dynamic detail totals remained artwork/DOM-quiet dominated: album `6697 -> 7678 ms`, artist `4820 -> 1494 ms`, playlist `3867 -> 3754 ms`; no semantic-readiness or timeout regression
- Skips: composer detail (no owned indexed composer), label detail (no reachable owned labelled album), identical on both revisions

## Tauri boundary
Adds typed canonical-ID migration commands used by the startup orchestrator and keeps the boundary additive. Frontend mocks/tests and Rust command tests cover the new contract.