### PR TITLE
fix(library): restore Navidrome timestamps with UTC offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,7 +188,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#1470](https://github.com/Psysonic/psysonic/pull/1470)**
 
-* Navidrome timestamps with negative UTC offsets no longer disappear from the local index, so New Releases, favourites and last played dates populate correctly. Existing libraries are repaired once at startup without requiring a full resync.
+* Navidrome timestamps with negative UTC offsets no longer disappear from the local index, so New Releases, favourites and last played dates populate correctly during sync. Existing library creation dates are repaired once at startup without requiring a full resync or overwriting newer favourite/play state.
 
 ## [1.51.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Nine topics that were never covered are now there: browsing several servers at once, the timeline queue view with Play from Here, capping the streaming bitrate per server address, the table view on the album pages, telling your own playlists from shared ones, the Composers page, the audio visualizer, the theme store and the background sources.
 * All of it in every language the app ships in.
 
+### Navidrome dates with UTC offsets populate New Releases again
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1470](https://github.com/Psysonic/psysonic/pull/1470)**
+
+* Navidrome timestamps with negative UTC offsets no longer disappear from the local index, so New Releases, favourites and last played dates populate correctly. Existing libraries are repaired once at startup without requiring a full resync.
+
 ## [1.51.0] - 2026-08-17
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,7 +188,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **By [@cucadmuh](https://github.com/cucadmuh), PR [#1470](https://github.com/Psysonic/psysonic/pull/1470)**
 
-* Navidrome timestamps with negative UTC offsets no longer disappear from the local index, so New Releases, favourites and last played dates populate correctly during sync. Existing library creation dates are repaired once at startup without requiring a full resync or overwriting newer favourite/play state.
+* Navidrome timestamps with negative UTC offsets no longer disappear from the local index, so New Releases, favourites and last played dates populate correctly during sync. Existing creation dates with safely identifiable old values are repaired gradually in the background; ambiguous cleared legacy values wait for a later sync rather than risk restoring stale data.
 
 ## [1.51.0] - 2026-08-17
 

--- a/src-tauri/crates/psysonic-library/src/repos/track/ingest.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/ingest.rs
@@ -331,7 +331,14 @@ ON CONFLICT(server_id, id) DO UPDATE SET
     WHEN excluded.server_updated_at IS NOT NULL THEN excluded.server_updated_at
     ELSE track.server_updated_at
   END,
-  server_created_at    = excluded.server_created_at,
+  server_created_at    = CASE
+    WHEN json_valid(excluded.raw_json)
+     AND (json_type(excluded.raw_json, '$.created') IS NOT NULL
+       OR json_type(excluded.raw_json, '$.createdAt') IS NOT NULL)
+      THEN excluded.server_created_at
+    WHEN excluded.server_created_at IS NOT NULL THEN excluded.server_created_at
+    ELSE track.server_created_at
+  END,
   deleted              = excluded.deleted,
   synced_at            = excluded.synced_at,
   raw_json             = CASE
@@ -422,7 +429,14 @@ ON CONFLICT(server_id, id) DO UPDATE SET
     WHEN excluded.server_updated_at IS NOT NULL THEN excluded.server_updated_at
     ELSE track.server_updated_at
   END,
-  server_created_at    = excluded.server_created_at,
+  server_created_at    = CASE
+    WHEN json_valid(excluded.raw_json)
+     AND (json_type(excluded.raw_json, '$.created') IS NOT NULL
+       OR json_type(excluded.raw_json, '$.createdAt') IS NOT NULL)
+      THEN excluded.server_created_at
+    WHEN excluded.server_created_at IS NOT NULL THEN excluded.server_created_at
+    ELSE track.server_created_at
+  END,
   deleted              = 0,
   synced_at            = excluded.synced_at,
   raw_json             = CASE

--- a/src-tauri/crates/psysonic-library/src/repos/track/remap.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/remap.rs
@@ -96,6 +96,27 @@ impl TrackRepository<'_> {
                         None
                     };
                     let raw_json = remap_merged_raw.as_deref().unwrap_or(r.raw_json.as_str());
+                    let remap_source_timestamps = if sparse_payload {
+                        detected_old
+                            .as_deref()
+                            .map(|old_id| load_remap_source_timestamps(&tx, &r.server_id, old_id))
+                            .transpose()?
+                            .flatten()
+                    } else {
+                        None
+                    };
+                    let server_updated_at = sparse_remap_timestamp(
+                        r.server_updated_at,
+                        &r.raw_json,
+                        &["updatedAt"],
+                        remap_source_timestamps.and_then(|timestamps| timestamps.0),
+                    );
+                    let server_created_at = sparse_remap_timestamp(
+                        r.server_created_at,
+                        &r.raw_json,
+                        &["created", "createdAt"],
+                        remap_source_timestamps.and_then(|timestamps| timestamps.1),
+                    );
 
                     upsert.execute(params![
                         r.server_id,
@@ -129,8 +150,8 @@ impl TrackRepository<'_> {
                         r.replay_gain_album_db,
                         r.replay_gain_peak,
                         r.content_hash,
-                        r.server_updated_at,
-                        r.server_created_at,
+                        server_updated_at,
+                        server_created_at,
                         if r.deleted { 1_i64 } else { 0 },
                         r.synced_at,
                         raw_json,
@@ -201,6 +222,39 @@ impl TrackRepository<'_> {
                 tx.commit()?;
                 Ok(RemapStats { remapped })
             })
+    }
+}
+
+fn load_remap_source_timestamps(
+    tx: &rusqlite::Transaction<'_>,
+    server_id: &str,
+    old_id: &str,
+) -> rusqlite::Result<Option<(Option<i64>, Option<i64>)>> {
+    tx.query_row(
+        "SELECT server_updated_at, server_created_at FROM track \
+         WHERE server_id = ?1 AND id = ?2",
+        params![server_id, old_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )
+    .optional()
+}
+
+fn sparse_remap_timestamp(
+    incoming: Option<i64>,
+    incoming_raw: &str,
+    keys: &[&str],
+    remap_source: Option<i64>,
+) -> Option<i64> {
+    let field_is_present = serde_json::from_str::<serde_json::Value>(incoming_raw)
+        .ok()
+        .is_some_and(|raw| {
+            raw.as_object()
+                .is_some_and(|raw| keys.iter().any(|key| raw.contains_key(*key)))
+        });
+    if field_is_present {
+        incoming
+    } else {
+        incoming.or(remap_source)
     }
 }
 

--- a/src-tauri/crates/psysonic-library/src/repos/track/remap.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/remap.rs
@@ -80,7 +80,18 @@ impl TrackRepository<'_> {
                     // that resolved source before inserting the new id, otherwise the
                     // later old-row deletion would discard the very fields sparse ingest
                     // is meant to preserve.
-                    let remap_merged_raw = if sparse_payload {
+                    let destination_exists = if sparse_payload && detected_old.is_some() {
+                        track_exists(&tx, &r.server_id, &r.id)?
+                    } else {
+                        false
+                    };
+                    // Missing destination fields may be explicit clears whose
+                    // JSON nulls were removed by SQLite `json_patch`. Once a
+                    // destination exists it must win completely; filling gaps
+                    // from the old source could resurrect cleared metadata.
+                    let preserve_remap_source =
+                        sparse_payload && detected_old.is_some() && !destination_exists;
+                    let remap_merged_raw = if preserve_remap_source {
                         detected_old
                             .as_deref()
                             .map(|old_id| {
@@ -96,7 +107,7 @@ impl TrackRepository<'_> {
                         None
                     };
                     let raw_json = remap_merged_raw.as_deref().unwrap_or(r.raw_json.as_str());
-                    let remap_source_timestamps = if sparse_payload {
+                    let remap_source_timestamps = if preserve_remap_source {
                         detected_old
                             .as_deref()
                             .map(|old_id| load_remap_source_timestamps(&tx, &r.server_id, old_id))
@@ -256,6 +267,20 @@ fn sparse_remap_timestamp(
     } else {
         incoming.or(remap_source)
     }
+}
+
+fn track_exists(
+    tx: &rusqlite::Transaction<'_>,
+    server_id: &str,
+    track_id: &str,
+) -> rusqlite::Result<bool> {
+    tx.query_row(
+        "SELECT 1 FROM track WHERE server_id = ?1 AND id = ?2",
+        params![server_id, track_id],
+        |_| Ok(()),
+    )
+    .optional()
+    .map(|row| row.is_some())
 }
 
 /// Merge a sparse incoming row against the rich row that was selected as the

--- a/src-tauri/crates/psysonic-library/src/repos/track/tests/ingest_sparse.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/tests/ingest_sparse.rs
@@ -326,37 +326,41 @@ fn explicit_nulls_clear_preserved_sparse_fields() {
     assert_eq!(values, (None, None, None));
 }
 
-/// `MAX(server_updated_at)` is where the native delta resumes reading. A
-/// bulk pass that does not carry the timestamp must not erase it, on either
-/// upsert shape — a resync that blanks it strands the delta.
+/// `MAX(server_updated_at)` is where the native delta resumes reading, while
+/// `server_created_at` drives New Releases. A bulk pass that carries neither
+/// timestamp must not erase either one on either upsert shape.
 #[test]
-fn a_bulk_pass_does_not_erase_the_delta_watermark() {
+fn a_bulk_pass_does_not_erase_sync_timestamps() {
     let store = LibraryStore::open_in_memory();
     let repo = TrackRepository::new(&store);
     repo.upsert_batch(&[enriched_row("t1")]).unwrap();
 
     let mut bulk = bulk_row_without_credit("t1");
     bulk.server_updated_at = None;
+    bulk.server_created_at = None;
     repo.upsert_sparse_batch_initial_ingest_timed(&[bulk.clone()], None)
         .unwrap();
-    assert_eq!(delta_watermark(&store, "t1"), Some(1_700_000_000));
+    assert_eq!(
+        sync_timestamps(&store, "t1"),
+        (Some(1_700_000_000), Some(1_699_000_000))
+    );
 
     repo.upsert_sparse_batch_initial_ingest_timed(&[bulk], Some(2))
         .unwrap();
     assert_eq!(
-        delta_watermark(&store, "t1"),
-        Some(1_700_000_000),
+        sync_timestamps(&store, "t1"),
+        (Some(1_700_000_000), Some(1_699_000_000)),
         "the resync path must preserve it too"
     );
 }
 
-fn delta_watermark(store: &LibraryStore, id: &str) -> Option<i64> {
+fn sync_timestamps(store: &LibraryStore, id: &str) -> (Option<i64>, Option<i64>) {
     store
         .with_conn("misc", |c| {
             c.query_row(
-                "SELECT server_updated_at FROM track WHERE id = ?1",
+                "SELECT server_updated_at, server_created_at FROM track WHERE id = ?1",
                 params![id],
-                |r| r.get(0),
+                |r| Ok((r.get(0)?, r.get(1)?)),
             )
         })
         .unwrap()

--- a/src-tauri/crates/psysonic-library/src/repos/track/tests/remap.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/tests/remap.rs
@@ -129,6 +129,8 @@ fn sparse_remap_merges_from_resolved_old_row_before_deleting_it() {
     let repo = TrackRepository::new(&store);
 
     let mut old = row_with_id_hash("s1", "tr_old", "deadbeef", "/path/x.flac");
+    old.server_updated_at = Some(1_700_000_123_000);
+    old.server_created_at = Some(1_699_000_123_000);
     old.raw_json = json!({
         "id": "tr_old",
         "artist": "FOVOS, Max Cardona",
@@ -146,6 +148,8 @@ fn sparse_remap_merges_from_resolved_old_row_before_deleting_it() {
     repo.upsert_batch(&[old]).unwrap();
 
     let mut incoming = row_with_id_hash("s1", "tr_new", "deadbeef", "/path/x.flac");
+    incoming.server_updated_at = None;
+    incoming.server_created_at = None;
     incoming.raw_json = json!({
         "id": "tr_new",
         "artist": "FOVOS, Someone Else",
@@ -190,6 +194,57 @@ fn sparse_remap_merges_from_resolved_old_row_before_deleting_it() {
             { "id": "max-cardona", "name": "Max Cardona" }
         ])
     );
+    let timestamps: (Option<i64>, Option<i64>) = store
+        .with_conn("misc", |c| {
+            c.query_row(
+                "SELECT server_updated_at, server_created_at FROM track \
+                 WHERE server_id = 's1' AND id = 'tr_new'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+        })
+        .unwrap();
+    assert_eq!(
+        timestamps,
+        (Some(1_700_000_123_000), Some(1_699_000_123_000)),
+        "timestamps omitted by the sparse remap payload survive the old-id deletion"
+    );
+}
+
+#[test]
+fn sparse_remap_explicit_null_timestamps_clear_old_values() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+
+    let mut old = row_with_id_hash("s1", "tr_old", "deadbeef", "/path/x.flac");
+    old.server_updated_at = Some(1_700_000_123_000);
+    old.server_created_at = Some(1_699_000_123_000);
+    repo.upsert_batch(&[old]).unwrap();
+
+    let mut incoming = row_with_id_hash("s1", "tr_new", "deadbeef", "/path/x.flac");
+    incoming.server_updated_at = None;
+    incoming.server_created_at = None;
+    incoming.raw_json = json!({
+        "id": "tr_new",
+        "updatedAt": null,
+        "createdAt": null
+    })
+    .to_string();
+
+    repo.upsert_sparse_batch_with_remap(&[incoming], true)
+        .unwrap();
+
+    let timestamps: (Option<i64>, Option<i64>) = store
+        .with_conn("misc", |c| {
+            c.query_row(
+                "SELECT server_updated_at, server_created_at FROM track \
+                 WHERE server_id = 's1' AND id = 'tr_new'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+        })
+        .unwrap();
+    assert_eq!(timestamps, (None, None));
 }
 
 #[test]

--- a/src-tauri/crates/psysonic-library/src/repos/track/tests/remap.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/tests/remap.rs
@@ -212,6 +212,86 @@ fn sparse_remap_merges_from_resolved_old_row_before_deleting_it() {
 }
 
 #[test]
+fn sparse_remap_keeps_newer_timestamps_on_an_existing_destination() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+
+    let mut old = row_with_id_hash("s1", "tr_old", "deadbeef", "/path/x.flac");
+    old.server_updated_at = Some(100);
+    old.server_created_at = Some(200);
+    let mut destination = row_with_id_hash("s1", "tr_new", "deadbeef", "/path/x.flac");
+    destination.server_updated_at = Some(300);
+    destination.server_created_at = Some(400);
+    repo.upsert_batch(&[old, destination]).unwrap();
+
+    let mut incoming = row_with_id_hash("s1", "tr_new", "deadbeef", "/path/x.flac");
+    incoming.server_updated_at = None;
+    incoming.server_created_at = None;
+    incoming.raw_json = json!({ "id": "tr_new", "title": "Current" }).to_string();
+
+    let stats = repo
+        .upsert_sparse_batch_with_remap(&[incoming], true)
+        .unwrap();
+    assert_eq!(stats.remapped.len(), 1);
+    assert_eq!(stats.remapped[0].old_id, "tr_old");
+    assert_eq!(stats.remapped[0].new_id, "tr_new");
+
+    let timestamps: (Option<i64>, Option<i64>) = store
+        .with_conn("test.existing_remap_destination", |conn| {
+            conn.query_row(
+                "SELECT server_updated_at, server_created_at FROM track \
+                 WHERE server_id = 's1' AND id = 'tr_new'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+        })
+        .unwrap();
+    assert_eq!(timestamps, (Some(300), Some(400)));
+}
+
+#[test]
+fn sparse_remap_does_not_resurrect_cleared_destination_timestamps() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+
+    let mut old = row_with_id_hash("s1", "tr_old", "deadbeef", "/path/x.flac");
+    old.server_updated_at = Some(100);
+    old.server_created_at = Some(200);
+    old.raw_json = json!({
+        "id": "tr_old",
+        "artists": [{ "id": "ar_old", "name": "Old artist" }],
+        "created": "2024-01-01T00:00:00+02:00"
+    })
+    .to_string();
+    let mut destination = row_with_id_hash("s1", "tr_new", "deadbeef", "/path/x.flac");
+    destination.server_updated_at = None;
+    destination.server_created_at = None;
+    repo.upsert_batch(&[old, destination]).unwrap();
+
+    let mut incoming = row_with_id_hash("s1", "tr_new", "deadbeef", "/path/x.flac");
+    incoming.server_updated_at = None;
+    incoming.server_created_at = None;
+    incoming.raw_json = json!({ "id": "tr_new", "title": "Current" }).to_string();
+    repo.upsert_sparse_batch_with_remap(&[incoming], true)
+        .unwrap();
+
+    let (updated_at, created_at, raw_json): (Option<i64>, Option<i64>, String) = store
+        .with_conn("test.cleared_remap_destination", |conn| {
+            conn.query_row(
+                "SELECT server_updated_at, server_created_at, raw_json FROM track \
+                 WHERE server_id = 's1' AND id = 'tr_new'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+        })
+        .unwrap();
+    assert_eq!((updated_at, created_at), (None, None));
+    let raw: serde_json::Value = serde_json::from_str(&raw_json).unwrap();
+    assert!(raw.get("artists").is_none());
+    assert!(raw.get("created").is_none());
+}
+
+#[test]
 fn sparse_remap_explicit_null_timestamps_clear_old_values() {
     let store = LibraryStore::open_in_memory();
     let repo = TrackRepository::new(&store);

--- a/src-tauri/crates/psysonic-library/src/store.rs
+++ b/src-tauri/crates/psysonic-library/src/store.rs
@@ -9,6 +9,7 @@ mod lifecycle;
 mod migrations;
 mod open;
 mod reconciles;
+mod track_timestamp_reconcile;
 
 pub use connection::WriteOpTiming;
 #[allow(unused_imports)]

--- a/src-tauri/crates/psysonic-library/src/store.rs
+++ b/src-tauri/crates/psysonic-library/src/store.rs
@@ -28,6 +28,7 @@ pub(crate) use migrations::{
     MIGRATION_025_IDENTITY_INVALIDATION, MIGRATION_026_LIBRARY_TAG_CURSOR,
 };
 pub use migrations::{LIBRARY_DB_MIN_COMPATIBLE_VERSION, LIBRARY_DB_SCHEMA_VERSION};
+pub use track_timestamp_reconcile::TrackTimestampBackfillStep;
 #[allow(unused_imports)]
 pub(crate) use reconciles::{
     ARTIST_NAME_FOLD_RECONCILE_ID, ARTIST_NAME_SORT_RECONCILE_ID,

--- a/src-tauri/crates/psysonic-library/src/store/open.rs
+++ b/src-tauri/crates/psysonic-library/src/store/open.rs
@@ -15,7 +15,7 @@ use super::reconciles::{
     maybe_reconcile_artist_name_fold, maybe_reconcile_artist_name_sort,
     maybe_reconcile_duration_sec_backfill, maybe_reconcile_library_id_backfill,
     maybe_reconcile_orphan_browse_rows, maybe_reconcile_replay_gain_peak,
-    reconcile_ready_rows_with_ingest_cursors,
+    maybe_reconcile_track_timestamp_backfill, reconcile_ready_rows_with_ingest_cursors,
 };
 use super::LibraryStore;
 
@@ -254,6 +254,18 @@ fn register_sql_functions(conn: &Connection) -> rusqlite::Result<()> {
             let name: String = ctx.get(0)?;
             Ok(name.trim().to_lowercase())
         },
+    )?;
+    conn.create_scalar_function(
+        "psysonic_parse_iso_ms",
+        1,
+        FunctionFlags::SQLITE_UTF8 | FunctionFlags::SQLITE_DETERMINISTIC,
+        |ctx| {
+            let timestamp = match ctx.get_raw(0) {
+                rusqlite::types::ValueRef::Text(value) => std::str::from_utf8(value).ok(),
+                _ => None,
+            };
+            Ok(timestamp.and_then(crate::sync::mapping::parse_iso_ms_str))
+        },
     )
 }
 
@@ -322,6 +334,7 @@ fn prepare_write_connection_for_open(conn: &Connection) -> rusqlite::Result<()> 
     maybe_reconcile_artist_name_fold(conn)?;
     maybe_reconcile_replay_gain_peak(conn)?;
     maybe_reconcile_library_id_backfill(conn)?;
+    maybe_reconcile_track_timestamp_backfill(conn)?;
     maybe_reconcile_duration_sec_backfill(conn)?;
     maybe_reconcile_orphan_browse_rows(conn)?;
     ensure_genre_tags_schema(conn)?;

--- a/src-tauri/crates/psysonic-library/src/store/open.rs
+++ b/src-tauri/crates/psysonic-library/src/store/open.rs
@@ -15,7 +15,7 @@ use super::reconciles::{
     maybe_reconcile_artist_name_fold, maybe_reconcile_artist_name_sort,
     maybe_reconcile_duration_sec_backfill, maybe_reconcile_library_id_backfill,
     maybe_reconcile_orphan_browse_rows, maybe_reconcile_replay_gain_peak,
-    maybe_reconcile_track_timestamp_backfill, reconcile_ready_rows_with_ingest_cursors,
+    reconcile_ready_rows_with_ingest_cursors,
 };
 use super::LibraryStore;
 
@@ -322,7 +322,6 @@ fn prepare_write_connection_for_open(conn: &Connection) -> rusqlite::Result<()> 
     maybe_reconcile_artist_name_fold(conn)?;
     maybe_reconcile_replay_gain_peak(conn)?;
     maybe_reconcile_library_id_backfill(conn)?;
-    maybe_reconcile_track_timestamp_backfill(conn)?;
     maybe_reconcile_duration_sec_backfill(conn)?;
     maybe_reconcile_orphan_browse_rows(conn)?;
     ensure_genre_tags_schema(conn)?;

--- a/src-tauri/crates/psysonic-library/src/store/open.rs
+++ b/src-tauri/crates/psysonic-library/src/store/open.rs
@@ -254,18 +254,6 @@ fn register_sql_functions(conn: &Connection) -> rusqlite::Result<()> {
             let name: String = ctx.get(0)?;
             Ok(name.trim().to_lowercase())
         },
-    )?;
-    conn.create_scalar_function(
-        "psysonic_parse_iso_ms",
-        1,
-        FunctionFlags::SQLITE_UTF8 | FunctionFlags::SQLITE_DETERMINISTIC,
-        |ctx| {
-            let timestamp = match ctx.get_raw(0) {
-                rusqlite::types::ValueRef::Text(value) => std::str::from_utf8(value).ok(),
-                _ => None,
-            };
-            Ok(timestamp.and_then(crate::sync::mapping::parse_iso_ms_str))
-        },
     )
 }
 

--- a/src-tauri/crates/psysonic-library/src/store/reconciles.rs
+++ b/src-tauri/crates/psysonic-library/src/store/reconciles.rs
@@ -20,10 +20,7 @@ pub(crate) const ORPHAN_BROWSE_RECONCILE_ID: &str = "orphan_browse_rows_reconcil
 pub(crate) const DURATION_SEC_BACKFILL_RECONCILE_ID: &str = "duration_sec_decimal_backfill_v1";
 const DURATION_SEC_BACKFILL_BATCH_SIZE: i64 = 1_000;
 
-/// One-time repair of timestamp columns lost when negative UTC offsets failed
-/// to parse, or shifted when positive offsets were treated as UTC wall time.
-pub(crate) const TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID: &str = "track_timestamp_backfill_v1";
-const TRACK_TIMESTAMP_BACKFILL_BATCH_SIZE: i64 = 1_000;
+pub(super) use super::track_timestamp_reconcile::maybe_reconcile_track_timestamp_backfill;
 
 pub(super) fn reconcile_ready_rows_with_ingest_cursors(conn: &Connection) -> rusqlite::Result<()> {
     let candidates = {
@@ -350,94 +347,6 @@ pub(super) fn maybe_reconcile_library_id_backfill(conn: &Connection) -> rusqlite
     repair_library_id_from_raw_json(conn)?;
     mark_library_id_backfill_reconcile_completed(conn)?;
     Ok(())
-}
-
-fn track_timestamp_backfill_completed(conn: &Connection) -> rusqlite::Result<bool> {
-    let completed: Option<Option<i64>> = conn
-        .query_row(
-            "SELECT completed_at FROM library_data_migration WHERE id = ?1",
-            params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
-            |row| row.get(0),
-        )
-        .optional()?;
-    Ok(completed.flatten().is_some())
-}
-
-/// Restore timestamp columns from stored payloads in bounded transactions.
-/// The registered scalar function uses the same parser as live sync. Existing
-/// values are retained when no usable raw timestamp exists.
-pub(super) fn maybe_reconcile_track_timestamp_backfill(conn: &Connection) -> rusqlite::Result<()> {
-    if track_timestamp_backfill_completed(conn)? {
-        return Ok(());
-    }
-    conn.execute(
-        "INSERT INTO library_data_migration (id, cursor_rowid, started_at) \
-         VALUES (?1, 0, strftime('%s','now')) \
-         ON CONFLICT(id) DO UPDATE SET \
-           started_at = COALESCE(library_data_migration.started_at, excluded.started_at)",
-        params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
-    )?;
-
-    loop {
-        let cursor: i64 = conn.query_row(
-            "SELECT cursor_rowid FROM library_data_migration WHERE id = ?1",
-            params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
-            |row| row.get(0),
-        )?;
-        let last_rowid: Option<i64> = conn.query_row(
-            "SELECT MAX(rowid) FROM ( \
-               SELECT rowid FROM track \
-               WHERE rowid > ?1 AND json_valid(raw_json) \
-                 AND (psysonic_parse_iso_ms(json_extract(raw_json, '$.created')) IS NOT NULL \
-                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.createdAt')) IS NOT NULL \
-                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.updatedAt')) IS NOT NULL \
-                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.starred')) IS NOT NULL \
-                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.starredAt')) IS NOT NULL \
-                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.playDate')) IS NOT NULL \
-                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.played')) IS NOT NULL \
-                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.playedAt')) IS NOT NULL) \
-               ORDER BY rowid LIMIT ?2 \
-             )",
-            params![cursor, TRACK_TIMESTAMP_BACKFILL_BATCH_SIZE],
-            |row| row.get(0),
-        )?;
-        let Some(last_rowid) = last_rowid else {
-            conn.execute(
-                "UPDATE library_data_migration \
-                 SET completed_at = strftime('%s','now') WHERE id = ?1",
-                params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
-            )?;
-            return Ok(());
-        };
-
-        let tx = conn.unchecked_transaction()?;
-        tx.execute(
-            "UPDATE track SET \
-               server_created_at = COALESCE( \
-                 psysonic_parse_iso_ms(json_extract(raw_json, '$.created')), \
-                 psysonic_parse_iso_ms(json_extract(raw_json, '$.createdAt')), \
-                 server_created_at), \
-               server_updated_at = COALESCE( \
-                 psysonic_parse_iso_ms(json_extract(raw_json, '$.updatedAt')), \
-                 server_updated_at), \
-               starred_at = COALESCE( \
-                 psysonic_parse_iso_ms(json_extract(raw_json, '$.starred')), \
-                 psysonic_parse_iso_ms(json_extract(raw_json, '$.starredAt')), \
-                 starred_at), \
-               played_at = COALESCE( \
-                 psysonic_parse_iso_ms(json_extract(raw_json, '$.playDate')), \
-                 psysonic_parse_iso_ms(json_extract(raw_json, '$.played')), \
-                 psysonic_parse_iso_ms(json_extract(raw_json, '$.playedAt')), \
-                 played_at) \
-             WHERE rowid > ?1 AND rowid <= ?2 AND json_valid(raw_json)",
-            params![cursor, last_rowid],
-        )?;
-        tx.execute(
-            "UPDATE library_data_migration SET cursor_rowid = ?2 WHERE id = ?1",
-            params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID, last_rowid],
-        )?;
-        tx.commit()?;
-    }
 }
 
 fn duration_sec_backfill_completed(conn: &Connection) -> rusqlite::Result<bool> {

--- a/src-tauri/crates/psysonic-library/src/store/reconciles.rs
+++ b/src-tauri/crates/psysonic-library/src/store/reconciles.rs
@@ -20,6 +20,7 @@ pub(crate) const ORPHAN_BROWSE_RECONCILE_ID: &str = "orphan_browse_rows_reconcil
 pub(crate) const DURATION_SEC_BACKFILL_RECONCILE_ID: &str = "duration_sec_decimal_backfill_v1";
 const DURATION_SEC_BACKFILL_BATCH_SIZE: i64 = 1_000;
 
+#[cfg(test)]
 pub(super) use super::track_timestamp_reconcile::maybe_reconcile_track_timestamp_backfill;
 
 pub(super) fn reconcile_ready_rows_with_ingest_cursors(conn: &Connection) -> rusqlite::Result<()> {

--- a/src-tauri/crates/psysonic-library/src/store/reconciles.rs
+++ b/src-tauri/crates/psysonic-library/src/store/reconciles.rs
@@ -20,6 +20,11 @@ pub(crate) const ORPHAN_BROWSE_RECONCILE_ID: &str = "orphan_browse_rows_reconcil
 pub(crate) const DURATION_SEC_BACKFILL_RECONCILE_ID: &str = "duration_sec_decimal_backfill_v1";
 const DURATION_SEC_BACKFILL_BATCH_SIZE: i64 = 1_000;
 
+/// One-time repair of timestamp columns lost when negative UTC offsets failed
+/// to parse, or shifted when positive offsets were treated as UTC wall time.
+pub(crate) const TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID: &str = "track_timestamp_backfill_v1";
+const TRACK_TIMESTAMP_BACKFILL_BATCH_SIZE: i64 = 1_000;
+
 pub(super) fn reconcile_ready_rows_with_ingest_cursors(conn: &Connection) -> rusqlite::Result<()> {
     let candidates = {
         let mut stmt = conn.prepare(
@@ -345,6 +350,94 @@ pub(super) fn maybe_reconcile_library_id_backfill(conn: &Connection) -> rusqlite
     repair_library_id_from_raw_json(conn)?;
     mark_library_id_backfill_reconcile_completed(conn)?;
     Ok(())
+}
+
+fn track_timestamp_backfill_completed(conn: &Connection) -> rusqlite::Result<bool> {
+    let completed: Option<Option<i64>> = conn
+        .query_row(
+            "SELECT completed_at FROM library_data_migration WHERE id = ?1",
+            params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(completed.flatten().is_some())
+}
+
+/// Restore timestamp columns from stored payloads in bounded transactions.
+/// The registered scalar function uses the same parser as live sync. Existing
+/// values are retained when no usable raw timestamp exists.
+pub(super) fn maybe_reconcile_track_timestamp_backfill(conn: &Connection) -> rusqlite::Result<()> {
+    if track_timestamp_backfill_completed(conn)? {
+        return Ok(());
+    }
+    conn.execute(
+        "INSERT INTO library_data_migration (id, cursor_rowid, started_at) \
+         VALUES (?1, 0, strftime('%s','now')) \
+         ON CONFLICT(id) DO UPDATE SET \
+           started_at = COALESCE(library_data_migration.started_at, excluded.started_at)",
+        params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+    )?;
+
+    loop {
+        let cursor: i64 = conn.query_row(
+            "SELECT cursor_rowid FROM library_data_migration WHERE id = ?1",
+            params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+            |row| row.get(0),
+        )?;
+        let last_rowid: Option<i64> = conn.query_row(
+            "SELECT MAX(rowid) FROM ( \
+               SELECT rowid FROM track \
+               WHERE rowid > ?1 AND json_valid(raw_json) \
+                 AND (psysonic_parse_iso_ms(json_extract(raw_json, '$.created')) IS NOT NULL \
+                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.createdAt')) IS NOT NULL \
+                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.updatedAt')) IS NOT NULL \
+                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.starred')) IS NOT NULL \
+                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.starredAt')) IS NOT NULL \
+                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.playDate')) IS NOT NULL \
+                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.played')) IS NOT NULL \
+                   OR psysonic_parse_iso_ms(json_extract(raw_json, '$.playedAt')) IS NOT NULL) \
+               ORDER BY rowid LIMIT ?2 \
+             )",
+            params![cursor, TRACK_TIMESTAMP_BACKFILL_BATCH_SIZE],
+            |row| row.get(0),
+        )?;
+        let Some(last_rowid) = last_rowid else {
+            conn.execute(
+                "UPDATE library_data_migration \
+                 SET completed_at = strftime('%s','now') WHERE id = ?1",
+                params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+            )?;
+            return Ok(());
+        };
+
+        let tx = conn.unchecked_transaction()?;
+        tx.execute(
+            "UPDATE track SET \
+               server_created_at = COALESCE( \
+                 psysonic_parse_iso_ms(json_extract(raw_json, '$.created')), \
+                 psysonic_parse_iso_ms(json_extract(raw_json, '$.createdAt')), \
+                 server_created_at), \
+               server_updated_at = COALESCE( \
+                 psysonic_parse_iso_ms(json_extract(raw_json, '$.updatedAt')), \
+                 server_updated_at), \
+               starred_at = COALESCE( \
+                 psysonic_parse_iso_ms(json_extract(raw_json, '$.starred')), \
+                 psysonic_parse_iso_ms(json_extract(raw_json, '$.starredAt')), \
+                 starred_at), \
+               played_at = COALESCE( \
+                 psysonic_parse_iso_ms(json_extract(raw_json, '$.playDate')), \
+                 psysonic_parse_iso_ms(json_extract(raw_json, '$.played')), \
+                 psysonic_parse_iso_ms(json_extract(raw_json, '$.playedAt')), \
+                 played_at) \
+             WHERE rowid > ?1 AND rowid <= ?2 AND json_valid(raw_json)",
+            params![cursor, last_rowid],
+        )?;
+        tx.execute(
+            "UPDATE library_data_migration SET cursor_rowid = ?2 WHERE id = ?1",
+            params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID, last_rowid],
+        )?;
+        tx.commit()?;
+    }
 }
 
 fn duration_sec_backfill_completed(conn: &Connection) -> rusqlite::Result<bool> {

--- a/src-tauri/crates/psysonic-library/src/store/tests/reconciles.rs
+++ b/src-tauri/crates/psysonic-library/src/store/tests/reconciles.rs
@@ -3,9 +3,10 @@ use rusqlite::params;
 use super::super::reconciles::{
     maybe_reconcile_artist_name_fold, maybe_reconcile_artist_name_sort,
     maybe_reconcile_duration_sec_backfill, maybe_reconcile_library_id_backfill,
-    maybe_reconcile_orphan_browse_rows, ARTIST_NAME_FOLD_RECONCILE_ID,
-    ARTIST_NAME_SORT_RECONCILE_ID, DURATION_SEC_BACKFILL_RECONCILE_ID,
-    LIBRARY_ID_BACKFILL_RECONCILE_ID, ORPHAN_BROWSE_RECONCILE_ID,
+    maybe_reconcile_orphan_browse_rows, maybe_reconcile_track_timestamp_backfill,
+    ARTIST_NAME_FOLD_RECONCILE_ID, ARTIST_NAME_SORT_RECONCILE_ID,
+    DURATION_SEC_BACKFILL_RECONCILE_ID, LIBRARY_ID_BACKFILL_RECONCILE_ID,
+    ORPHAN_BROWSE_RECONCILE_ID, TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID,
 };
 use super::super::LibraryStore;
 
@@ -311,6 +312,105 @@ fn library_id_backfill_reconcile_is_idempotent() {
         })
         .expect("library_id after second reconcile");
     assert_eq!(library_id_after, "");
+}
+
+#[test]
+fn track_timestamp_backfill_restores_offset_dates_once() {
+    type TimestampRow = (String, Option<i64>, Option<i64>, Option<i64>, Option<i64>);
+
+    let store = LibraryStore::open_in_memory();
+    store
+        .with_conn_mut("test.seed_timestamp_backfill", |conn| {
+            conn.execute(
+                "DELETE FROM library_data_migration WHERE id = ?1",
+                params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+            )?;
+            conn.execute(
+                "INSERT INTO track (server_id, id, title, album, duration_sec, deleted, synced_at, \
+                   raw_json, server_created_at, server_updated_at, starred_at, played_at) \
+                 VALUES ('s1', 'repair', 'Repair', 'Al', 1, 0, 1, \
+                   '{\"createdAt\":\"2026-08-26T22:04:58.676898-07:00\",\
+                      \"updatedAt\":\"2026-08-26T22:04:58.676898-07:00\",\
+                      \"starred\":true,\
+                      \"starredAt\":\"2026-08-26T22:04:58.676898-07:00\",\
+                      \"playDate\":\"2026-08-26T22:04:58.676898-07:00\"}', \
+                   NULL, NULL, NULL, NULL)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO track (server_id, id, title, album, duration_sec, deleted, synced_at, \
+                   raw_json, server_created_at, server_updated_at, starred_at, played_at) \
+                 VALUES ('s1', 'invalid', 'Invalid', 'Al', 1, 0, 1, \
+                   '{\"createdAt\":\"not-a-date\"}', 42, 42, 42, 42)",
+                [],
+            )?;
+            Ok(())
+        })
+        .expect("seed tracks");
+
+    store
+        .with_conn(
+            "test.timestamp_backfill",
+            maybe_reconcile_track_timestamp_backfill,
+        )
+        .expect("timestamp backfill");
+
+    let timestamps: Vec<TimestampRow> = store
+        .with_read_conn(|conn| {
+            conn.prepare(
+                "SELECT id, server_created_at, server_updated_at, starred_at, played_at \
+                 FROM track WHERE server_id = 's1' ORDER BY id",
+            )?
+            .query_map([], |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            })?
+            .collect()
+        })
+        .expect("backfilled timestamps");
+    assert_eq!(
+        timestamps,
+        vec![
+            ("invalid".into(), Some(42), Some(42), Some(42), Some(42)),
+            (
+                "repair".into(),
+                Some(1_787_807_098_000),
+                Some(1_787_807_098_000),
+                Some(1_787_807_098_000),
+                Some(1_787_807_098_000),
+            ),
+        ]
+    );
+
+    store
+        .with_conn_mut("test.clear_repaired_timestamp", |conn| {
+            conn.execute(
+                "UPDATE track SET server_created_at = NULL WHERE id = 'repair'",
+                [],
+            )
+        })
+        .expect("clear repaired timestamp");
+    store
+        .with_conn(
+            "test.timestamp_backfill_again",
+            maybe_reconcile_track_timestamp_backfill,
+        )
+        .expect("guarded timestamp backfill");
+    let created_after: Option<i64> = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT server_created_at FROM track WHERE id = 'repair'",
+                [],
+                |row| row.get(0),
+            )
+        })
+        .expect("created timestamp after guarded re-run");
+    assert_eq!(created_after, None);
 }
 
 #[test]

--- a/src-tauri/crates/psysonic-library/src/store/tests/reconciles.rs
+++ b/src-tauri/crates/psysonic-library/src/store/tests/reconciles.rs
@@ -9,7 +9,7 @@ use super::super::reconciles::{
     ORPHAN_BROWSE_RECONCILE_ID,
 };
 use super::super::track_timestamp_reconcile::TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID;
-use super::super::LibraryStore;
+use super::super::{LibraryStore, TrackTimestampBackfillStep};
 
 #[test]
 fn migration_022_backfills_unicode_artist_name_fold() {
@@ -459,6 +459,91 @@ fn track_timestamp_backfill_restores_offset_dates_once() {
         })
         .expect("created timestamp after guarded re-run");
     assert_eq!(created_after, None);
+}
+
+#[test]
+fn track_timestamp_backfill_is_not_part_of_database_open() {
+    let store = LibraryStore::open_in_memory();
+    let marker_count: i64 = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT COUNT(*) FROM library_data_migration WHERE id = ?1",
+                params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+                |row| row.get(0),
+            )
+        })
+        .expect("timestamp marker count");
+    assert_eq!(marker_count, 0);
+}
+
+#[test]
+fn track_timestamp_backfill_processes_one_resumable_batch() {
+    let store = LibraryStore::open_in_memory();
+    store.set_bulk_ingest_active(true);
+    assert_eq!(
+        store.run_track_timestamp_backfill_batch().unwrap(),
+        TrackTimestampBackfillStep::Deferred
+    );
+    store.set_bulk_ingest_active(false);
+
+    store
+        .with_conn_mut("test.seed_timestamp_batches", |conn| {
+            let tx = conn.transaction()?;
+            for index in 0..1_001 {
+                tx.execute(
+                    "INSERT INTO track (server_id, id, title, album, duration_sec, deleted, synced_at, raw_json) \
+                     VALUES ('s1', ?1, 'Track', 'Album', 1, 0, 1, '{}')",
+                    [format!("track-{index}")],
+                )?;
+            }
+            tx.commit()
+        })
+        .expect("seed timestamp batches");
+
+    assert_eq!(
+        store.run_track_timestamp_backfill_batch().unwrap(),
+        TrackTimestampBackfillStep::Pending
+    );
+    let first_cursor: (i64, Option<i64>) = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT cursor_rowid, completed_at FROM library_data_migration WHERE id = ?1",
+                params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+        })
+        .expect("first timestamp cursor");
+    assert_eq!(first_cursor, (1_000, None));
+
+    assert_eq!(
+        store.run_track_timestamp_backfill_batch().unwrap(),
+        TrackTimestampBackfillStep::Pending
+    );
+    let second_cursor: (i64, Option<i64>) = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT cursor_rowid, completed_at FROM library_data_migration WHERE id = ?1",
+                params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+        })
+        .expect("second timestamp cursor");
+    assert_eq!(second_cursor, (1_001, None));
+
+    assert_eq!(
+        store.run_track_timestamp_backfill_batch().unwrap(),
+        TrackTimestampBackfillStep::Complete
+    );
+    let completed_at: Option<i64> = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT completed_at FROM library_data_migration WHERE id = ?1",
+                params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+                |row| row.get(0),
+            )
+        })
+        .expect("completed timestamp marker");
+    assert!(completed_at.is_some());
 }
 
 #[test]

--- a/src-tauri/crates/psysonic-library/src/store/tests/reconciles.rs
+++ b/src-tauri/crates/psysonic-library/src/store/tests/reconciles.rs
@@ -6,8 +6,9 @@ use super::super::reconciles::{
     maybe_reconcile_orphan_browse_rows, maybe_reconcile_track_timestamp_backfill,
     ARTIST_NAME_FOLD_RECONCILE_ID, ARTIST_NAME_SORT_RECONCILE_ID,
     DURATION_SEC_BACKFILL_RECONCILE_ID, LIBRARY_ID_BACKFILL_RECONCILE_ID,
-    ORPHAN_BROWSE_RECONCILE_ID, TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID,
+    ORPHAN_BROWSE_RECONCILE_ID,
 };
+use super::super::track_timestamp_reconcile::TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID;
 use super::super::LibraryStore;
 
 #[test]
@@ -329,20 +330,52 @@ fn track_timestamp_backfill_restores_offset_dates_once() {
                 "INSERT INTO track (server_id, id, title, album, duration_sec, deleted, synced_at, \
                    raw_json, server_created_at, server_updated_at, starred_at, played_at) \
                  VALUES ('s1', 'repair', 'Repair', 'Al', 1, 0, 1, \
-                   '{\"createdAt\":\"2026-08-26T22:04:58.676898-07:00\",\
-                      \"updatedAt\":\"2026-08-26T22:04:58.676898-07:00\",\
-                      \"starred\":true,\
-                      \"starredAt\":\"2026-08-26T22:04:58.676898-07:00\",\
-                      \"playDate\":\"2026-08-26T22:04:58.676898-07:00\"}', \
-                   NULL, NULL, NULL, NULL)",
+                    '{\"createdAt\":\"2026-08-26T22:04:58.676898-07:00\",\
+                       \"updatedAt\":\"2024-01-01T00:00:00+02:00\",\
+                       \"starred\":true,\
+                       \"starredAt\":\"2026-08-26T22:04:58.676898-07:00\",\
+                       \"playDate\":\"2026-08-26T22:04:58.676898-07:00\"}', \
+                    NULL, NULL, 777, 888)",
                 [],
             )?;
             conn.execute(
                 "INSERT INTO track (server_id, id, title, album, duration_sec, deleted, synced_at, \
                    raw_json, server_created_at, server_updated_at, starred_at, played_at) \
                  VALUES ('s1', 'invalid', 'Invalid', 'Al', 1, 0, 1, \
-                   '{\"createdAt\":\"not-a-date\"}', 42, 42, 42, 42)",
+                    '{\"createdAt\":\"not-a-date\"}', 42, 42, 42, 42)",
                 [],
+            )?;
+            conn.execute(
+                "INSERT INTO track (server_id, id, title, album, duration_sec, deleted, synced_at, \
+                   raw_json, server_created_at, server_updated_at) \
+                 VALUES ('s1', 'positive', 'Positive', 'Al', 1, 0, 1, \
+                   '{\"createdAt\":\"2024-01-01T00:00:00+02:00\"}', \
+                   1704067200000, NULL)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO track (server_id, id, title, album, duration_sec, deleted, synced_at, \
+                   raw_json, server_created_at, server_updated_at) \
+                 VALUES ('s1', 'authoritative', 'Authoritative', 'Al', 1, 0, 1, \
+                   '{\"createdAt\":\"2026-08-26T22:04:58.676898-07:00\",\
+                      \"updatedAt\":\"2024-01-01T00:00:00+02:00\"}', 100, 200)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO track (server_id, id, title, album, duration_sec, deleted, synced_at, \
+                   raw_json, server_created_at, server_updated_at) \
+                 VALUES ('s1', 'stale-alias', 'Stale alias', 'Al', 1, 0, 1, \
+                   '{\"createdAt\":null,\"created\":\"2026-08-26T22:04:58.676898-07:00\"}', \
+                   NULL, NULL)",
+                [],
+            )?;
+            conn.execute_batch(
+                "CREATE TABLE timestamp_update_audit (track_id TEXT NOT NULL); \
+                 CREATE TRIGGER audit_timestamp_update \
+                 AFTER UPDATE OF server_created_at, server_updated_at ON track \
+                 BEGIN \
+                   INSERT INTO timestamp_update_audit (track_id) VALUES (NEW.id); \
+                 END;",
             )?;
             Ok(())
         })
@@ -376,15 +409,30 @@ fn track_timestamp_backfill_restores_offset_dates_once() {
     assert_eq!(
         timestamps,
         vec![
+            ("authoritative".into(), Some(100), Some(200), None, None),
             ("invalid".into(), Some(42), Some(42), Some(42), Some(42)),
+            ("positive".into(), Some(1_704_060_000_000), None, None, None),
             (
                 "repair".into(),
                 Some(1_787_807_098_000),
-                Some(1_787_807_098_000),
-                Some(1_787_807_098_000),
-                Some(1_787_807_098_000),
+                Some(1_704_060_000_000),
+                Some(777),
+                Some(888),
             ),
+            ("stale-alias".into(), None, None, None, None),
         ]
+    );
+    let updated_ids: Vec<String> = store
+        .with_read_conn(|conn| {
+            conn.prepare("SELECT track_id FROM timestamp_update_audit ORDER BY track_id")?
+                .query_map([], |row| row.get(0))?
+                .collect()
+        })
+        .expect("timestamp update audit");
+    assert_eq!(
+        updated_ids,
+        vec!["positive".to_string(), "repair".to_string()],
+        "the reconcile must not rewrite unaffected or authoritative rows"
     );
 
     store

--- a/src-tauri/crates/psysonic-library/src/store/tests/reconciles.rs
+++ b/src-tauri/crates/psysonic-library/src/store/tests/reconciles.rs
@@ -1,5 +1,7 @@
 use rusqlite::params;
+use serde_json::json;
 
+use crate::repos::TrackRepository;
 use super::super::reconciles::{
     maybe_reconcile_artist_name_fold, maybe_reconcile_artist_name_sort,
     maybe_reconcile_duration_sec_backfill, maybe_reconcile_library_id_backfill,
@@ -349,7 +351,7 @@ fn track_timestamp_backfill_restores_offset_dates_once() {
                 "INSERT INTO track (server_id, id, title, album, duration_sec, deleted, synced_at, \
                    raw_json, server_created_at, server_updated_at) \
                  VALUES ('s1', 'positive', 'Positive', 'Al', 1, 0, 1, \
-                   '{\"createdAt\":\"2024-01-01T00:00:00+02:00\"}', \
+                   '{\"created\":\"2024-01-01T00:00:00+02:00\"}', \
                    1704067200000, NULL)",
                 [],
             )?;
@@ -474,6 +476,68 @@ fn track_timestamp_backfill_is_not_part_of_database_open() {
         })
         .expect("timestamp marker count");
     assert_eq!(marker_count, 0);
+}
+
+#[test]
+fn sparse_created_clear_is_not_repaired_from_a_retained_legacy_alias() {
+    let store = LibraryStore::open_in_memory();
+    store
+        .with_conn_mut("test.seed_sparse_created_clear", |conn| {
+            conn.execute(
+                "DELETE FROM library_data_migration WHERE id = ?1",
+                params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+            )?;
+            conn.execute(
+                "INSERT INTO track (server_id, id, title, album, duration_sec, deleted, synced_at, \
+                   raw_json, server_created_at) \
+                 VALUES ('s1', 't1', 'Track', 'Album', 1, 0, 1, \
+                   '{\"id\":\"t1\",\"created\":\"2026-08-26T22:04:58.676898-07:00\"}', NULL)",
+                [],
+            )?;
+            Ok(())
+        })
+        .expect("seed sparse created clear");
+
+    let incoming = crate::sync::mapping::navidrome_song_to_track_row(
+        "s1",
+        &json!({ "id": "t1", "title": "Track", "createdAt": null }),
+        2,
+        None,
+    )
+    .unwrap();
+    TrackRepository::new(&store)
+        .upsert_sparse_batch_with_remap(&[incoming], false)
+        .expect("sparse timestamp clear");
+
+    let stored_raw: serde_json::Value = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT raw_json FROM track WHERE server_id = 's1' AND id = 't1'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+        })
+        .map(|raw| serde_json::from_str(&raw).unwrap())
+        .expect("stored sparse JSON");
+    assert!(stored_raw.get("createdAt").is_none());
+    assert!(stored_raw.get("created").is_some());
+
+    store
+        .with_conn(
+            "test.timestamp_backfill_after_sparse_clear",
+            maybe_reconcile_track_timestamp_backfill,
+        )
+        .expect("timestamp backfill after sparse clear");
+    let created_at: Option<i64> = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT server_created_at FROM track WHERE server_id = 's1' AND id = 't1'",
+                [],
+                |row| row.get(0),
+            )
+        })
+        .expect("created timestamp after sparse clear");
+    assert_eq!(created_at, None);
 }
 
 #[test]

--- a/src-tauri/crates/psysonic-library/src/store/track_timestamp_reconcile.rs
+++ b/src-tauri/crates/psysonic-library/src/store/track_timestamp_reconcile.rs
@@ -1,0 +1,140 @@
+use rusqlite::{params, Connection, OptionalExtension};
+
+/// One-time repair of server timestamp columns lost when negative UTC offsets
+/// failed to parse, or shifted when positive offsets were treated as UTC wall time.
+pub(crate) const TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID: &str = "track_timestamp_backfill_v1";
+const TRACK_TIMESTAMP_BACKFILL_BATCH_SIZE: i64 = 1_000;
+
+fn track_timestamp_backfill_completed(conn: &Connection) -> rusqlite::Result<bool> {
+    let completed: Option<Option<i64>> = conn
+        .query_row(
+            "SELECT completed_at FROM library_data_migration WHERE id = ?1",
+            params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(completed.flatten().is_some())
+}
+
+fn timestamp_field<'a>(raw: &'a serde_json::Value, keys: &[&str]) -> Option<&'a str> {
+    for key in keys {
+        if let Some(value) = raw.get(*key) {
+            return value.as_str();
+        }
+    }
+    None
+}
+
+/// Reproduce the old parser result only far enough to identify rows that the
+/// offset fix must repair. Negative offsets failed entirely; positive offsets
+/// were stored as UTC wall time without applying the offset.
+fn parse_iso_ms_before_offset_fix(timestamp: &str) -> Option<i64> {
+    let trimmed = timestamp.trim();
+    let Some(time_index) = trimmed.find('T') else {
+        return crate::sync::mapping::parse_iso_ms_str(trimmed);
+    };
+    let timezone_index = trimmed[time_index + 1..]
+        .find(['Z', '+', '-'])
+        .map(|offset| time_index + 1 + offset);
+    match timezone_index.and_then(|index| trimmed.as_bytes().get(index).copied()) {
+        Some(b'-') => None,
+        Some(b'+') => {
+            let index = timezone_index?;
+            let wall_time = format!("{}Z", &trimmed[..index]);
+            crate::sync::mapping::parse_iso_ms_str(&wall_time)
+        }
+        _ => crate::sync::mapping::parse_iso_ms_str(trimmed),
+    }
+}
+
+fn repaired_offset_timestamp(current: Option<i64>, timestamp: Option<&str>) -> Option<i64> {
+    let timestamp = timestamp?;
+    let corrected = crate::sync::mapping::parse_iso_ms_str(timestamp)?;
+    let previous = parse_iso_ms_before_offset_fix(timestamp);
+    if previous == Some(corrected) || current.is_some_and(|value| Some(value) != previous) {
+        return None;
+    }
+    Some(corrected)
+}
+
+/// Restore only server timestamps demonstrably affected by the old offset
+/// parser. Physical-row batches bound each transaction, while authoritative
+/// favourite/play hot columns and values changed after ingest remain untouched.
+pub(super) fn maybe_reconcile_track_timestamp_backfill(conn: &Connection) -> rusqlite::Result<()> {
+    if track_timestamp_backfill_completed(conn)? {
+        return Ok(());
+    }
+    conn.execute(
+        "INSERT INTO library_data_migration (id, cursor_rowid, started_at) \
+         VALUES (?1, 0, strftime('%s','now')) \
+         ON CONFLICT(id) DO UPDATE SET \
+           started_at = COALESCE(library_data_migration.started_at, excluded.started_at)",
+        params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+    )?;
+
+    loop {
+        let cursor: i64 = conn.query_row(
+            "SELECT cursor_rowid FROM library_data_migration WHERE id = ?1",
+            params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+            |row| row.get(0),
+        )?;
+        let rows = {
+            let mut stmt = conn.prepare(
+                "SELECT rowid, raw_json, server_created_at, server_updated_at \
+                 FROM track WHERE rowid > ?1 ORDER BY rowid LIMIT ?2",
+            )?;
+            let rows = stmt
+                .query_map(
+                    params![cursor, TRACK_TIMESTAMP_BACKFILL_BATCH_SIZE],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, Option<i64>>(2)?,
+                            row.get::<_, Option<i64>>(3)?,
+                        ))
+                    },
+                )?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            rows
+        };
+        let Some(last_rowid) = rows.last().map(|row| row.0) else {
+            conn.execute(
+                "UPDATE library_data_migration \
+                 SET completed_at = strftime('%s','now') WHERE id = ?1",
+                params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+            )?;
+            return Ok(());
+        };
+
+        let tx = conn.unchecked_transaction()?;
+        for (rowid, raw_json, server_created_at, server_updated_at) in rows {
+            let Ok(raw) = serde_json::from_str::<serde_json::Value>(&raw_json) else {
+                continue;
+            };
+            // `createdAt` is the current Navidrome field. If it is present but
+            // empty/null, do not fall back to an older `created` alias retained
+            // by a prior sparse JSON merge.
+            let repaired_created = repaired_offset_timestamp(
+                server_created_at,
+                timestamp_field(&raw, &["createdAt", "created"]),
+            );
+            let repaired_updated =
+                repaired_offset_timestamp(server_updated_at, timestamp_field(&raw, &["updatedAt"]));
+            if repaired_created.is_some() || repaired_updated.is_some() {
+                tx.execute(
+                    "UPDATE track SET \
+                       server_created_at = COALESCE(?2, server_created_at), \
+                       server_updated_at = COALESCE(?3, server_updated_at) \
+                     WHERE rowid = ?1",
+                    params![rowid, repaired_created, repaired_updated],
+                )?;
+            }
+        }
+        tx.execute(
+            "UPDATE library_data_migration SET cursor_rowid = ?2 WHERE id = ?1",
+            params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID, last_rowid],
+        )?;
+        tx.commit()?;
+    }
+}

--- a/src-tauri/crates/psysonic-library/src/store/track_timestamp_reconcile.rs
+++ b/src-tauri/crates/psysonic-library/src/store/track_timestamp_reconcile.rs
@@ -66,6 +66,27 @@ fn repaired_offset_timestamp(current: Option<i64>, timestamp: Option<&str>) -> O
     Some(corrected)
 }
 
+fn repaired_created_timestamp(
+    current: Option<i64>,
+    raw: &serde_json::Value,
+) -> Option<i64> {
+    if let Some(created_at) = raw.get("createdAt") {
+        return repaired_offset_timestamp(current, created_at.as_str());
+    }
+
+    // A sparse `createdAt: null` patch removes that key from stored JSON and
+    // may leave an older `created` alias behind. With a NULL hot column those
+    // shapes are indistinguishable from a pre-fix parse failure, so only use
+    // the legacy alias when the old positive-offset parser value proves it is
+    // the source of the currently stored value.
+    current.and_then(|current| {
+        repaired_offset_timestamp(
+            Some(current),
+            raw.get("created").and_then(|value| value.as_str()),
+        )
+    })
+}
+
 fn reconcile_track_timestamp_backfill_batch(
     conn: &Connection,
 ) -> rusqlite::Result<TrackTimestampBackfillStep> {
@@ -119,13 +140,7 @@ fn reconcile_track_timestamp_backfill_batch(
         let Ok(raw) = serde_json::from_str::<serde_json::Value>(&raw_json) else {
             continue;
         };
-        // `createdAt` is the current Navidrome field. If it is present but
-        // empty/null, do not fall back to an older `created` alias retained
-        // by a prior sparse JSON merge.
-        let repaired_created = repaired_offset_timestamp(
-            server_created_at,
-            timestamp_field(&raw, &["createdAt", "created"]),
-        );
+        let repaired_created = repaired_created_timestamp(server_created_at, &raw);
         let repaired_updated =
             repaired_offset_timestamp(server_updated_at, timestamp_field(&raw, &["updatedAt"]));
         if repaired_created.is_some() || repaired_updated.is_some() {

--- a/src-tauri/crates/psysonic-library/src/store/track_timestamp_reconcile.rs
+++ b/src-tauri/crates/psysonic-library/src/store/track_timestamp_reconcile.rs
@@ -1,9 +1,18 @@
 use rusqlite::{params, Connection, OptionalExtension};
 
+use super::LibraryStore;
+
 /// One-time repair of server timestamp columns lost when negative UTC offsets
 /// failed to parse, or shifted when positive offsets were treated as UTC wall time.
 pub(crate) const TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID: &str = "track_timestamp_backfill_v1";
 const TRACK_TIMESTAMP_BACKFILL_BATCH_SIZE: i64 = 1_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrackTimestampBackfillStep {
+    Deferred,
+    Pending,
+    Complete,
+}
 
 fn track_timestamp_backfill_completed(conn: &Connection) -> rusqlite::Result<bool> {
     let completed: Option<Option<i64>> = conn
@@ -57,12 +66,11 @@ fn repaired_offset_timestamp(current: Option<i64>, timestamp: Option<&str>) -> O
     Some(corrected)
 }
 
-/// Restore only server timestamps demonstrably affected by the old offset
-/// parser. Physical-row batches bound each transaction, while authoritative
-/// favourite/play hot columns and values changed after ingest remain untouched.
-pub(super) fn maybe_reconcile_track_timestamp_backfill(conn: &Connection) -> rusqlite::Result<()> {
+fn reconcile_track_timestamp_backfill_batch(
+    conn: &Connection,
+) -> rusqlite::Result<TrackTimestampBackfillStep> {
     if track_timestamp_backfill_completed(conn)? {
-        return Ok(());
+        return Ok(TrackTimestampBackfillStep::Complete);
     }
     conn.execute(
         "INSERT INTO library_data_migration (id, cursor_rowid, started_at) \
@@ -72,69 +80,96 @@ pub(super) fn maybe_reconcile_track_timestamp_backfill(conn: &Connection) -> rus
         params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
     )?;
 
-    loop {
-        let cursor: i64 = conn.query_row(
-            "SELECT cursor_rowid FROM library_data_migration WHERE id = ?1",
+    let cursor: i64 = conn.query_row(
+        "SELECT cursor_rowid FROM library_data_migration WHERE id = ?1",
+        params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
+        |row| row.get(0),
+    )?;
+    let rows = {
+        let mut stmt = conn.prepare(
+            "SELECT rowid, raw_json, server_created_at, server_updated_at \
+             FROM track WHERE rowid > ?1 ORDER BY rowid LIMIT ?2",
+        )?;
+        let rows = stmt
+            .query_map(
+                params![cursor, TRACK_TIMESTAMP_BACKFILL_BATCH_SIZE],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Option<i64>>(2)?,
+                        row.get::<_, Option<i64>>(3)?,
+                    ))
+                },
+            )?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows
+    };
+    let Some(last_rowid) = rows.last().map(|row| row.0) else {
+        conn.execute(
+            "UPDATE library_data_migration \
+             SET completed_at = strftime('%s','now') WHERE id = ?1",
             params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
-            |row| row.get(0),
         )?;
-        let rows = {
-            let mut stmt = conn.prepare(
-                "SELECT rowid, raw_json, server_created_at, server_updated_at \
-                 FROM track WHERE rowid > ?1 ORDER BY rowid LIMIT ?2",
-            )?;
-            let rows = stmt
-                .query_map(
-                    params![cursor, TRACK_TIMESTAMP_BACKFILL_BATCH_SIZE],
-                    |row| {
-                        Ok((
-                            row.get::<_, i64>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, Option<i64>>(2)?,
-                            row.get::<_, Option<i64>>(3)?,
-                        ))
-                    },
-                )?
-                .collect::<rusqlite::Result<Vec<_>>>()?;
-            rows
-        };
-        let Some(last_rowid) = rows.last().map(|row| row.0) else {
-            conn.execute(
-                "UPDATE library_data_migration \
-                 SET completed_at = strftime('%s','now') WHERE id = ?1",
-                params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID],
-            )?;
-            return Ok(());
-        };
+        return Ok(TrackTimestampBackfillStep::Complete);
+    };
 
-        let tx = conn.unchecked_transaction()?;
-        for (rowid, raw_json, server_created_at, server_updated_at) in rows {
-            let Ok(raw) = serde_json::from_str::<serde_json::Value>(&raw_json) else {
-                continue;
-            };
-            // `createdAt` is the current Navidrome field. If it is present but
-            // empty/null, do not fall back to an older `created` alias retained
-            // by a prior sparse JSON merge.
-            let repaired_created = repaired_offset_timestamp(
-                server_created_at,
-                timestamp_field(&raw, &["createdAt", "created"]),
-            );
-            let repaired_updated =
-                repaired_offset_timestamp(server_updated_at, timestamp_field(&raw, &["updatedAt"]));
-            if repaired_created.is_some() || repaired_updated.is_some() {
-                tx.execute(
-                    "UPDATE track SET \
-                       server_created_at = COALESCE(?2, server_created_at), \
-                       server_updated_at = COALESCE(?3, server_updated_at) \
-                     WHERE rowid = ?1",
-                    params![rowid, repaired_created, repaired_updated],
-                )?;
-            }
+    let tx = conn.unchecked_transaction()?;
+    for (rowid, raw_json, server_created_at, server_updated_at) in rows {
+        let Ok(raw) = serde_json::from_str::<serde_json::Value>(&raw_json) else {
+            continue;
+        };
+        // `createdAt` is the current Navidrome field. If it is present but
+        // empty/null, do not fall back to an older `created` alias retained
+        // by a prior sparse JSON merge.
+        let repaired_created = repaired_offset_timestamp(
+            server_created_at,
+            timestamp_field(&raw, &["createdAt", "created"]),
+        );
+        let repaired_updated =
+            repaired_offset_timestamp(server_updated_at, timestamp_field(&raw, &["updatedAt"]));
+        if repaired_created.is_some() || repaired_updated.is_some() {
+            tx.execute(
+                "UPDATE track SET \
+                   server_created_at = COALESCE(?2, server_created_at), \
+                   server_updated_at = COALESCE(?3, server_updated_at) \
+                 WHERE rowid = ?1",
+                params![rowid, repaired_created, repaired_updated],
+            )?;
         }
-        tx.execute(
-            "UPDATE library_data_migration SET cursor_rowid = ?2 WHERE id = ?1",
-            params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID, last_rowid],
-        )?;
-        tx.commit()?;
+    }
+    tx.execute(
+        "UPDATE library_data_migration SET cursor_rowid = ?2 WHERE id = ?1",
+        params![TRACK_TIMESTAMP_BACKFILL_RECONCILE_ID, last_rowid],
+    )?;
+    tx.commit()?;
+    Ok(TrackTimestampBackfillStep::Pending)
+}
+
+impl LibraryStore {
+    /// Restore one physical-row batch of server timestamps affected by the old
+    /// offset parser. The background scheduler calls this only while idle.
+    pub fn run_track_timestamp_backfill_batch(
+        &self,
+    ) -> Result<TrackTimestampBackfillStep, String> {
+        if self.bulk_ingest_active() {
+            return Ok(TrackTimestampBackfillStep::Deferred);
+        }
+        self.with_conn("track_timestamp_reconcile.batch", |conn| {
+            if self.bulk_ingest_active() {
+                return Ok(TrackTimestampBackfillStep::Deferred);
+            }
+            reconcile_track_timestamp_backfill_batch(conn)
+        })
+    }
+}
+
+/// Test helper that drains every batch without scheduler delays.
+#[cfg(test)]
+pub(super) fn maybe_reconcile_track_timestamp_backfill(conn: &Connection) -> rusqlite::Result<()> {
+    loop {
+        if reconcile_track_timestamp_backfill_batch(conn)? == TrackTimestampBackfillStep::Complete {
+            return Ok(());
+        }
     }
 }

--- a/src-tauri/crates/psysonic-library/src/sync/mapping.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping.rs
@@ -189,15 +189,8 @@ pub fn subsonic_song_to_track_row(
             .and_then(|rg| rg.get("trackPeak"))
             .and_then(|v| v.as_f64()),
         content_hash: None,
-        server_updated_at: raw_value
-            .get("updatedAt")
-            .and_then(Value::as_str)
-            .and_then(parse_iso_ms_str),
-        server_created_at: raw_value
-            .get("created")
-            .or_else(|| raw_value.get("createdAt"))
-            .and_then(|v| v.as_str())
-            .and_then(parse_iso_ms_str),
+        server_updated_at: parse_raw_iso_ms(raw_value, &["updatedAt"]),
+        server_created_at: parse_raw_iso_ms(raw_value, &["created", "createdAt"]),
         deleted: false,
         synced_at,
         raw_json: raw_value.to_string(),
@@ -277,10 +270,7 @@ pub fn navidrome_song_to_track_row(
         .and_then(|v| v.as_str())
         .unwrap_or_default()
         .to_string();
-    let server_updated_at = raw
-        .get("updatedAt")
-        .and_then(|v| v.as_str())
-        .and_then(parse_iso_ms_str);
+    let server_updated_at = parse_raw_iso_ms(raw, &["updatedAt"]);
     let library_id = json_string_field(raw, "libraryId")
         .or_else(|| json_string_field(raw, "library_id"))
         .or_else(|| json_string_field(raw, "musicFolderId"))
@@ -306,10 +296,7 @@ pub fn navidrome_song_to_track_row(
         bit_rate: raw.get("bitRate").and_then(|v| v.as_i64()),
         size_bytes: raw.get("size").and_then(|v| v.as_i64()),
         cover_art_id: string_field(raw, "coverArtId").or_else(|| string_field(raw, "coverArt")),
-        starred_at: raw
-            .get("starredAt")
-            .and_then(|v| v.as_str())
-            .and_then(parse_iso_ms_str),
+        starred_at: parse_raw_iso_ms(raw, &["starredAt"]),
         user_rating: raw.get("rating").and_then(|v| v.as_i64()),
         play_count: raw.get("playCount").and_then(|v| v.as_i64()),
         // Navidrome's own API calls this `playDate`; `playedAt` was never one of
@@ -326,13 +313,7 @@ pub fn navidrome_song_to_track_row(
         // key that merely holds a string would settle on an empty `playDate` —
         // which Navidrome has been seen to send for never-played rows — and
         // never look at a usable `played` beside it.
-        played_at: ["playDate", "played", "playedAt"]
-            .iter()
-            .find_map(|key| {
-                raw.get(*key)
-                    .and_then(|v| v.as_str())
-                    .and_then(parse_iso_ms_str)
-            }),
+        played_at: parse_raw_iso_ms(raw, &["playDate", "played", "playedAt"]),
         server_path: string_field(raw, "path"),
         library_id,
         isrc: string_field(raw, "isrc"),
@@ -344,10 +325,7 @@ pub fn navidrome_song_to_track_row(
         replay_gain_peak: raw.get("rgTrackPeak").and_then(|v| v.as_f64()),
         content_hash: None,
         server_updated_at,
-        server_created_at: raw
-            .get("createdAt")
-            .and_then(|v| v.as_str())
-            .and_then(parse_iso_ms_str),
+        server_created_at: parse_raw_iso_ms(raw, &["createdAt"]),
         deleted: false,
         synced_at,
         raw_json: raw.to_string(),
@@ -383,31 +361,42 @@ fn parse_iso_ms(s: Option<&str>) -> Option<i64> {
     s.and_then(parse_iso_ms_str)
 }
 
+fn parse_raw_iso_ms(raw: &Value, keys: &[&str]) -> Option<i64> {
+    keys.iter().find_map(|key| {
+        raw.get(*key)
+            .and_then(Value::as_str)
+            .and_then(parse_iso_ms_str)
+    })
+}
+
 /// Lightweight ISO-8601 → epoch-ms parser. Supports the Navidrome /
 /// OpenSubsonic shape (`2024-06-01T12:00:00Z` or
 /// `2024-06-01T12:00:00.123+02:00`). Falls back to `None` on parse
 /// failure — sync code never panics on a bad timestamp.
 pub(crate) fn parse_iso_ms_str(s: &str) -> Option<i64> {
-    // Strip fractional + timezone before doing the manual parse —
-    // SQLite stores starred_at / played_at as integer ms, so we only
-    // need second precision rounded up from the offset.
+    // Strip fractional seconds before doing the manual parse. The schema keeps
+    // millisecond integers, but sync ordering only requires second precision.
     let trimmed = s.trim();
     if trimmed.is_empty() {
         return None;
     }
-    // Accept either `Z`, `+HH:MM`, or no suffix. Reduce to a flat
-    // `YYYY-MM-DDTHH:MM:SS` core for parsing — server-side timestamps
-    // are already in UTC for Navidrome, and we don't track timezone
-    // in the schema column.
-    let core = trimmed
-        .find(|c: char| {
-            c == '.'
-                || c == 'Z'
-                || c == '+'
-                || (c == '-' && trimmed.find('T').is_some_and(|t| trimmed[t..].contains(c)))
-        })
-        .map(|i| &trimmed[..i])
-        .unwrap_or(trimmed);
+    // Search for a timezone sign only after `T`. Searching the whole string
+    // mistakes the first date separator in `2026-08-26...-07:00` for the offset.
+    let timezone_index = trimmed.find('T').and_then(|time_index| {
+        trimmed[time_index + 1..]
+            .find(['Z', '+', '-'])
+            .map(|offset| time_index + 1 + offset)
+    });
+    let core_end = [trimmed.find('.'), timezone_index]
+        .into_iter()
+        .flatten()
+        .min()
+        .unwrap_or(trimmed.len());
+    let core = &trimmed[..core_end];
+    let timezone_offset_seconds = match timezone_index {
+        Some(index) => parse_timezone_offset_seconds(&trimmed[index..])?,
+        None => 0,
+    };
     let mut parts = core.split(['T', '-', ':']);
     let year: i64 = parts.next()?.parse().ok()?;
     let month: i64 = parts.next()?.parse().ok()?;
@@ -432,8 +421,29 @@ pub(crate) fn parse_iso_ms_str(s: &str) -> Option<i64> {
     let doy = (153 * m + 2) / 5 + day - 1;
     let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
     let days = era * 146_097 + doe - 719_468;
-    let seconds = days * 86_400 + hour * 3600 + minute * 60 + second;
+    let seconds = days * 86_400 + hour * 3600 + minute * 60 + second - timezone_offset_seconds;
     Some(seconds.saturating_mul(1000))
+}
+
+fn parse_timezone_offset_seconds(suffix: &str) -> Option<i64> {
+    if suffix == "Z" {
+        return Some(0);
+    }
+    let (sign, offset) = match suffix.as_bytes().first()? {
+        b'+' => (1, &suffix[1..]),
+        b'-' => (-1, &suffix[1..]),
+        _ => return None,
+    };
+    let (hours, minutes) = offset.split_once(':')?;
+    if hours.len() != 2 || minutes.len() != 2 {
+        return None;
+    }
+    let hours: i64 = hours.parse().ok()?;
+    let minutes: i64 = minutes.parse().ok()?;
+    if hours > 23 || minutes > 59 {
+        return None;
+    }
+    Some(sign * (hours * 3_600 + minutes * 60))
 }
 
 /// UTC ISO-8601 with `Z` suffix for Subsonic `starred` payloads.

--- a/src-tauri/crates/psysonic-library/src/sync/mapping/tests/rows.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping/tests/rows.rs
@@ -63,6 +63,25 @@ fn navidrome_song_maps_native_field_shape() {
 }
 
 #[test]
+fn navidrome_song_maps_negative_offset_timestamps() {
+    let raw = json!({
+        "id": "tr_1",
+        "title": "Hello",
+        "createdAt": "2026-08-26T22:04:58.676898-07:00",
+        "updatedAt": "2026-08-26T22:04:58.676898-07:00",
+        "starredAt": "2026-08-26T22:04:58.676898-07:00",
+        "playDate": "2026-08-26T22:04:58.676898-07:00"
+    });
+
+    let row = navidrome_song_to_track_row("s1", &raw, 1, None).unwrap();
+
+    assert_eq!(row.server_created_at, Some(1_787_807_098_000));
+    assert_eq!(row.server_updated_at, Some(1_787_807_098_000));
+    assert_eq!(row.starred_at, Some(1_787_807_098_000));
+    assert_eq!(row.played_at, Some(1_787_807_098_000));
+}
+
+#[test]
 fn navidrome_song_normalizes_current_participants_into_structured_artist_refs() {
     let raw = json!({
         "id": "tr_1",

--- a/src-tauri/crates/psysonic-library/src/sync/mapping/tests/timestamps.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping/tests/timestamps.rs
@@ -15,7 +15,13 @@ fn parse_iso_handles_zulu_suffix() {
 #[test]
 fn parse_iso_handles_fractional_and_offset() {
     let ms = parse_iso_ms_str("2024-01-01T00:00:00.123+02:00").unwrap();
-    assert_eq!(ms, 1_704_067_200_000);
+    assert_eq!(ms, 1_704_060_000_000);
+}
+
+#[test]
+fn parse_iso_handles_fractional_and_negative_offset() {
+    let ms = parse_iso_ms_str("2026-08-26T22:04:58.676898-07:00").unwrap();
+    assert_eq!(ms, 1_787_807_098_000);
 }
 
 #[test]
@@ -23,4 +29,5 @@ fn parse_iso_rejects_garbage() {
     assert!(parse_iso_ms_str("").is_none());
     assert!(parse_iso_ms_str("not-a-date").is_none());
     assert!(parse_iso_ms_str("9999-99-99").is_none());
+    assert!(parse_iso_ms_str("2024-01-01T00:00:00+24:00").is_none());
 }

--- a/src-tauri/src/lib_commands/app_api/core.rs
+++ b/src-tauri/src/lib_commands/app_api/core.rs
@@ -138,6 +138,11 @@ pub(crate) fn greet(name: &str) -> String {
 #[tauri::command]
 #[specta::specta]
 pub(crate) fn exit_app(app_handle: tauri::AppHandle) {
+    if let Some(runtime) = app_handle.try_state::<psysonic_library::LibraryRuntime>() {
+        runtime
+            .scheduler_cancel
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
     if let Some(cache) = app_handle.try_state::<analysis_cache::AnalysisCache>() {
         let _ = cache.checkpoint_wal("exit");
     }

--- a/src-tauri/src/startup/services/library_scheduler.rs
+++ b/src-tauri/src/startup/services/library_scheduler.rs
@@ -8,6 +8,47 @@ use tauri::{Emitter, Manager};
 const MAX_BACKGROUND_SCHEDULER_CONCURRENCY: usize = 2;
 const BACKGROUND_SCHEDULER_TICK_TIMEOUT: Duration = Duration::from_secs(120);
 
+fn timestamp_repair_is_allowed(runtime: &psysonic_library::LibraryRuntime) -> bool {
+    use psysonic_library::sync::bandwidth::PlaybackHint;
+    use std::sync::atomic::Ordering;
+
+    !runtime.scheduler_cancel.load(Ordering::SeqCst)
+        && runtime.current_playback_hint() == PlaybackHint::Idle
+        && runtime.current_job().is_none()
+        && runtime.ensure_ordinary_sync_activity_allowed().is_ok()
+}
+
+async fn run_timestamp_repair_batch_if_idle(runtime: &psysonic_library::LibraryRuntime) {
+    use psysonic_library::store::TrackTimestampBackfillStep;
+
+    if !timestamp_repair_is_allowed(runtime) {
+        return;
+    }
+
+    let store = Arc::clone(&runtime.store);
+    match tokio::task::spawn_blocking(move || store.run_track_timestamp_backfill_batch()).await {
+        Ok(Ok(TrackTimestampBackfillStep::Deferred | TrackTimestampBackfillStep::Pending)) => {}
+        Ok(Ok(TrackTimestampBackfillStep::Complete)) => {}
+        Ok(Err(error)) => {
+            crate::app_eprintln!("[library-db] background timestamp repair failed: {error}");
+        }
+        Err(error) => {
+            crate::app_eprintln!("[library-db] background timestamp repair task failed: {error}");
+        }
+    }
+}
+
+async fn run_timestamp_repair_after_startup_grace(
+    runtime: &psysonic_library::LibraryRuntime,
+    startup_deferred: &mut bool,
+) {
+    if *startup_deferred {
+        *startup_deferred = false;
+    } else {
+        run_timestamp_repair_batch_if_idle(runtime).await;
+    }
+}
+
 async fn run_bounded_scheduler_sessions<I, F, Fut>(sessions: I, run: F)
 where
     I: IntoIterator,
@@ -62,6 +103,7 @@ pub(super) fn spawn(app_for_sched: tauri::AppHandle) {
 
         let mut interval = tokio::time::interval(Duration::from_secs(30));
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let mut timestamp_repair_startup_deferred = true;
         loop {
             interval.tick().await;
             let Some(state) = app_for_sched.try_state::<psysonic_library::LibraryRuntime>() else {
@@ -72,6 +114,11 @@ pub(super) fn spawn(app_for_sched: tauri::AppHandle) {
             }
             let sessions = state.snapshot_sessions();
             if sessions.is_empty() {
+                run_timestamp_repair_after_startup_grace(
+                    &state,
+                    &mut timestamp_repair_startup_deferred,
+                )
+                .await;
                 continue;
             }
             let hint = state.current_playback_hint();
@@ -198,6 +245,11 @@ pub(super) fn spawn(app_for_sched: tauri::AppHandle) {
                 }
             })
             .await;
+            run_timestamp_repair_after_startup_grace(
+                &state,
+                &mut timestamp_repair_startup_deferred,
+            )
+            .await;
         }
     });
 }
@@ -229,6 +281,31 @@ mod tests {
         assert!(foreground_blocks_scheduler_session(Some(&delta), "s1"));
         assert!(!foreground_blocks_scheduler_session(Some(&delta), "s2"));
         assert!(!foreground_blocks_scheduler_session(None, "s1"));
+    }
+
+    #[test]
+    fn timestamp_repair_yields_to_playback_foreground_sync_and_shutdown() {
+        use psysonic_library::sync::bandwidth::PlaybackHint;
+
+        let runtime = psysonic_library::LibraryRuntime::new(Arc::new(
+            psysonic_library::LibraryStore::open_in_memory(),
+        ));
+        assert!(timestamp_repair_is_allowed(&runtime));
+
+        runtime.set_playback_hint(PlaybackHint::Playing);
+        assert!(!timestamp_repair_is_allowed(&runtime));
+        runtime.set_playback_hint(PlaybackHint::PrefetchActive);
+        assert!(!timestamp_repair_is_allowed(&runtime));
+        runtime.set_playback_hint(PlaybackHint::Idle);
+
+        runtime
+            .install_current_job(foreground_job("s1", "delta_sync"))
+            .unwrap();
+        assert!(!timestamp_repair_is_allowed(&runtime));
+        runtime.clear_current_job_if_matches("s1-delta_sync");
+
+        runtime.scheduler_cancel.store(true, Ordering::SeqCst);
+        assert!(!timestamp_repair_is_allowed(&runtime));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src-tauri/src/startup/services/library_scheduler.rs
+++ b/src-tauri/src/startup/services/library_scheduler.rs
@@ -18,15 +18,50 @@ fn timestamp_repair_is_allowed(runtime: &psysonic_library::LibraryRuntime) -> bo
         && runtime.ensure_ordinary_sync_activity_allowed().is_ok()
 }
 
-async fn run_timestamp_repair_batch_if_idle(runtime: &psysonic_library::LibraryRuntime) {
+async fn run_timestamp_repair_batch_if_idle_with<F>(
+    runtime: &psysonic_library::LibraryRuntime,
+    run_batch: F,
+) where
+    F: FnOnce(
+            Arc<psysonic_library::LibraryStore>,
+        ) -> Result<psysonic_library::store::TrackTimestampBackfillStep, String>
+        + Send
+        + 'static,
+{
+    if !timestamp_repair_is_allowed(runtime) {
+        return;
+    }
+
+    run_timestamp_repair_batch_after_initial_check(runtime, run_batch).await;
+}
+
+async fn run_timestamp_repair_batch_after_initial_check<F>(
+    runtime: &psysonic_library::LibraryRuntime,
+    run_batch: F,
+) where
+    F: FnOnce(
+            Arc<psysonic_library::LibraryStore>,
+        ) -> Result<psysonic_library::store::TrackTimestampBackfillStep, String>
+        + Send
+        + 'static,
+{
     use psysonic_library::store::TrackTimestampBackfillStep;
 
+    let sync_activity = runtime.sync_activity_guard().await;
     if !timestamp_repair_is_allowed(runtime) {
         return;
     }
 
     let store = Arc::clone(&runtime.store);
-    match tokio::task::spawn_blocking(move || store.run_track_timestamp_backfill_batch()).await {
+    match tokio::task::spawn_blocking(move || {
+        // A dropped async wrapper does not abort blocking work. Keep the
+        // activity guard inside the closure so database swaps still wait for
+        // the write to finish after task cancellation.
+        let _sync_activity = sync_activity;
+        run_batch(store)
+    })
+    .await
+    {
         Ok(Ok(TrackTimestampBackfillStep::Deferred | TrackTimestampBackfillStep::Pending)) => {}
         Ok(Ok(TrackTimestampBackfillStep::Complete)) => {}
         Ok(Err(error)) => {
@@ -36,6 +71,13 @@ async fn run_timestamp_repair_batch_if_idle(runtime: &psysonic_library::LibraryR
             crate::app_eprintln!("[library-db] background timestamp repair task failed: {error}");
         }
     }
+}
+
+async fn run_timestamp_repair_batch_if_idle(runtime: &psysonic_library::LibraryRuntime) {
+    run_timestamp_repair_batch_if_idle_with(runtime, |store| {
+        store.run_track_timestamp_backfill_batch()
+    })
+    .await;
 }
 
 async fn run_timestamp_repair_after_startup_grace(
@@ -306,6 +348,83 @@ mod tests {
 
         runtime.scheduler_cancel.store(true, Ordering::SeqCst);
         assert!(!timestamp_repair_is_allowed(&runtime));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn timestamp_repair_holds_sync_activity_until_the_batch_finishes() {
+        use psysonic_library::store::TrackTimestampBackfillStep;
+        use std::sync::mpsc;
+
+        let runtime = Arc::new(psysonic_library::LibraryRuntime::new(Arc::new(
+            psysonic_library::LibraryStore::open_in_memory(),
+        )));
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let runtime_for_repair = Arc::clone(&runtime);
+        let repair = tokio::spawn(async move {
+            run_timestamp_repair_batch_if_idle_with(&runtime_for_repair, move |_| {
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                Ok(TrackTimestampBackfillStep::Complete)
+            })
+            .await;
+        });
+
+        tokio::task::spawn_blocking(move || {
+            started_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("timestamp repair did not start")
+        })
+        .await
+        .unwrap();
+        repair.abort();
+        assert!(repair.await.unwrap_err().is_cancelled());
+
+        let drain = runtime.cancel_and_drain_sync(None, None);
+        tokio::pin!(drain);
+        tokio::select! {
+            biased;
+            _ = &mut drain => panic!(
+                "cancelled wrapper released activity before blocking repair finished"
+            ),
+            _ = tokio::task::yield_now() => {}
+        }
+
+        release_tx.send(()).unwrap();
+        let guard = tokio::time::timeout(Duration::from_secs(1), &mut drain)
+            .await
+            .expect("sync drain did not finish after repair")
+            .unwrap();
+        drop(guard);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn queued_timestamp_repair_rechecks_shutdown_after_the_activity_guard() {
+        use psysonic_library::store::TrackTimestampBackfillStep;
+
+        let runtime = Arc::new(psysonic_library::LibraryRuntime::new(Arc::new(
+            psysonic_library::LibraryStore::open_in_memory(),
+        )));
+        let barrier = runtime.cancel_and_drain_sync(None, None).await.unwrap();
+        let batch_called = Arc::new(AtomicBool::new(false));
+        let batch_called_for_task = Arc::clone(&batch_called);
+        let repair = run_timestamp_repair_batch_after_initial_check(&runtime, move |_| {
+            batch_called_for_task.store(true, Ordering::SeqCst);
+            Ok(TrackTimestampBackfillStep::Complete)
+        });
+        tokio::pin!(repair);
+
+        tokio::select! {
+            biased;
+            () = &mut repair => panic!("timestamp repair completed while activity was blocked"),
+            _ = tokio::task::yield_now() => {}
+        }
+        runtime.scheduler_cancel.store(true, Ordering::SeqCst);
+        drop(barrier);
+        tokio::time::timeout(Duration::from_secs(1), &mut repair)
+            .await
+            .expect("queued timestamp repair did not finish");
+        assert!(!batch_called.load(Ordering::SeqCst));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

- Parse positive and negative RFC 3339 UTC offsets correctly in Subsonic and Navidrome timestamps.
- Preserve creation timestamps when sparse initial-ingest or resync payloads omit them.
- Run a bounded, resumable background reconcile that restores only server timestamps demonstrably damaged by the old parser, without overwriting newer favourite/play state.

## User impact

Navidrome libraries whose timestamps contain negative UTC offsets can populate New Releases again. Safely identifiable existing values are repaired gradually after startup without blocking database open; ambiguous legacy values wait for a later sync rather than risk restoring intentionally cleared data.

## Verification

- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- --test-threads=1`
- Timestamp, remap, and scheduler regression tests cover offset parsing, authoritative hot-column preservation, explicit clears, existing remap destinations, raw metadata non-resurrection, bounded resume, and drain/cancellation behavior across non-abortable blocking work.
- Real database A/B using a supplied 11,397-track snapshot:
  - Base: 11,397 missing creation/update timestamps; New Releases returned 0 albums.
  - Head: 0 missing creation/update timestamps; New Releases returned 30 albums.
  - The original synchronous implementation completed open and repair in 885 ms; the final implementation removes that O(n) work from database open.
- The exact parallel workspace test command hits the same two timing-only ingest assertions on base and head under local contention: base 1.16/1.20 s, head 1.18/1.22 s. Both pass in isolation in 0.07-0.08 s, and the complete serial workspace run passes.
- Follow-up isolated repair on an 11,719-track pre-fix copy:
  - `server_created_at` NULL: 11,719 → 0.
  - `server_updated_at` NULL: 11,719 → 2; both remaining payloads have no update field.
  - Starred rows: 0 → 0; played rows: 17 → 17, confirming the repair does not rebuild mutable user state from stale JSON.
- Marker completed at cursor 11,722.
- Database-open regression coverage confirms the repair marker is not created or drained by the open pipeline.
- Final serial workspace result: 121 root tests, 186 analysis tests, 398 audio tests, 52 core tests, 126 integration tests, 830 library tests, and 159 syncfs tests passed; 15 tests were ignored. Clippy passed with `-D warnings`.
- Two independent final static review passes reported no findings after the data-provenance and scheduler-lifecycle fixes.

## Runtime benchmark

- Applicability: required; this removes database-open work, adds low-priority scheduler work, and changes data used by the Home New Releases feed.
- Baseline: `6d88c4ac6aafc233b1a29cccdc85998647aa71cf` / report `2026-08-28T09-56-53-612Z`
- Original final code: `07489ba9` / report `2026-08-28T10-01-08-116Z`
- Original confirmation: report `2026-08-28T10-03-09-731Z`
- Data-safety commit: `92d4d8bd` / reports `2026-08-28T12-36-20-012Z`, `2026-08-28T12-36-58-570Z`, `2026-08-28T12-37-41-813Z`
- Background final: `8b01e51e` / reports `2026-08-28T14-13-06-983Z`, `2026-08-28T14-13-47-743Z`, `2026-08-28T14-18-50-017Z`, `2026-08-28T14-19-32-759Z`
- Final reviewed head: `6390802d` / reports `2026-08-28T17-44-50-936Z`, `2026-08-28T17-45-43-798Z`
- Command: `psysonic benchmark run --scenario core-pages --runs 2 --profile realistic --json`
- Environment: Linux debug, one selected server, stable scope fingerprint. Baseline/background comparison used 1283x694 at DPR 2; the repeated final-head smoke pair used 1269x694 at DPR 2.
- Affected route: Home `/`, including the New Releases feed.
- Result: no errors, timeouts, skipped routes, or wrong routes. The repeated final-head run reported Home 1,222 ms, Albums 1,055 ms, Artists 841 ms, Tracks 996 ms, and Favorites 1,632 ms median total; the first-run Tracks spike did not reproduce.
- Noise check: Home alternated between approximately 0.9-1.4 s route work and a 6-7 s post-ready DOM-quiet wait. The spike is not semantic readiness, does not reproduce on the other routes, and matches earlier scheduler/background-noise reports. The repair emits no frontend event and the benchmark profile's repair marker was already complete.
- Errors, timeouts, wrong routes, and affected interaction failures: none.

## Database and API notes

- No schema migration or compatibility-version change.
- The repair uses the existing `library_data_migration` marker/cursor mechanism, reads exactly 1,000 physical rows per transaction, and writes only rows whose server timestamp is demonstrably affected.
- Database open does not run the repair. The existing 30-second library scheduler waits through its first tick, runs due sync sessions first, and then processes at most one repair batch only while playback is idle, no foreground sync or migration is active, and bulk ingest is inactive. The activity barrier remains held inside blocking work even if its async wrapper is cancelled, and app exit closes scheduler admission.
- No Tauri command, event, or payload contract changes.
