### PR TITLE
fix(library): keep album versions separate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Navidrome timestamps with negative UTC offsets no longer disappear from the local index, so New Releases, favourites and last played dates populate correctly during sync. Existing creation dates with safely identifiable old values are repaired gradually in the background; ambiguous cleared legacy values wait for a later sync rather than risk restoring stale data.
 
+### Different album versions stay separate
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1471](https://github.com/Psysonic/psysonic/pull/1471)**
+
+* Standard, deluxe, remastered and other physical versions of the same album no longer collapse into one release in combined libraries, artist discographies or Album Detail. Matching copies of the same version still merge across servers.
+* Existing libraries rebuild their derived identity keys once after updating; the library database and user state are unchanged.
+
 ## [1.51.0] - 2026-08-17
 
 ## Added

--- a/src-tauri/crates/psysonic-integration/src/subsonic/types.rs
+++ b/src-tauri/crates/psysonic-integration/src/subsonic/types.rs
@@ -24,6 +24,36 @@ where
     })
 }
 
+fn de_string_vec_flexible<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(match value {
+        Some(serde_json::Value::String(value)) => vec![value],
+        Some(serde_json::Value::Array(values)) => values
+            .into_iter()
+            .filter_map(|value| value.as_str().map(str::to_string))
+            .collect(),
+        _ => Vec::new(),
+    })
+}
+
+fn de_optional_album_summary_tags<'de, D>(
+    deserializer: D,
+) -> Result<Option<AlbumSummaryTags>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(match value {
+        Some(serde_json::Value::Object(object)) => {
+            serde_json::from_value(serde_json::Value::Object(object)).ok()
+        }
+        _ => None,
+    })
+}
+
 /// Navidrome often ships library ids as JSON numbers; Subsonic uses strings.
 fn de_string_or_number<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
@@ -162,9 +192,19 @@ pub struct MusicFolder {
 
 /// `#getAlbumList2` — page of album summaries (no song list).
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct AlbumSummaryTags {
+    #[serde(default, deserialize_with = "de_string_vec_flexible")]
+    pub albumversion: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct AlbumSummary {
     pub id: String,
     pub name: String,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default, deserialize_with = "de_optional_album_summary_tags")]
+    pub tags: Option<AlbumSummaryTags>,
     #[serde(default)]
     pub artist: Option<String>,
     #[serde(rename = "artistId", default)]
@@ -400,6 +440,38 @@ mod tests {
         let legacy: Song =
             serde_json::from_str(r#"{"id":"a","title":"t","isrc":"USRC17607839"}"#).unwrap();
         assert_eq!(legacy.isrc.as_deref(), Some("USRC17607839"));
+    }
+
+    #[test]
+    fn album_summary_tolerates_optional_albumversion_shapes() {
+        let scalar: AlbumSummary = serde_json::from_str(
+            r#"{"id":"a","name":"Album","tags":{"albumversion":"Deluxe"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            scalar.tags.unwrap().albumversion,
+            vec!["Deluxe".to_string()]
+        );
+
+        let mixed: AlbumSummary = serde_json::from_str(
+            r#"{"id":"a","name":"Album","tags":{"albumversion":[null,"",7,"Deluxe"]}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            mixed.tags.unwrap().albumversion,
+            vec!["".to_string(), "Deluxe".to_string()]
+        );
+
+        for malformed in [
+            r#"{"id":"a","name":"Album","tags":null}"#,
+            r#"{"id":"a","name":"Album","tags":"unexpected"}"#,
+            r#"{"id":"a","name":"Album","tags":{"albumversion":null}}"#,
+        ] {
+            let summary: AlbumSummary = serde_json::from_str(malformed).unwrap();
+            assert!(summary
+                .tags
+                .is_none_or(|tags| tags.albumversion.is_empty()));
+        }
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/album_overlay.rs
+++ b/src-tauri/crates/psysonic-library/src/album_overlay.rs
@@ -148,7 +148,13 @@ pub fn resolve_album_overlay(
                     .map(str::trim)
                     .filter(|value| !value.is_empty());
                 let normalized_key = (!exists)
-                    .then(|| crate::identity::build_album_key(artist, name))
+                    .then(|| {
+                        crate::identity::build_album_key_with_version(
+                            artist,
+                            name,
+                            album.version.as_deref(),
+                        )
+                    })
                     .flatten();
                 let identity_key = indexed_key
                     .clone()
@@ -279,12 +285,14 @@ mod tests {
                         id: "z-alternate".into(),
                         name: "Shared".into(),
                         artist: Some("Artist".into()),
+                        version: None,
                     },
                     LibraryAlbumOverlayCandidateDto {
                         server_id: "s2".into(),
                         id: "b-second".into(),
                         name: "Shared".into(),
                         artist: Some("Artist".into()),
+                        version: None,
                     },
                 ],
             },
@@ -369,12 +377,14 @@ mod tests {
                         id: "fresh-a".into(),
                         name: "My Arms, Your Hearse".into(),
                         artist: Some("Opeth".into()),
+                        version: None,
                     },
                     LibraryAlbumOverlayCandidateDto {
                         server_id: "s2".into(),
                         id: "fresh-b".into(),
                         name: "My Arms Your Hearse".into(),
                         artist: Some("Opeth".into()),
+                        version: None,
                     },
                 ],
             },
@@ -385,6 +395,36 @@ mod tests {
         assert!(resolutions.iter().all(|resolution| {
             resolution.representative_server_id.is_none() && resolution.representative_id.is_none()
         }));
+    }
+
+    #[test]
+    fn keeps_unindexed_album_versions_in_separate_groups() {
+        let store = LibraryStore::open_in_memory();
+        let resolutions = resolve_album_overlay(
+            &store,
+            &LibraryResolveAlbumOverlayRequest {
+                scopes: vec![scope("s1", "l1")],
+                albums: vec![
+                    LibraryAlbumOverlayCandidateDto {
+                        server_id: "s1".into(),
+                        id: "standard".into(),
+                        name: "Album".into(),
+                        artist: Some("Artist".into()),
+                        version: Some("Standard".into()),
+                    },
+                    LibraryAlbumOverlayCandidateDto {
+                        server_id: "s1".into(),
+                        id: "deluxe".into(),
+                        name: "Album [Deluxe Edition]".into(),
+                        artist: Some("Artist".into()),
+                        version: Some("Deluxe Edition".into()),
+                    },
+                ],
+            },
+        )
+        .unwrap();
+
+        assert_ne!(resolutions[0].group, resolutions[1].group);
     }
 
     #[test]
@@ -402,6 +442,7 @@ mod tests {
                     id: "fresh-copy".into(),
                     name: "Shared".into(),
                     artist: Some("Artist".into()),
+                    version: None,
                 }],
             },
         )

--- a/src-tauri/crates/psysonic-library/src/commands/sync_session_support.rs
+++ b/src-tauri/crates/psysonic-library/src/commands/sync_session_support.rs
@@ -446,7 +446,11 @@ async fn library_sync_start_with_admission(
                 if let Some(creds) = navidrome_creds.clone() {
                     runner = runner.with_navidrome_credentials(creds);
                 }
-                let run = sync_outcome_to_result(runner.run().await, admission);
+                let outcome = runner.run().await;
+                let require_untagged = outcome
+                    .as_ref()
+                    .map_or(true, |report| force_full_tombstone || report.up_to_date);
+                let run = sync_outcome_to_result(outcome, admission);
                 if run.is_ok() {
                     run_tag_pass_best_effort(
                         &store,
@@ -454,7 +458,7 @@ async fn library_sync_start_with_admission(
                         &session_clone.server_id,
                         Some(Arc::clone(&cancel_for_task)),
                         Arc::clone(&progress),
-                        true,
+                        require_untagged,
                     )
                     .await;
                 }

--- a/src-tauri/crates/psysonic-library/src/dto.rs
+++ b/src-tauri/crates/psysonic-library/src/dto.rs
@@ -770,6 +770,8 @@ pub struct LibraryAlbumOverlayCandidateDto {
     pub id: String,
     pub name: String,
     pub artist: Option<String>,
+    #[serde(default)]
+    pub version: Option<String>,
 }
 
 /// Resolve a bounded network overlay batch against one ordered browse scope.

--- a/src-tauri/crates/psysonic-library/src/identity/invalidation.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/invalidation.rs
@@ -41,6 +41,13 @@ pub(crate) fn record_tracks<'a>(
     record(tx, TRACK_KIND, tracks)
 }
 
+pub(crate) fn record_albums<'a>(
+    tx: &Transaction<'_>,
+    albums: impl IntoIterator<Item = (&'a str, &'a str)>,
+) -> rusqlite::Result<()> {
+    record(tx, ALBUM_KIND, albums)
+}
+
 pub(crate) fn record_album_scopes(
     tx: &Transaction<'_>,
     scopes: &HashSet<AlbumScope>,

--- a/src-tauri/crates/psysonic-library/src/identity/keys.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/keys.rs
@@ -21,6 +21,60 @@ pub(crate) fn build_album_key(artist: Option<&str>, album: &str) -> Option<Strin
     join_norm_parts([norm_part(artist.unwrap_or("")), norm_part(album)])
 }
 
+fn album_name_without_appended_version<'a>(album: &'a str, version: &str) -> &'a str {
+    let album = album.trim();
+    let suffix = format!(" ({})", version.trim());
+    if album.len() > suffix.len() {
+        let (base, candidate) = album.split_at(album.len() - suffix.len());
+        if candidate.eq_ignore_ascii_case(&suffix) {
+            return base.trim_end();
+        }
+    }
+    album
+}
+
+pub(crate) fn build_album_key_with_version(
+    artist: Option<&str>,
+    album: &str,
+    version: Option<&str>,
+) -> Option<String> {
+    let version = version.map(str::trim).filter(|value| !value.is_empty());
+    let normalized_version = version.and_then(norm_part);
+    let Some(normalized_version) = normalized_version else {
+        return build_album_key(artist, album);
+    };
+    let album = album_name_without_appended_version(album, version.unwrap_or_default());
+    join_norm_parts([
+        norm_part(artist.unwrap_or("")),
+        norm_part(album),
+        Some(normalized_version),
+    ])
+}
+
+pub(crate) fn build_track_cluster_key_with_version(
+    artist: Option<&str>,
+    title: &str,
+    album: &str,
+    version: Option<&str>,
+) -> Option<String> {
+    let version = version.map(str::trim).filter(|value| !value.is_empty());
+    let normalized_version = version.and_then(norm_part);
+    let Some(normalized_version) = normalized_version else {
+        return join_norm_parts([
+            norm_part(artist.unwrap_or("")),
+            norm_part(title),
+            norm_part(album),
+        ]);
+    };
+    let album = album_name_without_appended_version(album, version.unwrap_or_default());
+    join_norm_parts([
+        norm_part(artist.unwrap_or("")),
+        norm_part(title),
+        norm_part(album),
+        Some(normalized_version),
+    ])
+}
+
 pub fn build_track_cluster_keys(
     artist: Option<&str>,
     title: &str,
@@ -87,5 +141,39 @@ mod tests {
             keys.album_key,
             Some(format!("compartist{}greatesthits", sep))
         );
+    }
+
+    #[test]
+    fn album_version_distinguishes_releases() {
+        let standard = build_album_key_with_version(Some("Artist"), "Album", Some("Standard"));
+        let deluxe =
+            build_album_key_with_version(Some("Artist"), "Album", Some("Deluxe Edition"));
+        assert_ne!(standard, deluxe);
+    }
+
+    #[test]
+    fn appended_album_version_matches_the_plain_album_name() {
+        let plain =
+            build_album_key_with_version(Some("Artist"), "Album", Some("Deluxe Edition"));
+        let appended = build_album_key_with_version(
+            Some("Artist"),
+            "Album (Deluxe Edition)",
+            Some("Deluxe Edition"),
+        );
+        assert_eq!(plain, appended);
+
+        let plain_track = build_track_cluster_key_with_version(
+            Some("Artist"),
+            "Song",
+            "Album",
+            Some("Deluxe Edition"),
+        );
+        let appended_track = build_track_cluster_key_with_version(
+            Some("Artist"),
+            "Song",
+            "Album (Deluxe Edition)",
+            Some("Deluxe Edition"),
+        );
+        assert_eq!(plain_track, appended_track);
     }
 }

--- a/src-tauri/crates/psysonic-library/src/identity/keys.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/keys.rs
@@ -23,10 +23,58 @@ pub(crate) fn build_album_key(artist: Option<&str>, album: &str) -> Option<Strin
 
 fn album_name_without_appended_version<'a>(album: &'a str, version: &str) -> &'a str {
     let album = album.trim();
-    let suffix = format!(" ({})", version.trim());
-    if album.len() > suffix.len() {
-        let (base, candidate) = album.split_at(album.len() - suffix.len());
-        if candidate.eq_ignore_ascii_case(&suffix) {
+    let version = version.trim();
+    const WRAPPERS: &[(char, char)] = &[
+        ('(', ')'),
+        ('[', ']'),
+        ('{', '}'),
+        ('<', '>'),
+        ('（', '）'),
+        ('［', '］'),
+        ('｛', '｝'),
+        ('＜', '＞'),
+        ('【', '】'),
+        ('「', '」'),
+        ('『', '』'),
+    ];
+
+    let version_content = WRAPPERS
+        .iter()
+        .find_map(|(open, close)| {
+            version
+                .strip_prefix(*open)
+                .and_then(|value| value.strip_suffix(*close))
+        })
+        .unwrap_or(version);
+    let Some(normalized_version) = norm_part(version_content) else {
+        return album;
+    };
+
+    for (open, close) in WRAPPERS {
+        let Some(without_close) = album.strip_suffix(*close) else {
+            continue;
+        };
+        let mut depth = 1usize;
+        let open_index = without_close.char_indices().rev().find_map(|(index, character)| {
+            if character == *close {
+                depth = depth.saturating_add(1);
+                None
+            } else if character == *open {
+                depth = depth.saturating_sub(1);
+                (depth == 0).then_some(index)
+            } else {
+                None
+            }
+        });
+        let Some(open_index) = open_index else {
+            continue;
+        };
+        let base = &without_close[..open_index];
+        if !base.chars().last().is_some_and(char::is_whitespace) {
+            continue;
+        }
+        let suffix_content = &without_close[open_index + open.len_utf8()..];
+        if norm_part(suffix_content).as_deref() == Some(normalized_version.as_str()) {
             return base.trim_end();
         }
     }
@@ -175,5 +223,67 @@ mod tests {
             Some("Deluxe Edition"),
         );
         assert_eq!(plain_track, appended_track);
+    }
+
+    #[test]
+    fn bracketed_album_version_matches_the_plain_album_name() {
+        let plain = build_album_key_with_version(Some("Artist"), "Album", Some("Deluxe Edition"));
+        let appended = build_album_key_with_version(
+            Some("Artist"),
+            "Album [Deluxe Edition]",
+            Some("Deluxe Edition"),
+        );
+        assert_eq!(plain, appended);
+
+        let already_bracketed =
+            build_album_key_with_version(Some("Artist"), "Album", Some("[Deluxe Edition]"));
+        let already_bracketed_appended = build_album_key_with_version(
+            Some("Artist"),
+            "Album [Deluxe Edition]",
+            Some("[Deluxe Edition]"),
+        );
+        assert_eq!(already_bracketed, already_bracketed_appended);
+    }
+
+    #[test]
+    fn suffix_check_does_not_split_inside_utf8() {
+        assert_eq!(album_name_without_appended_version("éabc", "x"), "éabc");
+    }
+
+    #[test]
+    fn appended_album_version_matches_unicode_case_variants() {
+        let plain = build_album_key_with_version(Some("Artist"), "Album", Some("[ÉDITION]"));
+        let appended = build_album_key_with_version(
+            Some("Artist"),
+            "Album [édition]",
+            Some("[ÉDITION]"),
+        );
+        assert_eq!(plain, appended);
+    }
+
+    #[test]
+    fn appended_album_version_matches_canonical_unicode_and_wide_brackets() {
+        let plain = build_album_key_with_version(Some("Artist"), "Album", Some("Édition"));
+        let decomposed = build_album_key_with_version(
+            Some("Artist"),
+            "Album 【E\u{301}dition】",
+            Some("Édition"),
+        );
+        assert_eq!(plain, decomposed);
+    }
+
+    #[test]
+    fn appended_album_version_matches_nested_wrappers() {
+        let plain = build_album_key_with_version(
+            Some("Artist"),
+            "Album",
+            Some("Deluxe (2024)"),
+        );
+        let appended = build_album_key_with_version(
+            Some("Artist"),
+            "Album (Deluxe (2024))",
+            Some("Deluxe (2024)"),
+        );
+        assert_eq!(plain, appended);
     }
 }

--- a/src-tauri/crates/psysonic-library/src/identity/mod.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/mod.rs
@@ -13,7 +13,7 @@ pub use attach::{
 };
 pub use norm::NORM_VERSION;
 pub(crate) use norm::norm_part;
-pub(crate) use invalidation::{record_album_scopes, record_artists, record_tracks};
+pub(crate) use invalidation::{record_album_scopes, record_albums, record_artists, record_tracks};
 pub use rebuild::{
     cluster_rebuild_needed, ensure_cluster_keys_built, ensure_pending_cluster_keys,
     identity_maintenance_needed, rebuild_cluster_keys,
@@ -24,4 +24,4 @@ pub(crate) use rebuild::{
 };
 
 pub use keys::{build_track_cluster_keys, TrackClusterKeys};
-pub(crate) use keys::build_album_key;
+pub(crate) use keys::build_album_key_with_version;

--- a/src-tauri/crates/psysonic-library/src/identity/norm.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/norm.rs
@@ -28,7 +28,8 @@ pub(crate) const KEY_SEP: char = '\u{001f}';
 ///     uniformity cannot derive a key, so a correctly tagged guest track no
 ///     longer costs the album its identity.
 /// v7: Ukrainian Cyrillic folding (ї→і).
-pub const NORM_VERSION: &str = "7";
+/// v8: album identity includes the OpenSubsonic/Navidrome album version when present.
+pub const NORM_VERSION: &str = "8";
 
 /// Normalize one identity field. Returns `None` when input is empty/whitespace-only
 /// or when normalization strips everything (punctuation-only, etc.).

--- a/src-tauri/crates/psysonic-library/src/identity/norm.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/norm.rs
@@ -29,7 +29,9 @@ pub(crate) const KEY_SEP: char = '\u{001f}';
 ///     longer costs the album its identity.
 /// v7: Ukrainian Cyrillic folding (ї→і).
 /// v8: album identity includes the OpenSubsonic/Navidrome album version when present.
-pub const NORM_VERSION: &str = "8";
+/// v9: version suffix stripping uses identity normalization and album-level
+///     list metadata no longer outranks an authoritative track version.
+pub const NORM_VERSION: &str = "9";
 
 /// Normalize one identity field. Returns `None` when input is empty/whitespace-only
 /// or when normalization strips everything (punctuation-only, etc.).

--- a/src-tauri/crates/psysonic-library/src/identity/rebuild/pipeline.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/rebuild/pipeline.rs
@@ -53,17 +53,58 @@ fn json_text_expr(json_column: &str, path: &str) -> String {
     )
 }
 
+fn json_string_or_first_array_text_expr(json_column: &str, path: &str) -> String {
+    let scalar = json_text_expr(json_column, path);
+    format!(
+        "COALESCE({scalar}, ( \
+           SELECT NULLIF(TRIM(tag.value), '') \
+           FROM json_each( \
+             CASE WHEN json_valid({json_column}) THEN \
+               CASE WHEN json_type({json_column}, '{path}') = 'array' \
+                    THEN {json_column} ELSE '{{}}' END \
+             ELSE '{{}}' END, \
+             '{path}' \
+           ) AS tag \
+           WHERE tag.type = 'text' AND NULLIF(TRIM(tag.value), '') IS NOT NULL \
+           LIMIT 1 \
+         ))"
+    )
+}
+
+fn track_album_version_expr(track_json: &str) -> String {
+    let track_album_version = json_text_expr(track_json, "$.albumVersion");
+    let track_tag_version =
+        json_string_or_first_array_text_expr(track_json, "$.tags.albumversion");
+    format!("COALESCE({track_album_version}, {track_tag_version})")
+}
+
+fn json_true_expr(json_column: &str, path: &str) -> String {
+    format!(
+        "COALESCE(CASE WHEN json_valid({json_column}) \
+         THEN json_extract({json_column}, '{path}') = 1 END, 0)"
+    )
+}
+
 fn canonical_album_version_expr(album_json: &str, track_json: &str) -> String {
     let album_version = json_text_expr(album_json, "$.version");
-    let album_tag_version = json_text_expr(album_json, "$.tags.albumversion[0]");
-    let track_album_version = json_text_expr(track_json, "$.albumVersion");
-    let track_version = json_text_expr(track_json, "$.version");
-    let track_tag_version = json_text_expr(track_json, "$.tags.albumversion[0]");
-    let track_value = format!(
-        "COALESCE({track_album_version}, {track_version}, {track_tag_version})"
+    let album_tag_version =
+        json_string_or_first_array_text_expr(album_json, "$.tags.albumversion");
+    let album_value = format!("COALESCE({album_version}, {album_tag_version})");
+    let album_from_list = json_true_expr(album_json, "$._psysonicAlbumVersionFromList");
+    let track_value = track_album_version_expr(track_json);
+    let track_from_list = json_true_expr(track_json, "$._psysonicAlbumVersionFromList");
+    let track_needs_refresh =
+        json_true_expr(track_json, "$._psysonicAlbumVersionNeedsListRefresh");
+    let authoritative_track = format!(
+        "CASE WHEN NOT ({track_from_list}) AND NOT ({track_needs_refresh}) \
+         THEN {track_value} END"
     );
     format!(
-        "COALESCE(MAX({album_version}), MAX({album_tag_version}), \
+        "COALESCE( \
+           MAX(CASE WHEN NOT ({album_from_list}) THEN {album_value} END), \
+           CASE WHEN COUNT(DISTINCT {authoritative_track}) = 1 \
+                THEN MAX({authoritative_track}) END, \
+           MAX({album_value}), \
            CASE WHEN COUNT(DISTINCT {track_value}) = 1 THEN MAX({track_value}) END)"
     )
 }
@@ -96,6 +137,17 @@ fn upsert_source_track(
             canonical_album.as_deref().unwrap_or(&album),
             canonical_album_version.as_deref(),
         );
+        if album_id.as_deref().is_none_or(|id| id.trim().is_empty()) {
+            let album_identity_artist = album_artist
+                .as_deref()
+                .filter(|name| !name.trim().is_empty())
+                .or(artist.as_deref());
+            keys.album_key = build_album_key_with_version(
+                album_identity_artist,
+                canonical_album.as_deref().unwrap_or(&album),
+                canonical_album_version.as_deref(),
+            );
+        }
     }
     keys.artist_key = canonical_artist
         .as_deref()
@@ -148,6 +200,7 @@ pub(super) fn rebuild_cluster_keys_on_conn(
     let va_credit =
         crate::album_compilation_filter::collection_credit_sql("MAX(source.album_artist)");
     let album_version = canonical_album_version_expr("album_meta.raw_json", "source.raw_json");
+    let track_album_version = track_album_version_expr("t.raw_json");
     let select = format!(
         "WITH physical_album AS MATERIALIZED ( \
            SELECT source.server_id, source.album_id, \
@@ -189,8 +242,11 @@ pub(super) fn rebuild_cluster_keys_on_conn(
          ) \
          SELECT t.server_id, COALESCE(t.library_id, ''), t.id, t.artist, ar.name, t.title, \
                  t.album_artist, t.album, t.album_id, physical_album.canonical_album_artist, \
-                 physical_album.canonical_album, physical_album.canonical_album_version, \
-                 t.duration_sec \
+                  physical_album.canonical_album, \
+                  CASE WHEN NULLIF(TRIM(t.album_id), '') IS NULL \
+                       THEN {track_album_version} \
+                       ELSE physical_album.canonical_album_version END, \
+                  t.duration_sec \
          FROM track t \
          LEFT JOIN artist ar ON ar.server_id = t.server_id AND ar.id = t.artist_id \
          LEFT JOIN physical_album \
@@ -274,6 +330,7 @@ pub(super) fn apply_identity_invalidations_on_conn(
     let va_credit =
         crate::album_compilation_filter::collection_credit_sql("MAX(source.album_artist)");
     let album_version = canonical_album_version_expr("album_meta.raw_json", "source.raw_json");
+    let track_album_version = track_album_version_expr("t.raw_json");
     let select = &format!(
         "WITH invalidated_artist AS MATERIALIZED ( \
                     SELECT entity_id FROM identity_invalidation \
@@ -332,8 +389,11 @@ pub(super) fn apply_identity_invalidations_on_conn(
                   ) \
                   SELECT t.server_id, COALESCE(t.library_id, ''), t.id, t.artist, ar.name, \
                           t.title, t.album_artist, t.album, t.album_id, \
-                          physical_album.canonical_album_artist, physical_album.canonical_album, \
-                          physical_album.canonical_album_version, t.duration_sec \
+                           physical_album.canonical_album_artist, physical_album.canonical_album, \
+                           CASE WHEN NULLIF(TRIM(t.album_id), '') IS NULL \
+                                THEN {track_album_version} \
+                                ELSE physical_album.canonical_album_version END, \
+                           t.duration_sec \
                   FROM candidate_track candidate \
                   CROSS JOIN track t INDEXED BY sqlite_autoindex_track_1 \
                   LEFT JOIN artist ar \

--- a/src-tauri/crates/psysonic-library/src/identity/rebuild/pipeline.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/rebuild/pipeline.rs
@@ -5,7 +5,10 @@ use super::ranks::{
     recompute_all_occurrence_ranks, reset_affected_rank_partitions,
 };
 use super::{concrete_physical_album_key, dirty_meta_key, set_cluster_meta, DIRTY_META_PREFIX};
-use crate::identity::keys::{build_album_key, build_track_cluster_keys};
+use crate::identity::keys::{
+    build_album_key_with_version, build_track_cluster_key_with_version,
+    build_track_cluster_keys,
+};
 use crate::identity::norm::norm_part;
 
 const UPSERT_CLUSTER_KEY_SQL: &str = "
@@ -37,8 +40,33 @@ type SourceTrackRow = (
     Option<String>,
     Option<String>,
     Option<String>,
+    Option<String>,
     i64,
 );
+
+fn json_text_expr(json_column: &str, path: &str) -> String {
+    format!(
+        "CASE WHEN json_valid({json_column}) THEN \
+           CASE WHEN json_type({json_column}, '{path}') = 'text' \
+                THEN NULLIF(TRIM(json_extract({json_column}, '{path}')), '') END \
+         END"
+    )
+}
+
+fn canonical_album_version_expr(album_json: &str, track_json: &str) -> String {
+    let album_version = json_text_expr(album_json, "$.version");
+    let album_tag_version = json_text_expr(album_json, "$.tags.albumversion[0]");
+    let track_album_version = json_text_expr(track_json, "$.albumVersion");
+    let track_version = json_text_expr(track_json, "$.version");
+    let track_tag_version = json_text_expr(track_json, "$.tags.albumversion[0]");
+    let track_value = format!(
+        "COALESCE({track_album_version}, {track_version}, {track_tag_version})"
+    );
+    format!(
+        "COALESCE(MAX({album_version}), MAX({album_tag_version}), \
+           CASE WHEN COUNT(DISTINCT {track_value}) = 1 THEN MAX({track_value}) END)"
+    )
+}
 
 fn upsert_source_track(
     source: SourceTrackRow,
@@ -56,10 +84,19 @@ fn upsert_source_track(
         album_id,
         canonical_album_artist,
         canonical_album,
+        canonical_album_version,
         duration_sec,
     ) = source;
     let mut keys =
         build_track_cluster_keys(artist.as_deref(), &title, &album, album_artist.as_deref());
+    if canonical_album_version.is_some() {
+        keys.cluster_key = build_track_cluster_key_with_version(
+            artist.as_deref(),
+            &title,
+            canonical_album.as_deref().unwrap_or(&album),
+            canonical_album_version.as_deref(),
+        );
+    }
     keys.artist_key = canonical_artist
         .as_deref()
         .filter(|name| !name.trim().is_empty())
@@ -70,7 +107,11 @@ fn upsert_source_track(
             .as_deref()
             .filter(|name| !name.trim().is_empty())
             .and_then(|name| {
-                build_album_key(Some(name), canonical_album.as_deref().unwrap_or(&album))
+                build_album_key_with_version(
+                    Some(name),
+                    canonical_album.as_deref().unwrap_or(&album),
+                    canonical_album_version.as_deref(),
+                )
             })
             .or_else(|| Some(concrete_physical_album_key(&server_id, album_id)));
     }
@@ -106,6 +147,7 @@ pub(super) fn rebuild_cluster_keys_on_conn(
     // out too, not just the one spelling the filter happens to match.
     let va_credit =
         crate::album_compilation_filter::collection_credit_sql("MAX(source.album_artist)");
+    let album_version = canonical_album_version_expr("album_meta.raw_json", "source.raw_json");
     let select = format!(
         "WITH physical_album AS MATERIALIZED ( \
            SELECT source.server_id, source.album_id, \
@@ -134,17 +176,21 @@ pub(super) fn rebuild_cluster_keys_on_conn(
                                         THEN 1 ELSE 0 END) > 0 \
                          THEN MAX(NULLIF(TRIM(source.album_artist), '')) END \
                   ) AS canonical_album_artist, \
-                  MAX(source.album) AS canonical_album \
-           FROM track source \
-           LEFT JOIN artist ar_source \
-             ON ar_source.server_id = source.server_id AND ar_source.id = source.artist_id \
+                   MAX(source.album) AS canonical_album, \
+                   {album_version} AS canonical_album_version \
+            FROM track source \
+            LEFT JOIN artist ar_source \
+              ON ar_source.server_id = source.server_id AND ar_source.id = source.artist_id \
+            LEFT JOIN album album_meta \
+              ON album_meta.server_id = source.server_id AND album_meta.id = source.album_id \
            WHERE source.deleted = 0 \
              AND source.album_id IS NOT NULL AND source.album_id != ''{album_server_filter} \
            GROUP BY source.server_id, source.album_id \
          ) \
          SELECT t.server_id, COALESCE(t.library_id, ''), t.id, t.artist, ar.name, t.title, \
-                t.album_artist, t.album, t.album_id, physical_album.canonical_album_artist, \
-                physical_album.canonical_album, t.duration_sec \
+                 t.album_artist, t.album, t.album_id, physical_album.canonical_album_artist, \
+                 physical_album.canonical_album, physical_album.canonical_album_version, \
+                 t.duration_sec \
          FROM track t \
          LEFT JOIN artist ar ON ar.server_id = t.server_id AND ar.id = t.artist_id \
          LEFT JOIN physical_album \
@@ -227,6 +273,7 @@ pub(super) fn apply_identity_invalidations_on_conn(
     // pass ran last.
     let va_credit =
         crate::album_compilation_filter::collection_credit_sql("MAX(source.album_artist)");
+    let album_version = canonical_album_version_expr("album_meta.raw_json", "source.raw_json");
     let select = &format!(
         "WITH invalidated_artist AS MATERIALIZED ( \
                     SELECT entity_id FROM identity_invalidation \
@@ -269,20 +316,24 @@ pub(super) fn apply_identity_invalidations_on_conn(
                                                  THEN 1 ELSE 0 END) > 0 \
                                   THEN MAX(NULLIF(TRIM(source.album_artist), '')) END \
                            ) AS canonical_album_artist, \
-                           MAX(source.album) AS canonical_album \
-                    FROM invalidated_album ia \
-                    CROSS JOIN track source INDEXED BY idx_track_album \
-                    LEFT JOIN artist ar_source \
-                      ON ar_source.server_id = source.server_id \
-                     AND ar_source.id = source.artist_id \
+                            MAX(source.album) AS canonical_album, \
+                            {album_version} AS canonical_album_version \
+                     FROM invalidated_album ia \
+                     CROSS JOIN track source INDEXED BY idx_track_album \
+                     LEFT JOIN artist ar_source \
+                       ON ar_source.server_id = source.server_id \
+                      AND ar_source.id = source.artist_id \
+                     LEFT JOIN album album_meta \
+                       ON album_meta.server_id = source.server_id \
+                      AND album_meta.id = source.album_id \
                     WHERE source.server_id = ?1 AND source.album_id = ia.entity_id \
                       AND source.deleted = 0 \
                     GROUP BY source.server_id, source.album_id \
                   ) \
                   SELECT t.server_id, COALESCE(t.library_id, ''), t.id, t.artist, ar.name, \
-                         t.title, t.album_artist, t.album, t.album_id, \
-                         physical_album.canonical_album_artist, physical_album.canonical_album, \
-                         t.duration_sec \
+                          t.title, t.album_artist, t.album, t.album_id, \
+                          physical_album.canonical_album_artist, physical_album.canonical_album, \
+                          physical_album.canonical_album_version, t.duration_sec \
                   FROM candidate_track candidate \
                   CROSS JOIN track t INDEXED BY sqlite_autoindex_track_1 \
                   LEFT JOIN artist ar \
@@ -348,5 +399,6 @@ fn map_source_track_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SourceTrack
         row.get(9)?,
         row.get(10)?,
         row.get(11)?,
+        row.get(12)?,
     ))
 }

--- a/src-tauri/crates/psysonic-library/src/identity/rebuild/tests/album_identity.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/rebuild/tests/album_identity.rs
@@ -207,6 +207,119 @@ fn rebuild_uses_saved_album_version_to_split_physical_releases() {
     assert_ne!(standard_key, deluxe_key);
 }
 
+#[test]
+fn rebuild_ignores_unrelated_top_level_track_version() {
+    let store = LibraryStore::open_in_memory();
+    let first = physical_album_track_row(
+        "s1", "t1", "Song", "Artist", "artist-1", "Album", "album-1", "Artist", "lib",
+    );
+    let mut second = physical_album_track_row(
+        "s1", "t2", "Song", "Artist", "artist-1", "Album", "album-2", "Artist", "lib",
+    );
+    second.raw_json = r#"{"version":"unrelated-song-value"}"#.into();
+    TrackRepository::new(&store)
+        .upsert_batch(&[first, second])
+        .unwrap();
+    store
+        .with_conn_mut("test.seed_track_version_artist", |conn| {
+            conn.execute(
+                "INSERT INTO artist (server_id, id, name, synced_at) \
+                 VALUES ('s1', 'artist-1', 'Artist', 1)",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    rebuild_cluster_keys(&store, None).unwrap();
+
+    let (first_key, second_key) = store
+        .with_read_conn(|conn| {
+            Ok((
+                read_cluster_row(conn, "s1", "t1")?.unwrap(),
+                read_cluster_row(conn, "s1", "t2")?.unwrap(),
+            ))
+        })
+        .unwrap();
+    assert_eq!(first_key.0, second_key.0);
+    assert_eq!(first_key.1, second_key.1);
+}
+
+#[test]
+fn rebuild_versions_tracks_without_physical_album_ids() {
+    let store = LibraryStore::open_in_memory();
+    let mut standard = track_row(
+        "s1",
+        "standard",
+        "Song",
+        Some("Artist"),
+        "Album",
+        Some("Artist"),
+        200,
+        "lib",
+    );
+    standard.raw_json = r#"{"albumVersion":"Standard"}"#.into();
+    let mut deluxe = standard.clone();
+    deluxe.id = "deluxe".into();
+    deluxe.raw_json = r#"{"albumVersion":"Deluxe Edition"}"#.into();
+    let mut standard_tag = standard.clone();
+    standard_tag.id = "standard-tag".into();
+    standard_tag.raw_json = r#"{"tags":{"albumversion":["","Standard"]}}"#.into();
+    TrackRepository::new(&store)
+        .upsert_batch(&[standard, deluxe, standard_tag])
+        .unwrap();
+
+    rebuild_cluster_keys(&store, None).unwrap();
+
+    let (standard_key, deluxe_key, standard_tag_key) = store
+        .with_read_conn(|conn| {
+            Ok((
+                read_cluster_row(conn, "s1", "standard")?.unwrap(),
+                read_cluster_row(conn, "s1", "deluxe")?.unwrap(),
+                read_cluster_row(conn, "s1", "standard-tag")?.unwrap(),
+            ))
+        })
+        .unwrap();
+    assert_ne!(standard_key.0, deluxe_key.0);
+    assert_ne!(standard_key.1, deluxe_key.1);
+    assert_eq!(standard_key.0, standard_tag_key.0);
+    assert_eq!(standard_key.1, standard_tag_key.1);
+}
+
+#[test]
+fn rebuild_ignores_object_shaped_albumversion_tags() {
+    let store = LibraryStore::open_in_memory();
+    let plain = track_row(
+        "s1",
+        "plain",
+        "Song",
+        Some("Artist"),
+        "Album",
+        Some("Artist"),
+        200,
+        "lib",
+    );
+    let mut malformed = plain.clone();
+    malformed.id = "malformed".into();
+    malformed.raw_json = r#"{"tags":{"albumversion":{"name":"Deluxe"}}}"#.into();
+    TrackRepository::new(&store)
+        .upsert_batch(&[plain, malformed])
+        .unwrap();
+
+    rebuild_cluster_keys(&store, None).unwrap();
+
+    let (plain_key, malformed_key) = store
+        .with_read_conn(|conn| {
+            Ok((
+                read_cluster_row(conn, "s1", "plain")?.unwrap(),
+                read_cluster_row(conn, "s1", "malformed")?.unwrap(),
+            ))
+        })
+        .unwrap();
+    assert_eq!(plain_key.0, malformed_key.0);
+    assert_eq!(plain_key.1, malformed_key.1);
+}
+
 /// The credit-matches-a-performer test is not enough on its own: plenty of
 /// libraries tag compilation tracks with the label as the track artist too.
 /// Then the label matches, and two unrelated compilations sharing a title

--- a/src-tauri/crates/psysonic-library/src/identity/rebuild/tests/album_identity.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/rebuild/tests/album_identity.rs
@@ -149,6 +149,64 @@ fn rebuild_keys_an_album_with_a_guest_track_by_its_own_credit() {
     );
 }
 
+#[test]
+fn rebuild_uses_saved_album_version_to_split_physical_releases() {
+    let store = LibraryStore::open_in_memory();
+    let standard = physical_album_track_row(
+        "s1",
+        "standard-track",
+        "Opening",
+        "Artist",
+        "artist-1",
+        "Album",
+        "album-standard",
+        "Artist",
+        "lib",
+    );
+    let mut deluxe = physical_album_track_row(
+        "s1",
+        "deluxe-track",
+        "Bonus",
+        "Artist",
+        "artist-1",
+        "Album",
+        "album-deluxe",
+        "Artist",
+        "lib",
+    );
+    deluxe.raw_json = r#"{"tags":{"albumversion":["Deluxe Edition"]}}"#.into();
+    TrackRepository::new(&store)
+        .upsert_batch(&[standard, deluxe])
+        .unwrap();
+    store
+        .with_conn_mut("test.seed_album_versions", |conn| {
+            conn.execute(
+                "INSERT INTO artist (server_id, id, name, synced_at) \
+                 VALUES ('s1', 'artist-1', 'Artist', 1)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO album (server_id, id, name, synced_at, raw_json) VALUES \
+                   ('s1', 'album-standard', 'Album', 1, '{\"version\":\"Standard\"}'), \
+                   ('s1', 'album-deluxe', 'Album', 1, '{}')",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    rebuild_cluster_keys(&store, None).unwrap();
+    let (standard_key, deluxe_key) = store
+        .with_read_conn(|conn| {
+            Ok((
+                read_cluster_row(conn, "s1", "standard-track")?.unwrap().1,
+                read_cluster_row(conn, "s1", "deluxe-track")?.unwrap().1,
+            ))
+        })
+        .unwrap();
+    assert_ne!(standard_key, deluxe_key);
+}
+
 /// The credit-matches-a-performer test is not enough on its own: plenty of
 /// libraries tag compilation tracks with the label as the track artist too.
 /// Then the label matches, and two unrelated compilations sharing a title

--- a/src-tauri/crates/psysonic-library/src/identity/rebuild/tests/incremental.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/rebuild/tests/incremental.rs
@@ -55,6 +55,44 @@ fn incremental_track_change_refreshes_the_physical_album_closure_once() {
 }
 
 #[test]
+fn incremental_album_version_change_refreshes_album_and_track_identity() {
+    let store = LibraryStore::open_in_memory();
+    store
+        .with_conn_mut("test.seed_artist", |conn| {
+            conn.execute(
+                "INSERT INTO artist(server_id, id, name, synced_at) \
+                 VALUES ('s1', 'artist-1', 'Artist', 1)",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+    let mut row = physical_album_track_row(
+        "s1", "t1", "Track", "Artist", "artist-1", "Album", "album-1", "Artist", "lib",
+    );
+    row.raw_json = r#"{"albumVersion":"Standard"}"#.into();
+    TrackRepository::new(&store)
+        .upsert_batch(&[row.clone()])
+        .unwrap();
+    rebuild_cluster_keys(&store, Some("s1")).unwrap();
+    let before = store
+        .with_read_conn(|conn| read_cluster_row(conn, "s1", "t1"))
+        .unwrap()
+        .unwrap();
+
+    row.raw_json = r#"{"albumVersion":"Deluxe Edition"}"#.into();
+    TrackRepository::new(&store).upsert_batch(&[row]).unwrap();
+    assert_eq!(ensure_cluster_keys_built(&store, "s1").unwrap(), 1);
+
+    let after = store
+        .with_read_conn(|conn| read_cluster_row(conn, "s1", "t1"))
+        .unwrap()
+        .unwrap();
+    assert_ne!(before.0, after.0);
+    assert_ne!(before.1, after.1);
+}
+
+#[test]
 fn incremental_tombstone_recomputes_remaining_album_identity() {
     let store = LibraryStore::open_in_memory();
     store

--- a/src-tauri/crates/psysonic-library/src/identity/rebuild/tests/incremental.rs
+++ b/src-tauri/crates/psysonic-library/src/identity/rebuild/tests/incremental.rs
@@ -93,6 +93,41 @@ fn incremental_album_version_change_refreshes_album_and_track_identity() {
 }
 
 #[test]
+fn incremental_album_version_change_refreshes_track_without_album_id() {
+    let store = LibraryStore::open_in_memory();
+    let mut row = track_row(
+        "s1",
+        "t1",
+        "Track",
+        Some("Artist"),
+        "Album",
+        Some("Artist"),
+        200,
+        "lib",
+    );
+    row.raw_json = r#"{"albumVersion":"Standard"}"#.into();
+    TrackRepository::new(&store)
+        .upsert_batch(&[row.clone()])
+        .unwrap();
+    rebuild_cluster_keys(&store, Some("s1")).unwrap();
+    let before = store
+        .with_read_conn(|conn| read_cluster_row(conn, "s1", "t1"))
+        .unwrap()
+        .unwrap();
+
+    row.raw_json = r#"{"albumVersion":"Deluxe Edition"}"#.into();
+    TrackRepository::new(&store).upsert_batch(&[row]).unwrap();
+    assert_eq!(ensure_cluster_keys_built(&store, "s1").unwrap(), 1);
+
+    let after = store
+        .with_read_conn(|conn| read_cluster_row(conn, "s1", "t1"))
+        .unwrap()
+        .unwrap();
+    assert_ne!(before.0, after.0);
+    assert_ne!(before.1, after.1);
+}
+
+#[test]
 fn incremental_tombstone_recomputes_remaining_album_identity() {
     let store = LibraryStore::open_in_memory();
     store

--- a/src-tauri/crates/psysonic-library/src/repos/track/ingest.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/ingest.rs
@@ -85,6 +85,140 @@ pub(super) fn sync_persisted_track_genre_rows(
     Ok(())
 }
 
+pub(super) fn invalidate_album_list_completion(
+    tx: &Transaction<'_>,
+    rows: &[TrackRow],
+) -> rusqlite::Result<()> {
+    let server_ids: HashSet<&str> = rows.iter().map(|row| row.server_id.as_str()).collect();
+    for server_id in server_ids {
+        tx.execute(
+            "INSERT INTO library_tag_state \
+             (server_id, folders_hash, last_untagged_count, completed_at) \
+             VALUES (?1, 'dirty', 0, 0) \
+             ON CONFLICT(server_id) DO UPDATE SET \
+               folders_hash = 'dirty', last_untagged_count = 0, completed_at = 0",
+            [server_id],
+        )?;
+    }
+    Ok(())
+}
+
+pub(super) fn normalize_sparse_album_version_provenance(
+    tx: &Transaction<'_>,
+    server_id: &str,
+    track_id: &str,
+    incoming_raw: &str,
+) -> rusqlite::Result<()> {
+    let Ok(serde_json::Value::Object(incoming)) = serde_json::from_str(incoming_raw) else {
+        return Ok(());
+    };
+    if incoming.contains_key("albumVersion") {
+        tx.execute(
+            "UPDATE track SET raw_json = json_remove( \
+               json_patch('{}', raw_json), \
+               '$.tags.albumversion', \
+               '$._psysonicAlbumVersionFromList', \
+               '$._psysonicAlbumVersionNeedsListRefresh' \
+             ) WHERE server_id = ?1 AND id = ?2 AND json_valid(raw_json)",
+            params![server_id, track_id],
+        )?;
+        return Ok(());
+    }
+    let albumversion = incoming
+        .get("tags")
+        .and_then(serde_json::Value::as_object)
+        .and_then(|tags| tags.get("albumversion"));
+    let Some(albumversion) = albumversion else {
+        tx.execute(
+            "UPDATE track SET raw_json = json_set( \
+               raw_json, \
+               '$.albumVersion', \
+               COALESCE( \
+                 CASE WHEN json_type( \
+                   raw_json, '$.tags.albumversion' \
+                 ) = 'text' THEN NULLIF(TRIM(json_extract( \
+                   raw_json, '$.tags.albumversion' \
+                 )), '') END, \
+                 (SELECT TRIM(tag.value) \
+                  FROM json_each( \
+                    CASE WHEN json_type( \
+                      raw_json, '$.tags.albumversion' \
+                    ) = 'array' THEN raw_json ELSE '{}' END, \
+                    '$.tags.albumversion' \
+                  ) AS tag \
+                  WHERE tag.type = 'text' \
+                    AND NULLIF(TRIM(tag.value), '') IS NOT NULL \
+                  LIMIT 1) \
+               ), \
+               '$._psysonicAlbumVersionNeedsListRefresh', json('true') \
+             ) WHERE server_id = ?1 AND id = ?2 \
+               AND json_valid(raw_json) \
+               AND json_type(raw_json, '$') = 'object' \
+               AND NULLIF(TRIM(json_extract( \
+                 raw_json, '$.albumVersion' \
+               )), '') IS NULL \
+               AND NOT COALESCE(json_extract( \
+                 raw_json, '$._psysonicAlbumVersionFromList' \
+               ) = 1, 0) \
+               AND ( \
+                 (json_type(raw_json, '$.tags.albumversion') = 'text' \
+                  AND NULLIF(TRIM(json_extract( \
+                    raw_json, '$.tags.albumversion' \
+                  )), '') IS NOT NULL) \
+                 OR EXISTS ( \
+                   SELECT 1 FROM json_each( \
+                     CASE WHEN json_type( \
+                       raw_json, '$.tags.albumversion' \
+                     ) = 'array' THEN raw_json ELSE '{}' END, \
+                     '$.tags.albumversion' \
+                   ) AS tag \
+                   WHERE tag.type = 'text' \
+                     AND NULLIF(TRIM(tag.value), '') IS NOT NULL \
+                 ) \
+               )",
+            params![server_id, track_id],
+        )?;
+        return Ok(());
+    };
+    let version = match albumversion {
+        serde_json::Value::String(version) => Some(version.as_str()),
+        serde_json::Value::Array(versions) => versions.iter().find_map(|version| {
+            version
+                .as_str()
+                .map(str::trim)
+                .filter(|version| !version.is_empty())
+        }),
+        _ => None,
+    }
+    .map(str::trim)
+    .filter(|version| !version.is_empty());
+    if let Some(version) = version {
+        tx.execute(
+            "UPDATE track SET raw_json = json_set( \
+               json_remove( \
+                 json_patch('{}', raw_json), \
+                 '$.albumVersion', \
+                 '$._psysonicAlbumVersionFromList', \
+                 '$._psysonicAlbumVersionNeedsListRefresh' \
+               ), \
+               '$.albumVersion', ?3 \
+             ) WHERE server_id = ?1 AND id = ?2 AND json_valid(raw_json)",
+            params![server_id, track_id, version],
+        )?;
+    } else {
+        tx.execute(
+            "UPDATE track SET raw_json = json_remove( \
+               json_patch('{}', raw_json), \
+               '$.albumVersion', \
+               '$._psysonicAlbumVersionFromList', \
+               '$._psysonicAlbumVersionNeedsListRefresh' \
+             ) WHERE server_id = ?1 AND id = ?2 AND json_valid(raw_json)",
+            params![server_id, track_id],
+        )?;
+    }
+    Ok(())
+}
+
 impl TrackRepository<'_> {
     /// Batch upsert without remap detection. Suitable for generic
     /// Subsonic servers where `UnstableTrackIds` is clear (track ids
@@ -226,6 +360,20 @@ impl TrackRepository<'_> {
                         }
                     }
                     drop(upsert);
+                    if sparse_payload {
+                        for row in rows {
+                            normalize_sparse_album_version_provenance(
+                                &tx,
+                                &row.server_id,
+                                &row.id,
+                                &row.raw_json,
+                            )?;
+                        }
+                        // A sparse song payload may omit album-level version data.
+                        // Invalidate completion before the best-effort list pass so
+                        // a failed request is retried on the next scheduler tick.
+                        invalidate_album_list_completion(&tx, rows)?;
+                    }
                     sync_persisted_track_genre_rows(&tx, rows)?;
                     crate::identity::mark_cluster_keys_dirty(
                         &tx,
@@ -343,7 +491,35 @@ ON CONFLICT(server_id, id) DO UPDATE SET
   synced_at            = excluded.synced_at,
   raw_json             = CASE
     WHEN ?37 != 0 AND json_valid(track.raw_json) AND json_valid(excluded.raw_json)
-      THEN json_patch(track.raw_json, excluded.raw_json)
+      THEN CASE
+        WHEN json_type(excluded.raw_json, '$.albumVersion') IS NOT NULL
+          THEN json_remove(
+            json_patch(track.raw_json, excluded.raw_json),
+            '$.tags.albumversion',
+            '$._psysonicAlbumVersionFromList',
+            '$._psysonicAlbumVersionNeedsListRefresh'
+          )
+        WHEN json_type(excluded.raw_json, '$.tags.albumversion') IS NOT NULL
+          THEN json_remove(
+            json_patch(track.raw_json, excluded.raw_json),
+            '$.albumVersion',
+            '$._psysonicAlbumVersionFromList',
+            '$._psysonicAlbumVersionNeedsListRefresh'
+          )
+        WHEN (
+          NULLIF(TRIM(json_extract(track.raw_json, '$.albumVersion')), '') IS NOT NULL
+          OR NULLIF(TRIM(json_extract(track.raw_json, '$.tags.albumversion[0]')), '') IS NOT NULL
+        ) AND NOT COALESCE(
+          json_extract(track.raw_json, '$._psysonicAlbumVersionFromList') = 1,
+          0
+        )
+          THEN json_set(
+            json_patch(track.raw_json, excluded.raw_json),
+            '$._psysonicAlbumVersionNeedsListRefresh',
+            json('true')
+          )
+        ELSE json_patch(track.raw_json, excluded.raw_json)
+      END
     ELSE excluded.raw_json
   END
 "#;
@@ -441,7 +617,35 @@ ON CONFLICT(server_id, id) DO UPDATE SET
   synced_at            = excluded.synced_at,
   raw_json             = CASE
     WHEN ?38 != 0 AND json_valid(track.raw_json) AND json_valid(excluded.raw_json)
-      THEN json_patch(track.raw_json, excluded.raw_json)
+      THEN CASE
+        WHEN json_type(excluded.raw_json, '$.albumVersion') IS NOT NULL
+          THEN json_remove(
+            json_patch(track.raw_json, excluded.raw_json),
+            '$.tags.albumversion',
+            '$._psysonicAlbumVersionFromList',
+            '$._psysonicAlbumVersionNeedsListRefresh'
+          )
+        WHEN json_type(excluded.raw_json, '$.tags.albumversion') IS NOT NULL
+          THEN json_remove(
+            json_patch(track.raw_json, excluded.raw_json),
+            '$.albumVersion',
+            '$._psysonicAlbumVersionFromList',
+            '$._psysonicAlbumVersionNeedsListRefresh'
+          )
+        WHEN (
+          NULLIF(TRIM(json_extract(track.raw_json, '$.albumVersion')), '') IS NOT NULL
+          OR NULLIF(TRIM(json_extract(track.raw_json, '$.tags.albumversion[0]')), '') IS NOT NULL
+        ) AND NOT COALESCE(
+          json_extract(track.raw_json, '$._psysonicAlbumVersionFromList') = 1,
+          0
+        )
+          THEN json_set(
+            json_patch(track.raw_json, excluded.raw_json),
+            '$._psysonicAlbumVersionNeedsListRefresh',
+            json('true')
+          )
+        ELSE json_patch(track.raw_json, excluded.raw_json)
+      END
     ELSE excluded.raw_json
   END,
   resync_gen           = excluded.resync_gen

--- a/src-tauri/crates/psysonic-library/src/repos/track/library_tagging.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/library_tagging.rs
@@ -1,6 +1,91 @@
-use rusqlite::{params, params_from_iter};
+use std::collections::HashSet;
+
+use psysonic_integration::subsonic::AlbumSummary;
+use rusqlite::{params, params_from_iter, Transaction};
 
 use super::TrackRepository;
+
+fn album_summary_version(album: &AlbumSummary) -> Option<&str> {
+    album
+        .version
+        .as_deref()
+        .map(str::trim)
+        .filter(|version| !version.is_empty())
+        .or_else(|| {
+            album.tags.as_ref().and_then(|tags| {
+                tags.albumversion
+                    .iter()
+                    .map(String::as_str)
+                    .map(str::trim)
+                    .find(|version| !version.is_empty())
+            })
+        })
+}
+
+fn normalize_page_tag_versions(
+    tx: &Transaction<'_>,
+    server_id: &str,
+    albums: &[AlbumSummary],
+) -> rusqlite::Result<()> {
+    const CHUNK: usize = 400;
+    for chunk in albums.chunks(CHUNK) {
+        let placeholders = (0..chunk.len()).map(|_| "?").collect::<Vec<_>>().join(", ");
+        let mut values = vec![rusqlite::types::Value::Text(server_id.to_string())];
+        values.extend(
+            chunk
+                .iter()
+                .map(|album| rusqlite::types::Value::Text(album.id.clone())),
+        );
+        for (table, id_column, version_path, live_filter) in [
+            ("track", "album_id", "$.albumVersion", "AND deleted = 0"),
+            ("album", "id", "$.version", ""),
+        ] {
+            let sql = format!(
+                "UPDATE {table} SET raw_json = json_set( \
+                   raw_json, '{version_path}', COALESCE( \
+                     CASE WHEN json_type( \
+                       raw_json, '$.tags.albumversion' \
+                     ) = 'text' THEN NULLIF(TRIM(json_extract( \
+                       raw_json, '$.tags.albumversion' \
+                     )), '') END, \
+                     (SELECT TRIM(tag.value) \
+                      FROM json_each( \
+                        CASE WHEN json_type( \
+                          raw_json, '$.tags.albumversion' \
+                        ) = 'array' THEN raw_json ELSE '{{}}' END, \
+                        '$.tags.albumversion' \
+                      ) AS tag \
+                      WHERE tag.type = 'text' \
+                        AND NULLIF(TRIM(tag.value), '') IS NOT NULL \
+                      LIMIT 1) \
+                   ) \
+                 ) WHERE server_id = ? AND {id_column} IN ({placeholders}) \
+                   {live_filter} \
+                   AND json_valid(raw_json) \
+                   AND json_type(raw_json, '$') = 'object' \
+                   AND NULLIF(TRIM(json_extract(raw_json, '{version_path}')), '') IS NULL \
+                   AND ( \
+                     (json_type(raw_json, '$.tags.albumversion') = 'text' \
+                      AND NULLIF(TRIM(json_extract( \
+                        raw_json, '$.tags.albumversion' \
+                      )), '') IS NOT NULL) \
+                     OR EXISTS ( \
+                       SELECT 1 FROM json_each( \
+                         CASE WHEN json_type( \
+                           raw_json, '$.tags.albumversion' \
+                         ) = 'array' THEN raw_json ELSE '{{}}' END, \
+                         '$.tags.albumversion' \
+                       ) AS tag \
+                       WHERE tag.type = 'text' \
+                         AND NULLIF(TRIM(tag.value), '') IS NOT NULL \
+                     ) \
+                   )"
+            );
+            tx.execute(&sql, params_from_iter(values.iter()))?;
+        }
+    }
+    Ok(())
+}
 
 impl TrackRepository<'_> {
     /// Live tracks with no `library_id` hot column (multi-library scope gap).
@@ -19,23 +104,272 @@ impl TrackRepository<'_> {
             .map_err(|e| e.to_string())
     }
 
-    /// Tag empty `library_id` rows by album membership. Only fills rows
-    /// where `library_id` is NULL/empty so prior tags are never clobbered.
-    pub fn tag_library_by_album_ids(
+    /// Apply one `getAlbumList2` page to tracks from a bulk song ingest.
+    /// Library ids only fill empty rows; album versions enrich raw metadata
+    /// and durably invalidate affected album identities in the same transaction.
+    pub fn apply_album_list_page(
         &self,
         server_id: &str,
         library_id: &str,
-        album_ids: &[String],
+        albums: &[AlbumSummary],
     ) -> Result<u64, String> {
-        if album_ids.is_empty() {
+        if albums.is_empty() {
             return Ok(0);
         }
         const CHUNK: usize = 400;
         let mut total = 0u64;
         self.store
-            .with_conn_mut("track.tag_library_by_album_ids", |conn| {
+            .with_conn_mut("track.apply_album_list_page", |conn| {
                 let tx = conn.transaction()?;
-                for chunk in album_ids.chunks(CHUNK) {
+                let mut version_changed_albums = HashSet::new();
+                normalize_page_tag_versions(&tx, server_id, albums)?;
+                for album in albums {
+                    let Some(version) = album_summary_version(album) else {
+                        continue;
+                    };
+                    let track_changes = tx
+                        .prepare_cached(
+                        "UPDATE track SET raw_json = json_set( \
+                           json_remove( \
+                             CASE WHEN json_valid(raw_json) THEN \
+                               CASE WHEN json_type(raw_json, '$') = 'object' \
+                                    THEN raw_json ELSE '{}' END \
+                             ELSE '{}' END, \
+                             '$.tags.albumversion', \
+                             '$._psysonicAlbumVersionNeedsListRefresh' \
+                           ), \
+                           '$.albumVersion', ?3, \
+                           '$._psysonicAlbumVersionFromList', json('true') \
+                          ) \
+                          WHERE server_id = ?1 AND album_id = ?2 AND deleted = 0 \
+                            AND ( \
+                              COALESCE( \
+                                CASE WHEN json_valid(raw_json) \
+                                           AND json_type(raw_json, '$.albumVersion') = 'text' \
+                                     THEN NULLIF(TRIM(json_extract( \
+                                       raw_json, '$.albumVersion' \
+                                     )), '') END, \
+                                CASE WHEN json_valid(raw_json) \
+                                           AND json_type( \
+                                             raw_json, '$.tags.albumversion[0]' \
+                                           ) = 'text' \
+                                     THEN NULLIF(TRIM(json_extract( \
+                                       raw_json, '$.tags.albumversion[0]' \
+                                     )), '') END \
+                              ) IS NOT ?3 \
+                              OR COALESCE(CASE WHEN json_valid(raw_json) \
+                                THEN json_extract( \
+                                  raw_json, '$._psysonicAlbumVersionNeedsListRefresh' \
+                                ) = 1 END, 0) \
+                            ) \
+                            AND ( \
+                              COALESCE( \
+                                CASE WHEN json_valid(raw_json) \
+                                           AND json_type(raw_json, '$.albumVersion') = 'text' \
+                                     THEN NULLIF(TRIM(json_extract( \
+                                       raw_json, '$.albumVersion' \
+                                     )), '') END, \
+                                CASE WHEN json_valid(raw_json) \
+                                           AND json_type( \
+                                             raw_json, '$.tags.albumversion[0]' \
+                                           ) = 'text' \
+                                     THEN NULLIF(TRIM(json_extract( \
+                                       raw_json, '$.tags.albumversion[0]' \
+                                     )), '') END \
+                              ) IS NULL \
+                              OR COALESCE(CASE WHEN json_valid(raw_json) \
+                                THEN json_extract( \
+                                  raw_json, '$._psysonicAlbumVersionFromList' \
+                                ) = 1 END, 0) \
+                              OR COALESCE(CASE WHEN json_valid(raw_json) \
+                                THEN json_extract( \
+                                  raw_json, '$._psysonicAlbumVersionNeedsListRefresh' \
+                                ) = 1 END, 0) \
+                            ) \
+                            AND NOT EXISTS ( \
+                              SELECT 1 FROM album a \
+                              WHERE a.server_id = track.server_id AND a.id = track.album_id \
+                                AND json_valid(a.raw_json) \
+                                AND COALESCE( \
+                                  CASE WHEN json_type(a.raw_json, '$.version') = 'text' \
+                                       THEN NULLIF(TRIM(json_extract( \
+                                         a.raw_json, '$.version' \
+                                       )), '') END, \
+                                  CASE WHEN json_type( \
+                                               a.raw_json, '$.tags.albumversion[0]' \
+                                             ) = 'text' \
+                                       THEN NULLIF(TRIM(json_extract( \
+                                         a.raw_json, '$.tags.albumversion[0]' \
+                                       )), '') END \
+                                ) IS NOT NULL \
+                                AND NOT COALESCE(CASE WHEN json_valid(a.raw_json) \
+                                  THEN json_extract( \
+                                    a.raw_json, '$._psysonicAlbumVersionFromList' \
+                                  ) = 1 END, 0) \
+                            )",
+                        )?
+                        .execute(params![server_id, album.id, version])?;
+                    let album_changes = tx
+                        .prepare_cached(
+                        "UPDATE album SET raw_json = json_set( \
+                           json_remove( \
+                             CASE WHEN json_valid(raw_json) THEN \
+                               CASE WHEN json_type(raw_json, '$') = 'object' \
+                                    THEN raw_json ELSE '{}' END \
+                             ELSE '{}' END, \
+                             '$.tags.albumversion' \
+                           ), \
+                           '$.version', ?3, \
+                           '$._psysonicAlbumVersionFromList', json('true') \
+                          ) \
+                          WHERE server_id = ?1 AND id = ?2 \
+                            AND COALESCE( \
+                              CASE WHEN json_valid(raw_json) \
+                                         AND json_type(raw_json, '$.version') = 'text' \
+                                   THEN NULLIF(TRIM(json_extract( \
+                                     raw_json, '$.version' \
+                                   )), '') END, \
+                              CASE WHEN json_valid(raw_json) \
+                                         AND json_type( \
+                                           raw_json, '$.tags.albumversion[0]' \
+                                         ) = 'text' \
+                                   THEN NULLIF(TRIM(json_extract( \
+                                     raw_json, '$.tags.albumversion[0]' \
+                                   )), '') END \
+                            ) IS NOT ?3 \
+                            AND ( \
+                              COALESCE( \
+                                CASE WHEN json_valid(raw_json) \
+                                           AND json_type(raw_json, '$.version') = 'text' \
+                                     THEN NULLIF(TRIM(json_extract( \
+                                       raw_json, '$.version' \
+                                     )), '') END, \
+                                CASE WHEN json_valid(raw_json) \
+                                           AND json_type( \
+                                             raw_json, '$.tags.albumversion[0]' \
+                                           ) = 'text' \
+                                     THEN NULLIF(TRIM(json_extract( \
+                                       raw_json, '$.tags.albumversion[0]' \
+                                     )), '') END \
+                              ) IS NULL \
+                              OR COALESCE(CASE WHEN json_valid(raw_json) \
+                                THEN json_extract( \
+                                  raw_json, '$._psysonicAlbumVersionFromList' \
+                                ) = 1 END, 0) \
+                            )",
+                        )?
+                        .execute(params![server_id, album.id, version])?;
+                    let changed = track_changes + album_changes;
+                    if changed > 0 {
+                        version_changed_albums.insert(album.id.clone());
+                    }
+                }
+
+                for chunk in albums
+                    .iter()
+                    .filter(|album| album_summary_version(album).is_none())
+                    .collect::<Vec<_>>()
+                    .chunks(CHUNK)
+                {
+                    let placeholders = (0..chunk.len()).map(|_| "?").collect::<Vec<_>>().join(", ");
+                    let mut lookup_params = vec![rusqlite::types::Value::Text(server_id.to_string())];
+                    lookup_params.extend(
+                        chunk
+                            .iter()
+                            .map(|album| rusqlite::types::Value::Text(album.id.clone())),
+                    );
+                    let changed_ids = {
+                        let sql = format!(
+                            "SELECT DISTINCT album_id FROM track \
+                             WHERE server_id = ? AND album_id IN ({placeholders}) \
+                                AND deleted = 0 AND json_valid(raw_json) \
+                                AND ( \
+                                  COALESCE(json_extract( \
+                                    raw_json, '$._psysonicAlbumVersionFromList' \
+                                  ) = 1, 0) \
+                                  OR COALESCE(json_extract( \
+                                    raw_json, \
+                                    '$._psysonicAlbumVersionNeedsListRefresh' \
+                                  ) = 1, 0) \
+                                ) \
+                              UNION \
+                              SELECT id FROM album \
+                              WHERE server_id = ? AND id IN ({placeholders}) \
+                                AND json_valid(raw_json) \
+                                AND COALESCE(json_extract( \
+                                  raw_json, '$._psysonicAlbumVersionFromList' \
+                                ) = 1, 0)"
+                        );
+                        let mut both_params = lookup_params.clone();
+                        both_params.extend(lookup_params.iter().cloned());
+                        let mut statement = tx.prepare(&sql)?;
+                        let ids = statement
+                            .query_map(params_from_iter(both_params.iter()), |row| row.get(0))?
+                            .collect::<rusqlite::Result<Vec<String>>>()?;
+                        ids
+                    };
+                    if changed_ids.is_empty() {
+                        continue;
+                    }
+                    let changed_placeholders = (0..changed_ids.len())
+                        .map(|_| "?")
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let mut changed_params =
+                        vec![rusqlite::types::Value::Text(server_id.to_string())];
+                    changed_params.extend(changed_ids.iter().cloned().map(Into::into));
+                    tx.execute(
+                        &format!(
+                            "UPDATE track SET raw_json = json_remove( \
+                               raw_json, \
+                               '$.albumVersion', \
+                               '$.tags.albumversion', \
+                               '$._psysonicAlbumVersionFromList', \
+                               '$._psysonicAlbumVersionNeedsListRefresh' \
+                              ) WHERE server_id = ? AND album_id IN ({changed_placeholders}) \
+                                AND deleted = 0 AND json_valid(raw_json) \
+                                AND ( \
+                                  COALESCE(json_extract( \
+                                    raw_json, '$._psysonicAlbumVersionFromList' \
+                                  ) = 1, 0) \
+                                  OR COALESCE(json_extract( \
+                                    raw_json, \
+                                    '$._psysonicAlbumVersionNeedsListRefresh' \
+                                  ) = 1, 0) \
+                                )"
+                        ),
+                        params_from_iter(changed_params.iter()),
+                    )?;
+                    tx.execute(
+                        &format!(
+                            "UPDATE album SET raw_json = json_remove( \
+                               raw_json, \
+                               '$.version', \
+                               '$.tags.albumversion', \
+                               '$._psysonicAlbumVersionFromList' \
+                              ) WHERE server_id = ? AND id IN ({changed_placeholders}) \
+                                AND json_valid(raw_json) \
+                                AND COALESCE(json_extract( \
+                                  raw_json, '$._psysonicAlbumVersionFromList' \
+                                ) = 1, 0)"
+                        ),
+                        params_from_iter(changed_params.iter()),
+                    )?;
+                    version_changed_albums.extend(changed_ids);
+                }
+                crate::identity::record_albums(
+                    &tx,
+                    version_changed_albums
+                        .iter()
+                        .map(|album_id| (server_id, album_id.as_str())),
+                )?;
+
+                if library_id.is_empty() {
+                    tx.commit()?;
+                    return Ok(total);
+                }
+                for chunk in albums.chunks(CHUNK) {
+                    let album_ids = chunk.iter().map(|album| &album.id).collect::<Vec<_>>();
                     let placeholders = (0..chunk.len()).map(|_| "?").collect::<Vec<_>>().join(", ");
                     let changed_album_sql = format!(
                         "SELECT DISTINCT album_id FROM track \
@@ -45,7 +379,7 @@ impl TrackRepository<'_> {
                     );
                     let mut changed_params: Vec<rusqlite::types::Value> =
                         vec![rusqlite::types::Value::Text(server_id.to_string())];
-                    changed_params.extend(chunk.iter().cloned().map(Into::into));
+                    changed_params.extend(album_ids.iter().map(|id| (*id).clone().into()));
                     let changed_album_ids = {
                         let mut statement = tx.prepare(&changed_album_sql)?;
                         let rows = statement

--- a/src-tauri/crates/psysonic-library/src/repos/track/remap.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/remap.rs
@@ -1,6 +1,9 @@
 use rusqlite::{params, OptionalExtension};
 
-use super::ingest::{sync_persisted_track_genre_rows, UPSERT_SQL};
+use super::ingest::{
+    invalidate_album_list_completion, normalize_sparse_album_version_provenance,
+    sync_persisted_track_genre_rows, UPSERT_SQL,
+};
 use super::retarget::retarget_track_references;
 use super::{RemapEntry, RemapStats, TrackRepository, TrackRow};
 
@@ -208,6 +211,17 @@ impl TrackRepository<'_> {
 
                 drop(upsert);
                 drop(remap_lookup);
+                if sparse_payload {
+                    for row in rows {
+                        normalize_sparse_album_version_provenance(
+                            &tx,
+                            &row.server_id,
+                            &row.id,
+                            &row.raw_json,
+                        )?;
+                    }
+                    invalidate_album_list_completion(&tx, rows)?;
+                }
                 sync_persisted_track_genre_rows(&tx, rows)?;
                 crate::identity::record_tracks(
                     &tx,
@@ -306,7 +320,31 @@ fn merge_sparse_raw_from_remap_source(
 
     tx.query_row(
         "SELECT CASE \
-           WHEN json_valid(?1) AND json_valid(?2) THEN json_patch(?1, ?2) \
+           WHEN json_valid(?1) AND json_valid(?2) THEN CASE \
+             WHEN json_type(?2, '$.albumVersion') IS NOT NULL THEN json_remove( \
+               json_patch(?1, ?2), \
+               '$.tags.albumversion', \
+               '$._psysonicAlbumVersionFromList', \
+               '$._psysonicAlbumVersionNeedsListRefresh' \
+             ) \
+             WHEN json_type(?2, '$.tags.albumversion') IS NOT NULL THEN json_remove( \
+               json_patch(?1, ?2), \
+               '$.albumVersion', \
+               '$._psysonicAlbumVersionFromList', \
+               '$._psysonicAlbumVersionNeedsListRefresh' \
+             ) \
+             WHEN ( \
+               NULLIF(TRIM(json_extract(?1, '$.albumVersion')), '') IS NOT NULL \
+               OR NULLIF(TRIM(json_extract(?1, '$.tags.albumversion[0]')), '') IS NOT NULL \
+             ) AND NOT COALESCE( \
+               json_extract(?1, '$._psysonicAlbumVersionFromList') = 1, 0 \
+             ) THEN json_set( \
+               json_patch(?1, ?2), \
+               '$._psysonicAlbumVersionNeedsListRefresh', \
+               json('true') \
+             ) \
+             ELSE json_patch(?1, ?2) \
+           END \
            ELSE ?2 \
          END",
         params![old_raw, incoming_raw],

--- a/src-tauri/crates/psysonic-library/src/repos/track/tests/library_tagging.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/tests/library_tagging.rs
@@ -1,9 +1,20 @@
+use psysonic_integration::subsonic::AlbumSummary;
 use rusqlite::params;
+use serde_json::json;
 
 use super::*;
 
+fn album_summary(id: &str, version: Option<&str>) -> AlbumSummary {
+    serde_json::from_value(json!({
+        "id": id,
+        "name": "Album",
+        "version": version,
+    }))
+    .unwrap()
+}
+
 #[test]
-fn tag_library_by_album_ids_fills_only_empty_rows_and_chunks() {
+fn apply_album_list_page_fills_only_empty_library_rows() {
     let store = LibraryStore::open_in_memory();
     let repo = TrackRepository::new(&store);
     let mut tagged = row("s1", "t1", "First");
@@ -19,7 +30,11 @@ fn tag_library_by_album_ids_fills_only_empty_rows_and_chunks() {
     crate::identity::rebuild_cluster_keys(&store, None).unwrap();
 
     let n = repo
-        .tag_library_by_album_ids("s1", "1", &["al1".into(), "al2".into()])
+        .apply_album_list_page(
+            "s1",
+            "1",
+            &[album_summary("al1", None), album_summary("al2", None)],
+        )
         .unwrap();
     assert_eq!(n, 2);
 
@@ -74,7 +89,7 @@ fn tag_library_by_album_ids_fills_only_empty_rows_and_chunks() {
 }
 
 #[test]
-fn tag_library_by_album_ids_with_no_empty_rows_is_write_free() {
+fn apply_album_list_page_with_no_new_metadata_is_write_free() {
     let store = LibraryStore::open_in_memory();
     let repo = TrackRepository::new(&store);
     let mut tagged = row("s1", "t1", "First");
@@ -87,7 +102,7 @@ fn tag_library_by_album_ids_with_no_empty_rows_is_write_free() {
         .unwrap();
 
     let changed = repo
-        .tag_library_by_album_ids("s1", "1", &["al1".into()])
+        .apply_album_list_page("s1", "1", &[album_summary("al1", None)])
         .unwrap();
 
     let after = store
@@ -95,6 +110,585 @@ fn tag_library_by_album_ids_with_no_empty_rows_is_write_free() {
         .unwrap();
     assert_eq!(changed, 0);
     assert_eq!(after, before);
+}
+
+#[test]
+fn apply_album_list_page_preserves_album_version_and_invalidates_identity() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+    let mut track = row("s1", "t1", "First");
+    track.album_id = Some("al1".into());
+    track.raw_json = r#"{"replayGain":{"trackGain":-1.2}}"#.into();
+    repo.upsert_batch(&[track]).unwrap();
+    store
+        .with_conn_mut("test.seed_album_version", |conn| {
+            conn.execute(
+                "INSERT INTO album (server_id, id, name, synced_at, raw_json) \
+                 VALUES ( \
+                   's1', 'al1', 'An Album', 1, \
+                   '{\"version\":\"Standard\",\"_psysonicAlbumVersionFromList\":true}' \
+                 )",
+                [],
+            )
+        })
+        .unwrap();
+    crate::identity::rebuild_cluster_keys(&store, None).unwrap();
+
+    repo.apply_album_list_page(
+        "s1",
+        "1",
+        &[album_summary("al1", Some("Deluxe Edition"))],
+    )
+    .unwrap();
+
+    let (raw, album_raw, pending): (String, String, i64) = store
+        .with_read_conn(|conn| {
+            Ok((
+                conn.query_row(
+                    "SELECT raw_json FROM track WHERE server_id = 's1' AND id = 't1'",
+                    [],
+                    |row| row.get(0),
+                )?,
+                conn.query_row(
+                    "SELECT raw_json FROM album WHERE server_id = 's1' AND id = 'al1'",
+                    [],
+                    |row| row.get(0),
+                )?,
+                conn.query_row(
+                    "SELECT COUNT(*) FROM identity_invalidation \
+                     WHERE server_id = 's1' AND kind = 'album' AND entity_id = 'al1'",
+                    [],
+                    |row| row.get(0),
+                )?,
+            ))
+        })
+        .unwrap();
+    let raw: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    let album_raw: serde_json::Value = serde_json::from_str(&album_raw).unwrap();
+    assert_eq!(raw["albumVersion"], json!("Deluxe Edition"));
+    assert_eq!(raw["replayGain"]["trackGain"], json!(-1.2));
+    assert_eq!(album_raw["version"], json!("Deluxe Edition"));
+    assert_eq!(pending, 1);
+
+    store
+        .with_conn_mut("test.clear_album_version_invalidation", |conn| {
+            conn.execute("DELETE FROM identity_invalidation", [])
+        })
+        .unwrap();
+    repo.apply_album_list_page("s1", "1", &[album_summary("al1", None)])
+        .unwrap();
+    let (raw, album_raw, pending): (String, String, i64) = store
+        .with_read_conn(|conn| {
+            Ok((
+                conn.query_row(
+                    "SELECT raw_json FROM track WHERE server_id = 's1' AND id = 't1'",
+                    [],
+                    |row| row.get(0),
+                )?,
+                conn.query_row(
+                    "SELECT raw_json FROM album WHERE server_id = 's1' AND id = 'al1'",
+                    [],
+                    |row| row.get(0),
+                )?,
+                conn.query_row(
+                    "SELECT COUNT(*) FROM identity_invalidation \
+                     WHERE server_id = 's1' AND kind = 'album' AND entity_id = 'al1'",
+                    [],
+                    |row| row.get(0),
+                )?,
+            ))
+        })
+        .unwrap();
+    let raw: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    let album_raw: serde_json::Value = serde_json::from_str(&album_raw).unwrap();
+    assert!(raw.get("albumVersion").is_none());
+    assert!(album_raw.get("version").is_none());
+    assert_eq!(pending, 1);
+}
+
+#[test]
+fn absent_summary_version_keeps_richer_unmarked_track_metadata() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+    let mut track = row("s1", "t1", "First");
+    track.album_id = Some("al1".into());
+    track.raw_json = r#"{"albumVersion":"From getAlbum"}"#.into();
+    repo.upsert_batch(&[track]).unwrap();
+    crate::identity::rebuild_cluster_keys(&store, None).unwrap();
+
+    repo.apply_album_list_page("s1", "1", &[album_summary("al1", None)])
+        .unwrap();
+    repo.apply_album_list_page(
+        "s1",
+        "1",
+        &[album_summary("al1", Some("Different summary"))],
+    )
+    .unwrap();
+
+    let raw: String = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT raw_json FROM track WHERE server_id = 's1' AND id = 't1'",
+                [],
+                |row| row.get(0),
+            )
+        })
+        .unwrap();
+    let raw: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(raw["albumVersion"], json!("From getAlbum"));
+}
+
+#[test]
+fn sparse_authoritative_versions_clear_list_provenance() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+    let mut top_level = row("s1", "top", "Top");
+    top_level.album_id = Some("al1".into());
+    let mut tag_only = row("s1", "tag", "Tag");
+    tag_only.album_id = Some("al2".into());
+    repo.upsert_batch(&[top_level, tag_only]).unwrap();
+    repo.apply_album_list_page(
+        "s1",
+        "1",
+        &[
+            album_summary("al1", Some("From list")),
+            album_summary("al2", Some("From list")),
+        ],
+    )
+    .unwrap();
+
+    let mut top_level = row("s1", "top", "Top");
+    top_level.album_id = Some("al1".into());
+    top_level.raw_json = json!({
+        "id": "top",
+        "albumVersion": "Authoritative top"
+    })
+    .to_string();
+    let mut tag_only = row("s1", "tag", "Tag");
+    tag_only.album_id = Some("al2".into());
+    tag_only.raw_json = json!({
+        "id": "tag",
+        "tags": { "albumversion": ["Authoritative tag"] }
+    })
+    .to_string();
+    repo.upsert_sparse_batch_initial_ingest_timed(&[top_level, tag_only], None)
+        .unwrap();
+
+    repo.apply_album_list_page(
+        "s1",
+        "1",
+        &[
+            album_summary("al1", Some("Changed list")),
+            album_summary("al2", Some("Changed list")),
+        ],
+    )
+    .unwrap();
+    repo.apply_album_list_page(
+        "s1",
+        "1",
+        &[album_summary("al1", None), album_summary("al2", None)],
+    )
+    .unwrap();
+
+    let raw = |id: &str| -> serde_json::Value {
+        let raw: String = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT raw_json FROM track WHERE server_id = 's1' AND id = ?1",
+                    [id],
+                    |row| row.get(0),
+                )
+            })
+            .unwrap();
+        serde_json::from_str(&raw).unwrap()
+    };
+    let top_level = raw("top");
+    assert_eq!(top_level["albumVersion"], json!("Authoritative top"));
+    assert!(top_level.get("_psysonicAlbumVersionFromList").is_none());
+    assert!(top_level
+        .get("_psysonicAlbumVersionNeedsListRefresh")
+        .is_none());
+    let tag_only = raw("tag");
+    assert_eq!(tag_only["albumVersion"], json!("Authoritative tag"));
+    assert_eq!(
+        tag_only["tags"]["albumversion"][0],
+        json!("Authoritative tag")
+    );
+    assert!(tag_only.get("_psysonicAlbumVersionFromList").is_none());
+}
+
+#[test]
+fn authoritative_tracks_outrank_list_marked_album_rows_for_identity() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+    let mut top_level = row("s1", "top", "Top");
+    top_level.album_id = Some("al1".into());
+    top_level.raw_json = json!({ "albumVersion": "Authoritative top" }).to_string();
+    let mut tag_only = row("s1", "tag", "Tag");
+    tag_only.album_id = Some("al2".into());
+    tag_only.raw_json = json!({
+        "tags": { "albumversion": ["Authoritative tag"] }
+    })
+    .to_string();
+    repo.upsert_batch(&[top_level, tag_only]).unwrap();
+    store
+        .with_conn_mut("test.seed_list_album_rows", |conn| {
+            for album_id in ["al1", "al2"] {
+                conn.execute(
+                    "INSERT INTO album (server_id, id, name, synced_at, raw_json) \
+                     VALUES ( \
+                       's1', ?1, 'An Album', 1, \
+                       '{\"version\":\"From list\",\"_psysonicAlbumVersionFromList\":true}' \
+                     )",
+                    [album_id],
+                )?;
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    repo.apply_album_list_page(
+        "s1",
+        "lib-1",
+        &[
+            album_summary("al1", Some("Changed list")),
+            album_summary("al2", Some("Changed list")),
+        ],
+    )
+    .unwrap();
+    crate::identity::rebuild_cluster_keys(&store, None).unwrap();
+
+    let key = |track_id: &str| -> String {
+        store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT album_key FROM cluster.track_cluster_key \
+                     WHERE server_id = 's1' AND track_id = ?1",
+                    [track_id],
+                    |row| row.get(0),
+                )
+            })
+            .unwrap()
+    };
+    assert_eq!(
+        key("top"),
+        crate::identity::build_album_key_with_version(
+            Some("The Artist"),
+            "An Album",
+            Some("Authoritative top")
+        )
+        .unwrap()
+    );
+    assert_eq!(
+        key("tag"),
+        crate::identity::build_album_key_with_version(
+            Some("The Artist"),
+            "An Album",
+            Some("Authoritative tag")
+        )
+        .unwrap()
+    );
+
+    repo.apply_album_list_page(
+        "s1",
+        "lib-1",
+        &[album_summary("al1", None), album_summary("al2", None)],
+    )
+    .unwrap();
+    crate::identity::ensure_cluster_keys_built(&store, "s1").unwrap();
+    assert_eq!(
+        key("top"),
+        crate::identity::build_album_key_with_version(
+            Some("The Artist"),
+            "An Album",
+            Some("Authoritative top")
+        )
+        .unwrap()
+    );
+    assert_eq!(
+        key("tag"),
+        crate::identity::build_album_key_with_version(
+            Some("The Artist"),
+            "An Album",
+            Some("Authoritative tag")
+        )
+        .unwrap()
+    );
+}
+
+#[test]
+fn absent_summary_preserves_unmarked_get_album_metadata() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+    let mut track = row("s1", "t1", "First");
+    track.synced_at = 10;
+    repo.upsert_batch(&[track]).unwrap();
+    store
+        .with_conn_mut("test.seed_get_album_version", |conn| {
+            conn.execute(
+                "INSERT INTO album (server_id, id, name, synced_at, raw_json) \
+                 VALUES ('s1', 'al1', 'An Album', 1, '{\"version\":\"getAlbum only\"}')",
+                [],
+            )
+        })
+        .unwrap();
+
+    repo.apply_album_list_page("s1", "lib-1", &[album_summary("al1", None)])
+        .unwrap();
+
+    let raw: String = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT raw_json FROM album WHERE server_id = 's1' AND id = 'al1'",
+                [],
+                |row| row.get(0),
+            )
+        })
+        .unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&raw).unwrap()["version"],
+        json!("getAlbum only")
+    );
+}
+
+#[test]
+fn sparse_omission_is_healed_by_the_next_album_list_page() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+    let mut track = row("s1", "t1", "First");
+    track.album_id = Some("al1".into());
+    track.raw_json = json!({
+        "tags": { "albumversion": ["", "Stale"] }
+    })
+    .to_string();
+    repo.upsert_batch(&[track]).unwrap();
+
+    let mut sparse = row("s1", "t1", "First");
+    sparse.album_id = Some("al1".into());
+    sparse.raw_json = json!({ "id": "t1", "title": "First" }).to_string();
+    repo.upsert_sparse_batch_initial_ingest_timed(&[sparse], None)
+        .unwrap();
+
+    repo.apply_album_list_page("s1", "1", &[album_summary("al1", Some("Fresh"))])
+        .unwrap();
+    let raw: String = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT raw_json FROM track WHERE server_id = 's1' AND id = 't1'",
+                [],
+                |row| row.get(0),
+            )
+        })
+        .unwrap();
+    let raw: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(raw["albumVersion"], json!("Fresh"));
+    assert_eq!(raw["_psysonicAlbumVersionFromList"], json!(true));
+    assert!(raw
+        .get("_psysonicAlbumVersionNeedsListRefresh")
+        .is_none());
+
+    repo.apply_album_list_page("s1", "1", &[album_summary("al1", None)])
+        .unwrap();
+    let raw: String = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT raw_json FROM track WHERE server_id = 's1' AND id = 't1'",
+                [],
+                |row| row.get(0),
+            )
+        })
+        .unwrap();
+    let raw: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert!(raw.get("albumVersion").is_none());
+    assert!(raw.get("_psysonicAlbumVersionFromList").is_none());
+}
+
+#[test]
+fn authoritative_top_level_clear_removes_stale_tag_fallback() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+    let mut track = row("s1", "t1", "First");
+    track.raw_json = json!({
+        "tags": { "albumversion": ["Stale tag"] },
+        "_psysonicAlbumVersionNeedsListRefresh": true
+    })
+    .to_string();
+    repo.upsert_batch(&[track]).unwrap();
+
+    let mut cleared = row("s1", "t1", "First");
+    cleared.raw_json = json!({
+        "id": "t1",
+        "albumVersion": null,
+        "tags": { "albumversion": ["Incoming fallback"] }
+    })
+    .to_string();
+    repo.upsert_sparse_batch_initial_ingest_timed(&[cleared], None)
+        .unwrap();
+
+    let raw: String = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT raw_json FROM track WHERE server_id = 's1' AND id = 't1'",
+                [],
+                |row| row.get(0),
+            )
+        })
+        .unwrap();
+    let raw: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert!(raw.get("albumVersion").is_none());
+    assert!(raw.pointer("/tags/albumversion").is_none());
+    assert!(raw
+        .get("_psysonicAlbumVersionNeedsListRefresh")
+        .is_none());
+
+    let mut newly_inserted = row("s1", "t2", "Second");
+    newly_inserted.raw_json = json!({
+        "id": "t2",
+        "albumVersion": null,
+        "tags": { "albumversion": ["Incoming fallback"] }
+    })
+    .to_string();
+    repo.upsert_sparse_batch_initial_ingest_timed(&[newly_inserted], None)
+        .unwrap();
+    let raw: String = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT raw_json FROM track WHERE server_id = 's1' AND id = 't2'",
+                [],
+                |row| row.get(0),
+            )
+        })
+        .unwrap();
+    let raw: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert!(raw.get("albumVersion").is_none());
+    assert!(raw.pointer("/tags/albumversion").is_none());
+}
+
+#[test]
+fn absent_summary_ignores_malformed_json_in_related_rows() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+    store
+        .with_conn_mut("test.seed_malformed_album_version", |conn| {
+            conn.execute(
+                "INSERT INTO track (server_id, id, title, album_id, synced_at, raw_json) \
+                 VALUES ('s1', 't1', 'Track', 'al1', 2, 'not-json')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO album (server_id, id, name, synced_at, raw_json) \
+                 VALUES ( \
+                   's1', 'al1', 'Album', 1, \
+                   '{\"version\":\"List\",\"_psysonicAlbumVersionFromList\":true}' \
+                 )",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    repo.apply_album_list_page("s1", "1", &[album_summary("al1", None)])
+        .unwrap();
+
+    let (track_raw, album_raw): (String, String) = store
+        .with_read_conn(|conn| {
+            Ok((
+                conn.query_row("SELECT raw_json FROM track WHERE id = 't1'", [], |row| {
+                    row.get(0)
+                })?,
+                conn.query_row("SELECT raw_json FROM album WHERE id = 'al1'", [], |row| {
+                    row.get(0)
+                })?,
+            ))
+        })
+        .unwrap();
+    assert_eq!(track_raw, "not-json");
+    assert!(serde_json::from_str::<serde_json::Value>(&album_raw)
+        .unwrap()
+        .get("version")
+        .is_none());
+}
+
+#[test]
+fn versioned_summary_repairs_malformed_json_without_aborting() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+    store
+        .with_conn_mut("test.seed_malformed_version_rows", |conn| {
+            conn.execute(
+                "INSERT INTO track (server_id, id, title, album_id, synced_at, raw_json) \
+                 VALUES ('s1', 't1', 'Track', 'al1', 2, 'not-json')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO track (server_id, id, title, album_id, synced_at, raw_json) \
+                 VALUES ('s1', 't2', 'Track', 'al2', 2, 'null')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO album (server_id, id, name, synced_at, raw_json) \
+                 VALUES ('s1', 'al1', 'Album', 1, 'not-json')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO album (server_id, id, name, synced_at, raw_json) \
+                 VALUES ('s1', 'al2', 'Album', 1, '[]')",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    repo.apply_album_list_page(
+        "s1",
+        "1",
+        &[
+            album_summary("al1", Some("Repaired")),
+            album_summary("al2", Some("Repaired")),
+        ],
+    )
+    .unwrap();
+
+    let (track_raw, album_raw): (String, String) = store
+        .with_read_conn(|conn| {
+            Ok((
+                conn.query_row("SELECT raw_json FROM track WHERE id = 't1'", [], |row| {
+                    row.get(0)
+                })?,
+                conn.query_row("SELECT raw_json FROM album WHERE id = 'al1'", [], |row| {
+                    row.get(0)
+                })?,
+            ))
+        })
+        .unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&track_raw).unwrap()["albumVersion"],
+        json!("Repaired")
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&album_raw).unwrap()["version"],
+        json!("Repaired")
+    );
+    let (track_raw, album_raw): (String, String) = store
+        .with_read_conn(|conn| {
+            Ok((
+                conn.query_row("SELECT raw_json FROM track WHERE id = 't2'", [], |row| {
+                    row.get(0)
+                })?,
+                conn.query_row("SELECT raw_json FROM album WHERE id = 'al2'", [], |row| {
+                    row.get(0)
+                })?,
+            ))
+        })
+        .unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&track_raw).unwrap()["albumVersion"],
+        json!("Repaired")
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&album_raw).unwrap()["version"],
+        json!("Repaired")
+    );
 }
 
 #[test]

--- a/src-tauri/crates/psysonic-library/src/repos/track/tests/remap.rs
+++ b/src-tauri/crates/psysonic-library/src/repos/track/tests/remap.rs
@@ -212,6 +212,71 @@ fn sparse_remap_merges_from_resolved_old_row_before_deleting_it() {
 }
 
 #[test]
+fn sparse_remap_invalidates_album_list_state_and_marks_preserved_version_pending() {
+    let store = LibraryStore::open_in_memory();
+    let repo = TrackRepository::new(&store);
+    let mut old = row_with_id_hash("s1", "tr_old", "deadbeef", "/path/x.flac");
+    old.raw_json = json!({
+        "id": "tr_old",
+        "tags": { "albumversion": ["", "Stale authoritative value"] }
+    })
+    .to_string();
+    repo.upsert_batch(&[old]).unwrap();
+    store
+        .with_conn_mut("test.seed_library_tag_state", |conn| {
+            conn.execute(
+                "INSERT INTO library_tag_state \
+                 (server_id, folders_hash, last_untagged_count, completed_at) \
+                 VALUES ('s1', '2|1:Main', 0, 1)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO library_tag_cursor \
+                 (server_id, folders_hash, next_folder_id, next_album_offset, updated_at) \
+                 VALUES ('s1', '2|1:Main', '1', 500, 1)",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    let mut incoming = row_with_id_hash("s1", "tr_new", "deadbeef", "/path/x.flac");
+    incoming.raw_json = json!({ "id": "tr_new", "title": "Title" }).to_string();
+    repo.upsert_sparse_batch_with_remap(&[incoming], true)
+        .unwrap();
+
+    let (state_hash, cursor_count, raw): (String, i64, String) = store
+        .with_read_conn(|conn| {
+            Ok((
+                conn.query_row(
+                    "SELECT folders_hash FROM library_tag_state WHERE server_id = 's1'",
+                    [],
+                    |row| row.get(0),
+                )?,
+                conn.query_row(
+                    "SELECT COUNT(*) FROM library_tag_cursor WHERE server_id = 's1'",
+                    [],
+                    |row| row.get(0),
+                )?,
+                conn.query_row(
+                    "SELECT raw_json FROM track WHERE server_id = 's1' AND id = 'tr_new'",
+                    [],
+                    |row| row.get(0),
+                )?,
+            ))
+        })
+        .unwrap();
+    let raw: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(state_hash, "dirty");
+    assert_eq!(cursor_count, 1);
+    assert_eq!(raw["albumVersion"], json!("Stale authoritative value"));
+    assert_eq!(
+        raw["_psysonicAlbumVersionNeedsListRefresh"],
+        json!(true)
+    );
+}
+
+#[test]
 fn sparse_remap_keeps_newer_timestamps_on_an_existing_destination() {
     let store = LibraryStore::open_in_memory();
     let repo = TrackRepository::new(&store);

--- a/src-tauri/crates/psysonic-library/src/scope_merge/tests/album_detail_identity.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge/tests/album_detail_identity.rs
@@ -215,3 +215,156 @@ fn ambiguous_physical_albums_stay_separate_but_open_all_tracks() {
     assert_eq!(detail.tracks.len(), 2);
     assert!(detail.tracks.iter().all(|track| track.server_id == "s1"));
 }
+
+#[test]
+fn album_versions_stay_separate_in_artist_and_album_detail() {
+    let store = LibraryStore::open_in_memory();
+    let mut standard = track(
+        "s1",
+        "standard-track",
+        "Opening",
+        Some("Artist"),
+        "Album",
+        "album-standard",
+        Some("artist-1"),
+        200,
+        "lib",
+        Some(2020),
+        None,
+        None,
+    );
+    standard.raw_json = r#"{"albumVersion":"Standard"}"#.into();
+    let mut deluxe = track(
+        "s1",
+        "deluxe-track",
+        "Bonus",
+        Some("Artist"),
+        "Album",
+        "album-deluxe",
+        Some("artist-1"),
+        240,
+        "lib",
+        Some(2020),
+        None,
+        None,
+    );
+    deluxe.raw_json = r#"{"albumVersion":"Deluxe Edition"}"#.into();
+    seed_and_rebuild(&store, &[standard, deluxe]);
+
+    let scopes = vec![scope_pair("s1", "lib")];
+    let artist = artist_detail(
+        &store,
+        &LibraryScopeArtistDetailRequest {
+            scopes: scopes.clone(),
+            artist_id: "artist-1".into(),
+            server_id: "s1".into(),
+            include_tracks: false,
+            top_tracks_limit: None,
+        },
+    )
+    .unwrap();
+    assert_eq!(artist.albums.len(), 2);
+
+    let standard_detail = album_detail(
+        &store,
+        &LibraryScopeAlbumDetailRequest {
+            scopes: scopes.clone(),
+            album_id: "album-standard".into(),
+            server_id: "s1".into(),
+        },
+    )
+    .unwrap();
+    assert_eq!(standard_detail.tracks.len(), 1);
+    assert_eq!(standard_detail.tracks[0].id, "standard-track");
+
+    let deluxe_detail = album_detail(
+        &store,
+        &LibraryScopeAlbumDetailRequest {
+            scopes,
+            album_id: "album-deluxe".into(),
+            server_id: "s1".into(),
+        },
+    )
+    .unwrap();
+    assert_eq!(deluxe_detail.tracks.len(), 1);
+    assert_eq!(deluxe_detail.tracks[0].id, "deluxe-track");
+}
+
+#[test]
+fn the_same_album_version_still_merges_across_servers() {
+    let store = LibraryStore::open_in_memory();
+    let mut primary = track(
+        "s1",
+        "s1-shared",
+        "Shared",
+        Some("Artist"),
+        "Album",
+        "s1-album",
+        Some("s1-artist"),
+        200,
+        "lib-a",
+        Some(2020),
+        None,
+        None,
+    );
+    primary.raw_json = r#"{"albumVersion":"Deluxe Edition"}"#.into();
+    let mut secondary_shared = track(
+        "s2",
+        "s2-shared",
+        "Shared",
+        Some("Artist"),
+        "Album (Deluxe Edition)",
+        "s2-album",
+        Some("s2-artist"),
+        200,
+        "lib-b",
+        Some(2020),
+        None,
+        None,
+    );
+    secondary_shared.raw_json = r#"{"albumVersion":"Deluxe Edition"}"#.into();
+    let mut secondary_bonus = track(
+        "s2",
+        "s2-bonus",
+        "Bonus",
+        Some("Artist"),
+        "Album (Deluxe Edition)",
+        "s2-album",
+        Some("s2-artist"),
+        240,
+        "lib-b",
+        Some(2020),
+        None,
+        None,
+    );
+    secondary_bonus.raw_json = r#"{"albumVersion":"Deluxe Edition"}"#.into();
+    seed_and_rebuild(&store, &[primary, secondary_shared, secondary_bonus]);
+
+    let scopes = vec![scope_pair("s1", "lib-a"), scope_pair("s2", "lib-b")];
+    let detail = album_detail(
+        &store,
+        &LibraryScopeAlbumDetailRequest {
+            scopes: scopes.clone(),
+            album_id: "s1-album".into(),
+            server_id: "s1".into(),
+        },
+    )
+    .unwrap();
+    assert_eq!(detail.tracks.len(), 2);
+    assert!(detail.tracks.iter().any(|track| track.id == "s1-shared"));
+    assert!(detail.tracks.iter().any(|track| track.id == "s2-bonus"));
+
+    let artist = artist_detail(
+        &store,
+        &LibraryScopeArtistDetailRequest {
+            scopes,
+            artist_id: "s1-artist".into(),
+            server_id: "s1".into(),
+            include_tracks: false,
+            top_tracks_limit: None,
+        },
+    )
+    .unwrap();
+    assert_eq!(artist.albums.len(), 1);
+    assert_eq!(artist.albums[0].song_count, Some(2));
+}

--- a/src-tauri/crates/psysonic-library/src/sync/album_metadata.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/album_metadata.rs
@@ -4,16 +4,36 @@
 //! from the server on visit. Track ingest still mirrors per-song fields.
 
 use psysonic_integration::subsonic::Album;
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 use serde_json::Value;
 
 use super::error::SyncError;
-use super::mapping::parse_iso_ms_str;
+use super::mapping::{album_version_from_tags, parse_iso_ms_str};
 use crate::store::LibraryStore;
 
 fn album_starred_at_from_raw(raw_album: &Value) -> Option<Option<i64>> {
     let starred = raw_album.get("starred")?;
     Some(starred.as_str().and_then(parse_iso_ms_str))
+}
+
+fn album_identity_version(raw_album: &Value) -> Option<String> {
+    raw_album
+        .get("version")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|version| !version.is_empty())
+        .or_else(|| album_version_from_tags(raw_album))
+        .map(str::to_string)
+}
+
+fn album_identity_state(raw_album: &Value) -> (Option<String>, bool) {
+    (
+        album_identity_version(raw_album),
+        raw_album
+            .get("_psysonicAlbumVersionFromList")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    )
 }
 
 /// Upsert `album` row metadata from a `#getAlbum` response. When `starred` is
@@ -33,13 +53,38 @@ pub(crate) fn upsert_album_from_get_album(
 ) -> Result<(), SyncError> {
     let starred_at = album_starred_at_from_raw(raw_album);
     let starred_flag = i64::from(starred_at.is_some());
-    let raw_json = raw_album.to_string();
+    let incoming_identity_version = album_identity_version(raw_album);
+    let mut stored_raw_album = raw_album.clone();
+    if let Some(object) = stored_raw_album.as_object_mut() {
+        object.remove("_psysonicAlbumVersionFromList");
+        let has_version = object
+            .get("version")
+            .and_then(Value::as_str)
+            .is_some_and(|version| !version.trim().is_empty());
+        if !has_version {
+            if let Some(version) = incoming_identity_version.as_ref() {
+                object.insert("version".to_string(), Value::String(version.clone()));
+            }
+        }
+    }
+    let raw_json = stored_raw_album.to_string();
     let song_count = album
         .song_count
         .or(Some(album.song.len() as i64));
     store
         .with_conn_mut("sync.upsert_album_metadata", |conn| {
-            conn.execute(
+            let tx = conn.transaction()?;
+            let previous_identity_version = tx
+                .query_row(
+                    "SELECT raw_json FROM album WHERE server_id = ?1 AND id = ?2",
+                    params![server_id, album.id],
+                    |row| row.get::<_, Option<String>>(0),
+                )
+                .optional()?
+                .flatten()
+                .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+                .map(|raw| album_identity_state(&raw));
+            tx.execute(
                 "INSERT INTO album (
                    server_id, id, name, artist, artist_id, song_count, duration_sec,
                    year, genre, cover_art_id, starred_at, synced_at, raw_json
@@ -73,6 +118,17 @@ pub(crate) fn upsert_album_from_get_album(
                     starred_flag,
                 ],
             )?;
+            let identity_changed = previous_identity_version.map_or_else(
+                || incoming_identity_version.is_some(),
+                |(previous_version, previous_from_list)| {
+                    previous_version.as_deref() != incoming_identity_version.as_deref()
+                        || previous_from_list
+                },
+            );
+            if identity_changed {
+                crate::identity::record_albums(&tx, [(server_id, album.id.as_str())])?;
+            }
+            tx.commit()?;
             Ok(())
         })
         .map_err(SyncError::Storage)
@@ -198,5 +254,167 @@ mod tests {
             artist_id.is_none(),
             "stale artist_id must not persist when getAlbum omits it"
         );
+    }
+
+    #[test]
+    fn upsert_records_album_identity_invalidation() {
+        let store = LibraryStore::open_in_memory();
+        let album = get_album_with_artist(Some("Artist"), Some("ar1"));
+        let raw = serde_json::json!({
+            "id": "al1",
+            "name": "Album",
+            "version": "Deluxe Edition"
+        });
+
+        upsert_album_from_get_album(&store, "s1", &album, &raw, 2).unwrap();
+
+        let pending: i64 = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT COUNT(*) FROM identity_invalidation \
+                     WHERE server_id = 's1' AND kind = 'album' AND entity_id = 'al1'",
+                    [],
+                    |row| row.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(pending, 1);
+    }
+
+    #[test]
+    fn upsert_accepts_a_legacy_null_raw_json() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn_mut("seed", |conn| {
+                conn.execute(
+                    "INSERT INTO album (server_id, id, name, synced_at, raw_json) \
+                     VALUES ('s1', 'al1', 'Old', 1, NULL)",
+                    [],
+                )
+            })
+            .unwrap();
+        let album = get_album_with_artist(Some("Artist"), Some("ar1"));
+        let raw = serde_json::json!({
+            "id": "al1",
+            "name": "Album",
+            "version": "Deluxe Edition"
+        });
+
+        upsert_album_from_get_album(&store, "s1", &album, &raw, 2).unwrap();
+
+        let stored: String = store
+            .with_read_conn(|conn| {
+                conn.query_row(
+                    "SELECT raw_json FROM album WHERE server_id = 's1' AND id = 'al1'",
+                    [],
+                    |row| row.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<Value>(&stored).unwrap()["version"],
+            serde_json::json!("Deluxe Edition")
+        );
+    }
+
+    #[test]
+    fn upsert_rolls_back_when_album_invalidation_fails() {
+        let store = LibraryStore::open_in_memory();
+        seed_album_with_artist(&store, "Old", "ar_old");
+        store
+            .with_conn_mut("test.abort_album_invalidation", |conn| {
+                conn.execute_batch(
+                    "CREATE TRIGGER abort_album_invalidation \
+                     BEFORE INSERT ON identity_invalidation \
+                     WHEN NEW.kind = 'album' \
+                     BEGIN SELECT RAISE(ABORT, 'stop'); END;",
+                )
+            })
+            .unwrap();
+        let album = get_album_with_artist(Some("New"), Some("ar_new"));
+        let raw = serde_json::json!({ "id": "al1", "name": "Album", "version": "Deluxe" });
+
+        assert!(upsert_album_from_get_album(&store, "s1", &album, &raw, 2).is_err());
+
+        let (artist, artist_id) = album_artist(&store);
+        assert_eq!(artist.as_deref(), Some("Old"));
+        assert_eq!(artist_id.as_deref(), Some("ar_old"));
+    }
+
+    #[test]
+    fn upsert_skips_identity_invalidation_when_version_is_unchanged() {
+        let store = LibraryStore::open_in_memory();
+        let album = get_album_with_artist(Some("Artist"), Some("ar1"));
+        let raw = serde_json::json!({
+            "id": "al1",
+            "name": "Album",
+            "version": "Deluxe Edition"
+        });
+        upsert_album_from_get_album(&store, "s1", &album, &raw, 1).unwrap();
+        store
+            .with_conn_mut("test.clear_invalidation", |conn| {
+                conn.execute("DELETE FROM identity_invalidation", [])
+            })
+            .unwrap();
+
+        upsert_album_from_get_album(&store, "s1", &album, &raw, 2).unwrap();
+
+        let pending: i64 = store
+            .with_read_conn(|conn| {
+                conn.query_row("SELECT COUNT(*) FROM identity_invalidation", [], |row| {
+                    row.get(0)
+                })
+            })
+            .unwrap();
+        assert_eq!(pending, 0);
+    }
+
+    #[test]
+    fn upsert_invalidates_when_same_version_becomes_authoritative() {
+        let store = LibraryStore::open_in_memory();
+        store
+            .with_conn_mut("seed", |conn| {
+                conn.execute(
+                    "INSERT INTO album (server_id, id, name, synced_at, raw_json) \
+                     VALUES ( \
+                       's1', 'al1', 'Album', 1, \
+                       '{\"version\":\"Deluxe Edition\",\
+                         \"_psysonicAlbumVersionFromList\":true}' \
+                     )",
+                    [],
+                )
+            })
+            .unwrap();
+        let album = get_album_with_artist(Some("Artist"), Some("ar1"));
+        let raw = serde_json::json!({
+            "id": "al1",
+            "name": "Album",
+            "version": "Deluxe Edition"
+        });
+
+        upsert_album_from_get_album(&store, "s1", &album, &raw, 2).unwrap();
+
+        let (pending, stored): (i64, String) = store
+            .with_read_conn(|conn| {
+                Ok((
+                    conn.query_row(
+                        "SELECT COUNT(*) FROM identity_invalidation \
+                         WHERE server_id = 's1' AND kind = 'album' AND entity_id = 'al1'",
+                        [],
+                        |row| row.get(0),
+                    )?,
+                    conn.query_row(
+                        "SELECT raw_json FROM album WHERE server_id = 's1' AND id = 'al1'",
+                        [],
+                        |row| row.get(0),
+                    )?,
+                ))
+            })
+            .unwrap();
+        assert_eq!(pending, 1);
+        assert!(serde_json::from_str::<Value>(&stored)
+            .unwrap()
+            .get("_psysonicAlbumVersionFromList")
+            .is_none());
     }
 }

--- a/src-tauri/crates/psysonic-library/src/sync/library_tag.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/library_tag.rs
@@ -1,9 +1,10 @@
-//! Post-sync library membership tagging for whole-server bulk ingests.
+//! Post-sync album-list enrichment for whole-server bulk ingests.
 //!
 //! Large Navidrome libraries ingest via OpenSubsonic `search3` without
 //! `libraryId` on each track. After a sync job completes, this pass pages
-//! `getAlbumList2` per music folder and tags `track.library_id` by album
-//! membership without re-ingesting tracks or touching `resync_gen`/tombstones.
+//! `getAlbumList2` per music folder, tags `track.library_id` by album membership,
+//! and copies album versions that the song payload omitted. It does not re-ingest
+//! tracks or touch `resync_gen`/tombstones.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -21,6 +22,8 @@ use super::progress::{Progress, ProgressEvent};
 
 const ALBUM_PAGE_SIZE: u32 = 500;
 const MAX_ALBUM_LIST_REQUESTS_PER_PASS: u32 = 8;
+const ALBUM_LIST_STATE_VERSION: &str = "2";
+const ALBUM_LIST_DIRTY_STATE: &str = "dirty";
 
 /// Summary of a library-tagging pass.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -60,6 +63,10 @@ pub(crate) fn folders_hash(folders: &[MusicFolder]) -> String {
         .join("|")
 }
 
+fn album_list_state_hash(folders: &[MusicFolder]) -> String {
+    format!("{ALBUM_LIST_STATE_VERSION}|{}", folders_hash(folders))
+}
+
 /// Skip when nothing is untagged, or a prior pass made no progress on the
 /// same folder set (avoids re-paging album-less tracks forever).
 pub(crate) fn should_run_tagging_pass(
@@ -67,12 +74,16 @@ pub(crate) fn should_run_tagging_pass(
     prior: Option<&TagStateRow>,
     cursor_active: bool,
     folders_hash: &str,
+    force_album_metadata: bool,
 ) -> bool {
-    if untagged == 0 {
-        return false;
-    }
     if cursor_active {
         return true;
+    }
+    if force_album_metadata {
+        return true;
+    }
+    if untagged == 0 {
+        return prior.is_none_or(|state| state.folders_hash != folders_hash);
     }
     if let Some(p) = prior {
         if p.last_untagged_count == untagged && p.folders_hash == folders_hash {
@@ -184,6 +195,30 @@ fn write_tag_completion(
         .map_err(|e| SyncError::Storage(e.to_string()))
 }
 
+fn clear_tag_cursor(store: &LibraryStore, server_id: &str) -> Result<(), SyncError> {
+    store
+        .with_conn_mut("library_tag.clear_cursor", |conn| {
+            conn.execute(
+                "DELETE FROM library_tag_cursor WHERE server_id = ?1",
+                rusqlite::params![server_id],
+            )
+        })
+        .map_err(|e| SyncError::Storage(e.to_string()))?;
+    Ok(())
+}
+
+fn clear_tag_state(store: &LibraryStore, server_id: &str) -> Result<(), SyncError> {
+    store
+        .with_conn_mut("library_tag.clear_state", |conn| {
+            conn.execute(
+                "DELETE FROM library_tag_state WHERE server_id = ?1",
+                rusqlite::params![server_id],
+            )
+        })
+        .map_err(|e| SyncError::Storage(e.to_string()))?;
+    Ok(())
+}
+
 fn check_cancel(cancel: Option<&Arc<AtomicBool>>) -> Result<(), SyncError> {
     if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
         return Err(SyncError::Cancelled);
@@ -192,11 +227,13 @@ fn check_cancel(cancel: Option<&Arc<AtomicBool>>) -> Result<(), SyncError> {
 }
 
 /// Best-effort post-sync pass: enumerate music folders, page scoped album
-/// lists, and fill empty `track.library_id` values by album membership.
+/// lists, fill empty `track.library_id` values, and preserve album versions
+/// omitted by `search3` song rows.
 ///
-/// When `require_untagged` is true (delta sync), returns immediately if no
-/// untagged tracks exist. Initial sync passes `false` so the gating logic
-/// still runs after folder enumeration.
+/// When `require_untagged` is true (an unchanged delta), returns immediately
+/// if membership and the versioned metadata cursor are already complete. A
+/// changed delta and initial sync pass `false` so album versions are refreshed
+/// even when every track already has a library id.
 pub async fn tag_library_membership(
     store: &LibraryStore,
     subsonic: &SubsonicClient,
@@ -210,11 +247,15 @@ pub async fn tag_library_membership(
         .count_untagged_tracks(server_id)
         .map_err(SyncError::Storage)?;
     let cursor = read_tag_cursor(store, server_id)?;
+    let prior = read_tag_state(store, server_id)?;
 
-    if require_untagged && untagged == 0 {
-        if let Some(cursor) = cursor.as_ref() {
-            write_tag_completion(store, server_id, &cursor.folders_hash, 0)?;
-        }
+    if require_untagged
+        && untagged == 0
+        && cursor.is_none()
+        && prior
+            .as_ref()
+            .is_some_and(|state| state.folders_hash.starts_with("2|"))
+    {
         return Ok(TagReport {
             folders_processed: 0,
             albums_processed: 0,
@@ -230,6 +271,12 @@ pub async fn tag_library_membership(
         .await
         .map_err(SyncError::from)?;
     if folders.is_empty() {
+        write_tag_completion(
+            store,
+            server_id,
+            &album_list_state_hash(&folders),
+            untagged,
+        )?;
         return Ok(TagReport {
             folders_processed: 0,
             albums_processed: 0,
@@ -242,10 +289,22 @@ pub async fn tag_library_membership(
 
     let mut folders = folders;
     folders.sort_by(|a, b| a.id.cmp(&b.id));
-    let hash = folders_hash(&folders);
-    let prior = read_tag_state(store, server_id)?;
+    let hash = album_list_state_hash(&folders);
     let active_cursor = cursor.as_ref().filter(|cursor| cursor.folders_hash == hash);
-    if !should_run_tagging_pass(untagged, prior.as_ref(), active_cursor.is_some(), &hash) {
+    let restart_after_active_dirty = active_cursor.is_some()
+        && prior
+            .as_ref()
+            .is_some_and(|state| state.folders_hash == ALBUM_LIST_DIRTY_STATE);
+    if cursor.is_some() && active_cursor.is_none() {
+        clear_tag_cursor(store, server_id)?;
+    }
+    if !should_run_tagging_pass(
+        untagged,
+        prior.as_ref(),
+        active_cursor.is_some(),
+        &hash,
+        !require_untagged,
+    ) {
         return Ok(TagReport {
             folders_processed: 0,
             albums_processed: 0,
@@ -305,10 +364,9 @@ pub async fn tag_library_membership(
                 }
                 break;
             }
-            let album_ids: Vec<String> = page.iter().map(|a| a.id.clone()).collect();
-            albums_processed += album_ids.len() as u32;
+            albums_processed += page.len() as u32;
             let tagged = tracks
-                .tag_library_by_album_ids(server_id, &folder.id, &album_ids)
+                .apply_album_list_page(server_id, &folder.id, &page)
                 .map_err(SyncError::Storage)?;
             tracks_tagged += tagged;
 
@@ -321,7 +379,13 @@ pub async fn tag_library_membership(
         .count_untagged_tracks(server_id)
         .map_err(SyncError::Storage)?;
     if completed {
-        write_tag_completion(store, server_id, &hash, untagged_remaining)?;
+        if restart_after_active_dirty {
+            write_tag_cursor(store, server_id, &hash, &folders[0].id, 0)?;
+            clear_tag_state(store, server_id)?;
+            completed = false;
+        } else {
+            write_tag_completion(store, server_id, &hash, untagged_remaining)?;
+        }
     }
 
     Ok(TagReport {

--- a/src-tauri/crates/psysonic-library/src/sync/library_tag/tests.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/library_tag/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::repos::{TrackRepository, TrackRow};
 use crate::store::LibraryStore;
 use psysonic_integration::subsonic::{SubsonicClient, SubsonicCredentials};
-use serde_json::json;
+use serde_json::{json, Value};
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -110,14 +110,60 @@ fn folders_hash_is_order_independent() {
 #[test]
 fn should_run_tagging_pass_gates_no_progress() {
     let prior = TagStateRow {
-        folders_hash: "1:Main".into(),
+        folders_hash: "2|1:Main".into(),
         last_untagged_count: 5,
     };
-    assert!(!should_run_tagging_pass(0, None, false, "1:Main"));
-    assert!(!should_run_tagging_pass(5, Some(&prior), false, "1:Main"));
-    assert!(should_run_tagging_pass(5, Some(&prior), true, "1:Main"));
-    assert!(should_run_tagging_pass(4, Some(&prior), false, "1:Main"));
-    assert!(should_run_tagging_pass(5, Some(&prior), false, "1:Other"));
+    let completed = TagStateRow {
+        folders_hash: "2|1:Main".into(),
+        last_untagged_count: 0,
+    };
+    let legacy = TagStateRow {
+        folders_hash: "1:Main".into(),
+        last_untagged_count: 0,
+    };
+    assert!(should_run_tagging_pass(0, None, false, "2|1:Main", true));
+    assert!(!should_run_tagging_pass(
+        0,
+        Some(&completed),
+        false,
+        "2|1:Main",
+        false
+    ));
+    assert!(should_run_tagging_pass(
+        0,
+        Some(&legacy),
+        false,
+        "2|1:Main",
+        false
+    ));
+    assert!(should_run_tagging_pass(
+        5,
+        Some(&prior),
+        false,
+        "2|1:Main",
+        true
+    ));
+    assert!(should_run_tagging_pass(
+        5,
+        Some(&prior),
+        true,
+        "2|1:Main",
+        false
+    ));
+    assert!(should_run_tagging_pass(
+        4,
+        Some(&prior),
+        false,
+        "2|1:Main",
+        false
+    ));
+    assert!(should_run_tagging_pass(
+        5,
+        Some(&prior),
+        false,
+        "2|1:Other",
+        false
+    ));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -224,6 +270,230 @@ async fn tag_library_membership_tags_by_album_and_respects_prior_tags() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn empty_folder_list_persists_completion_and_skips_the_next_tick() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/getMusicFolders.view"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": {
+                "status": "ok",
+                "musicFolders": { "musicFolder": [] }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let store = LibraryStore::open_in_memory();
+    let client = test_client(&server.uri());
+    let progress = Arc::new(super::super::progress::NoopProgress);
+
+    let first = tag_library_membership(
+        &store,
+        &client,
+        "srv",
+        None,
+        progress.clone(),
+        false,
+    )
+    .await
+    .unwrap();
+    assert!(first.skipped);
+    assert_eq!(
+        read_tag_state(&store, "srv")
+            .unwrap()
+            .unwrap()
+            .folders_hash,
+        "2|"
+    );
+
+    let second = tag_library_membership(&store, &client, "srv", None, progress, true)
+        .await
+        .unwrap();
+    assert!(second.skipped);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn initial_tag_pass_enriches_search3_tracks_with_album_versions() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/getMusicFolders.view"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": {
+                "status": "ok",
+                "musicFolders": { "musicFolder": { "id": 1, "name": "Main" } }
+            }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/getAlbumList2.view"))
+        .and(query_param("musicFolderId", "1"))
+        .and(query_param("offset", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": {
+                "status": "ok",
+                "albumList2": {
+                    "album": [
+                        { "id": "standard", "name": "Album", "version": "Standard" },
+                        {
+                            "id": "deluxe",
+                            "name": "Album",
+                            "tags": { "albumversion": ["Deluxe Edition"] }
+                        }
+                    ]
+                }
+            }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/getAlbumList2.view"))
+        .and(query_param("musicFolderId", "1"))
+        .and(query_param("offset", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": { "status": "ok", "albumList2": { "album": [] } }
+        })))
+        .mount(&server)
+        .await;
+
+    let store = LibraryStore::open_in_memory();
+    let mut standard = track_row("srv", "standard-track", "standard");
+    standard.album = "Album".into();
+    standard.album_artist = Some("Artist".into());
+    standard.artist = Some("Artist".into());
+    standard.library_id = Some("1".into());
+    let mut deluxe = track_row("srv", "deluxe-track", "deluxe");
+    deluxe.album = "Album".into();
+    deluxe.album_artist = Some("Artist".into());
+    deluxe.artist = Some("Artist".into());
+    deluxe.library_id = Some("1".into());
+    TrackRepository::new(&store)
+        .upsert_batch(&[standard, deluxe])
+        .unwrap();
+
+    let report = tag_library_membership(
+        &store,
+        &test_client(&server.uri()),
+        "srv",
+        None,
+        Arc::new(super::super::progress::NoopProgress),
+        false,
+    )
+    .await
+    .unwrap();
+    assert!(!report.skipped);
+    assert_eq!(report.tracks_tagged, 0);
+    crate::identity::ensure_cluster_keys_built(&store, "srv").unwrap();
+
+    let (standard_key, deluxe_key): (String, String) = store
+        .with_read_conn(|conn| {
+            Ok((
+                conn.query_row(
+                    "SELECT album_key FROM cluster.track_cluster_key \
+                     WHERE server_id = 'srv' AND track_id = 'standard-track'",
+                    [],
+                    |row| row.get(0),
+                )?,
+                conn.query_row(
+                    "SELECT album_key FROM cluster.track_cluster_key \
+                     WHERE server_id = 'srv' AND track_id = 'deluxe-track'",
+                    [],
+                    |row| row.get(0),
+                )?,
+            ))
+        })
+        .unwrap();
+    assert_ne!(standard_key, deluxe_key);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pending_version_refresh_retries_after_a_completed_tag_pass() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/getMusicFolders.view"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": {
+                "status": "ok",
+                "musicFolders": { "musicFolder": { "id": 1, "name": "Main" } }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/getAlbumList2.view"))
+        .and(query_param("musicFolderId", "1"))
+        .and(query_param("offset", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": {
+                "status": "ok",
+                "albumList2": {
+                    "album": [{ "id": "album-1", "name": "Album", "version": "Fresh" }]
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/getAlbumList2.view"))
+        .and(query_param("musicFolderId", "1"))
+        .and(query_param("offset", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": { "status": "ok", "albumList2": { "album": [] } }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let store = LibraryStore::open_in_memory();
+    let mut track = track_row("srv", "tagged", "album-1");
+    track.library_id = Some("1".into());
+    track.raw_json = json!({ "albumVersion": "Stale" }).to_string();
+    TrackRepository::new(&store).upsert_batch(&[track]).unwrap();
+    write_tag_completion(&store, "srv", "2|1:Main", 0).unwrap();
+    let mut sparse = track_row("srv", "tagged", "album-1");
+    sparse.library_id = Some("1".into());
+    sparse.raw_json = json!({ "id": "tagged", "title": "Track" }).to_string();
+    TrackRepository::new(&store)
+        .upsert_sparse_batch_initial_ingest_timed(&[sparse], None)
+        .unwrap();
+    assert_eq!(
+        read_tag_state(&store, "srv")
+            .unwrap()
+            .unwrap()
+            .folders_hash,
+        ALBUM_LIST_DIRTY_STATE
+    );
+
+    let report = tag_library_membership(
+        &store,
+        &test_client(&server.uri()),
+        "srv",
+        None,
+        Arc::new(super::super::progress::NoopProgress),
+        true,
+    )
+    .await
+    .unwrap();
+
+    assert!(!report.skipped);
+    let raw: String = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT raw_json FROM track WHERE server_id = 'srv' AND id = 'tagged'",
+                [],
+                |row| row.get(0),
+            )
+        })
+        .unwrap();
+    assert_eq!(
+        serde_json::from_str::<Value>(&raw).unwrap()["albumVersion"],
+        json!("Fresh")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn tag_library_membership_skips_when_no_progress_possible() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
@@ -241,7 +511,7 @@ async fn tag_library_membership_skips_when_no_progress_possible() {
     TrackRepository::new(&store)
         .upsert_batch(&[track_row("srv", "orphan", "no-album")])
         .unwrap();
-    write_tag_completion(&store, "srv", "1:Main", 1).unwrap();
+    write_tag_completion(&store, "srv", "2|1:Main", 1).unwrap();
 
     let report = tag_library_membership(
         &store,
@@ -249,7 +519,7 @@ async fn tag_library_membership_skips_when_no_progress_possible() {
         "srv",
         None,
         Arc::new(super::super::progress::NoopProgress),
-        false,
+        true,
     )
     .await
     .unwrap();
@@ -350,14 +620,14 @@ async fn tag_library_membership_resumes_from_persisted_page_cursor() {
         .unwrap();
     assert_eq!(cursor_count, 0);
 
-    let third = tag_library_membership(&store, &client, "srv", None, progress, false)
+    let third = tag_library_membership(&store, &client, "srv", None, progress, true)
         .await
         .unwrap();
     assert!(third.skipped);
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn tag_library_membership_finalizes_cursor_when_no_untagged_tracks_remain() {
+async fn tag_library_membership_finishes_metadata_cursor_when_tracks_are_tagged() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/rest/getMusicFolders.view"))
@@ -367,10 +637,21 @@ async fn tag_library_membership_finalizes_cursor_when_no_untagged_tracks_remain(
                 "musicFolders": { "musicFolder": { "id": 1, "name": "Main" } }
             }
         })))
-        .expect(1)
+        .expect(2)
         .mount(&server)
         .await;
     mount_bounded_full_album_pages(&server).await;
+    let resume_offset = MAX_ALBUM_LIST_REQUESTS_PER_PASS * ALBUM_PAGE_SIZE;
+    Mock::given(method("GET"))
+        .and(path("/rest/getAlbumList2.view"))
+        .and(query_param("musicFolderId", "1"))
+        .and(query_param("offset", resume_offset.to_string()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": { "status": "ok", "albumList2": { "album": [] } }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
 
     let store = LibraryStore::open_in_memory();
     TrackRepository::new(&store)
@@ -397,12 +678,151 @@ async fn tag_library_membership_finalizes_cursor_when_no_untagged_tracks_remain(
     let second = tag_library_membership(&store, &client, "srv", None, progress, true)
         .await
         .unwrap();
-    assert!(second.skipped);
+    assert!(!second.skipped);
     assert!(second.completed);
     assert_eq!(second.untagged_remaining, 0);
     assert!(read_tag_cursor(&store, "srv").unwrap().is_none());
 
     let completion = read_tag_state(&store, "srv").unwrap().unwrap();
-    assert_eq!(completion.folders_hash, "1:Main");
+    assert_eq!(completion.folders_hash, "2|1:Main");
     assert_eq!(completion.last_untagged_count, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dirty_active_cursor_finishes_then_restarts_from_the_first_page() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/getMusicFolders.view"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": {
+                "status": "ok",
+                "musicFolders": { "musicFolder": { "id": 1, "name": "Main" } }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/getAlbumList2.view"))
+        .and(query_param("musicFolderId", "1"))
+        .and(query_param("offset", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": { "status": "ok", "albumList2": { "album": [] } }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let store = LibraryStore::open_in_memory();
+    write_tag_cursor(&store, "srv", "2|1:Main", "1", 1).unwrap();
+    store
+        .with_conn_mut("test.mark_album_list_dirty", |conn| {
+            conn.execute(
+                "INSERT INTO library_tag_state \
+                 (server_id, folders_hash, last_untagged_count, completed_at) \
+                 VALUES ('srv', 'dirty', 0, 0)",
+                [],
+            )
+        })
+        .unwrap();
+
+    let report = tag_library_membership(
+        &store,
+        &test_client(&server.uri()),
+        "srv",
+        None,
+        Arc::new(super::super::progress::NoopProgress),
+        true,
+    )
+    .await
+    .unwrap();
+
+    assert!(!report.completed);
+    let cursor = read_tag_cursor(&store, "srv").unwrap().unwrap();
+    assert_eq!(cursor.next_album_offset, 0);
+    assert_eq!(cursor.next_folder_id, "1");
+    assert!(read_tag_state(&store, "srv").unwrap().is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tag_library_membership_restarts_a_legacy_cursor_from_the_first_page() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/getMusicFolders.view"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": {
+                "status": "ok",
+                "musicFolders": { "musicFolder": { "id": 1, "name": "Main" } }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/getAlbumList2.view"))
+        .and(query_param("musicFolderId", "1"))
+        .and(query_param("offset", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": {
+                "status": "ok",
+                "albumList2": {
+                    "album": [{ "id": "album-1", "name": "Album", "version": "Deluxe" }]
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/rest/getAlbumList2.view"))
+        .and(query_param("musicFolderId", "1"))
+        .and(query_param("offset", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": { "status": "ok", "albumList2": { "album": [] } }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let store = LibraryStore::open_in_memory();
+    let mut track = track_row("srv", "tagged", "album-1");
+    track.library_id = Some("1".into());
+    TrackRepository::new(&store).upsert_batch(&[track]).unwrap();
+    write_tag_completion(&store, "srv", "1:Main", 0).unwrap();
+    write_tag_cursor(&store, "srv", "1:Old", "1", 500).unwrap();
+
+    let report = tag_library_membership(
+        &store,
+        &test_client(&server.uri()),
+        "srv",
+        None,
+        Arc::new(super::super::progress::NoopProgress),
+        true,
+    )
+    .await
+    .unwrap();
+
+    assert!(!report.skipped);
+    assert!(report.completed);
+    assert!(read_tag_cursor(&store, "srv").unwrap().is_none());
+    assert_eq!(
+        read_tag_state(&store, "srv")
+            .unwrap()
+            .unwrap()
+            .folders_hash,
+        "2|1:Main"
+    );
+    let raw: String = store
+        .with_read_conn(|conn| {
+            conn.query_row(
+                "SELECT raw_json FROM track WHERE server_id = 'srv' AND id = 'tagged'",
+                [],
+                |row| row.get(0),
+            )
+        })
+        .unwrap();
+    assert_eq!(
+        serde_json::from_str::<Value>(&raw).unwrap()["albumVersion"],
+        json!("Deluxe")
+    );
 }

--- a/src-tauri/crates/psysonic-library/src/sync/mapping.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping.rs
@@ -22,6 +22,7 @@ const ALBUM_TO_TRACK_RAW_KEYS: &[(&str, &str)] = &[
     ("compilation", "compilation"),
     ("isCompilation", "isCompilation"),
     ("releaseTypes", "releaseTypes"),
+    ("version", "albumVersion"),
     ("artists", "albumArtists"),
     ("albumArtists", "albumArtists"),
     ("displayArtist", "displayAlbumArtist"),

--- a/src-tauri/crates/psysonic-library/src/sync/mapping.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping.rs
@@ -29,6 +29,40 @@ const ALBUM_TO_TRACK_RAW_KEYS: &[(&str, &str)] = &[
     ("displayAlbumArtist", "displayAlbumArtist"),
 ];
 
+pub(crate) fn album_version_from_tags(raw: &Value) -> Option<&str> {
+    match raw.pointer("/tags/albumversion") {
+        Some(Value::String(version)) => {
+            Some(str::trim(version.as_str())).filter(|version| !version.is_empty())
+        }
+        Some(Value::Array(versions)) => versions.iter().find_map(|version| {
+            version
+                .as_str()
+                .map(str::trim)
+                .filter(|version| !version.is_empty())
+        }),
+        _ => None,
+    }
+}
+
+fn track_raw_json(raw: &Value) -> String {
+    let needs_normalized_version = raw
+        .as_object()
+        .is_some_and(|object| !object.contains_key("albumVersion"));
+    if needs_normalized_version {
+        if let Some(version) = album_version_from_tags(raw) {
+            let mut normalized = raw.clone();
+            if let Some(object) = normalized.as_object_mut() {
+                object.insert(
+                    "albumVersion".to_string(),
+                    Value::String(version.to_string()),
+                );
+            }
+            return normalized.to_string();
+        }
+    }
+    raw.to_string()
+}
+
 /// Copy album-level OpenSubsonic fields onto each track `raw_json` during S2/getAlbum
 /// ingest, so track-grouped album browse can filter compilations and the album header
 /// can show individually linkable artists instead of one joined credit string.
@@ -44,9 +78,18 @@ const ALBUM_TO_TRACK_RAW_KEYS: &[(&str, &str)] = &[
 /// authoritative ids sitting in the same `getAlbum` response and push the UI back onto
 /// name matching.
 pub fn merge_album_open_subsonic_track_raw(raw_album: &Value, raw_song: &mut Value) {
+    let track_tag_version = album_version_from_tags(raw_song).map(str::to_string);
     let Some(obj) = raw_song.as_object_mut() else {
         return;
     };
+    if !obj
+        .get("albumVersion")
+        .is_some_and(is_usable_participant_value)
+    {
+        if let Some(version) = track_tag_version {
+            obj.insert("albumVersion".to_string(), Value::String(version));
+        }
+    }
     for (album_key, track_key) in ALBUM_TO_TRACK_RAW_KEYS {
         if obj.get(*track_key).is_some_and(is_usable_participant_value) {
             continue;
@@ -55,6 +98,17 @@ pub fn merge_album_open_subsonic_track_raw(raw_album: &Value, raw_song: &mut Val
             if is_usable_participant_value(v) {
                 obj.insert((*track_key).to_string(), v.clone());
             }
+        }
+    }
+    if !obj
+        .get("albumVersion")
+        .is_some_and(is_usable_participant_value)
+    {
+        if let Some(version) = album_version_from_tags(raw_album) {
+            obj.insert(
+                "albumVersion".to_string(),
+                Value::String(version.to_string()),
+            );
         }
     }
 }
@@ -194,7 +248,7 @@ pub fn subsonic_song_to_track_row(
         server_created_at: parse_raw_iso_ms(raw_value, &["created", "createdAt"]),
         deleted: false,
         synced_at,
-        raw_json: raw_value.to_string(),
+        raw_json: track_raw_json(raw_value),
     }
 }
 
@@ -329,7 +383,7 @@ pub fn navidrome_song_to_track_row(
         server_created_at: parse_raw_iso_ms(raw, &["createdAt"]),
         deleted: false,
         synced_at,
-        raw_json: raw.to_string(),
+        raw_json: track_raw_json(raw),
     })
 }
 

--- a/src-tauri/crates/psysonic-library/src/sync/mapping/tests/album_raw.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping/tests/album_raw.rs
@@ -16,6 +16,30 @@ fn merge_album_open_subsonic_track_raw_copies_album_flags() {
 }
 
 #[test]
+fn merge_album_open_subsonic_track_raw_copies_tag_only_album_version() {
+    let album = json!({ "tags": { "albumversion": ["", "Deluxe Edition"] } });
+    let mut song = json!({ "id": "tr_1", "title": "A" });
+
+    merge_album_open_subsonic_track_raw(&album, &mut song);
+
+    assert_eq!(song.get("albumVersion"), Some(&json!("Deluxe Edition")));
+}
+
+#[test]
+fn merge_album_open_subsonic_track_raw_keeps_the_song_tag_version() {
+    let album = json!({ "version": "Album edition" });
+    let mut song = json!({
+        "id": "tr_1",
+        "title": "A",
+        "tags": { "albumversion": ["", "Track edition"] }
+    });
+
+    merge_album_open_subsonic_track_raw(&album, &mut song);
+
+    assert_eq!(song.get("albumVersion"), Some(&json!("Track edition")));
+}
+
+#[test]
 fn merge_album_open_subsonic_track_raw_maps_album_participants_to_album_fields() {
     let album = json!({
         "artists": [{ "id": "ar1", "name": "Ice Nine Kills" }, { "id": "ar2", "name": "Shavo" }],

--- a/src-tauri/crates/psysonic-library/src/sync/mapping/tests/album_raw.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping/tests/album_raw.rs
@@ -3,11 +3,16 @@ use serde_json::json;
 
 #[test]
 fn merge_album_open_subsonic_track_raw_copies_album_flags() {
-    let album = json!({ "compilation": true, "releaseTypes": ["Compilation"] });
+    let album = json!({
+        "compilation": true,
+        "releaseTypes": ["Compilation"],
+        "version": "Deluxe Edition",
+    });
     let mut song = json!({ "id": "tr_1", "title": "A" });
     merge_album_open_subsonic_track_raw(&album, &mut song);
     assert_eq!(song.get("compilation"), Some(&json!(true)));
     assert_eq!(song.get("releaseTypes"), Some(&json!(["Compilation"])));
+    assert_eq!(song.get("albumVersion"), Some(&json!("Deluxe Edition")));
 }
 
 #[test]

--- a/src-tauri/crates/psysonic-library/src/sync/scheduler.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/scheduler.rs
@@ -325,7 +325,7 @@ impl<'a> BackgroundScheduler<'a> {
             &self.server_id,
             self.cancel.clone(),
             Arc::clone(&self.progress),
-            true,
+            delta_report.up_to_date,
         )
         .await;
 

--- a/src/features/album/utils/hotNewReleases.test.ts
+++ b/src/features/album/utils/hotNewReleases.test.ts
@@ -73,11 +73,16 @@ describe('hot New Releases overlay', () => {
 
   it('requests each selected library and keeps only recent valid dates', async () => {
     const now = Date.parse('2026-07-16T12:00:00Z');
-    getAlbumListForServer.mockImplementation(async (serverId: string) => [
-      album(`${serverId}-fresh`, '2026-07-16T11:00:00Z', serverId),
-      album(`${serverId}-old`, '2026-07-12T11:00:00Z', serverId),
-      album(`${serverId}-invalid`, 'not-a-date', serverId),
-    ]);
+    getAlbumListForServer.mockImplementation(async (serverId: string) => {
+      const fresh = album(`${serverId}-fresh`, '2026-07-16T11:00:00Z', serverId);
+      if (serverId === 's1') fresh.version = 'Deluxe Edition';
+      else fresh.tags = { albumversion: ['[Remaster]'] };
+      return [
+        fresh,
+        album(`${serverId}-old`, '2026-07-12T11:00:00Z', serverId),
+        album(`${serverId}-invalid`, 'not-a-date', serverId),
+      ];
+    });
     libraryResolveAlbumOverlay.mockImplementation(async ({ albums }: { albums: SubsonicAlbum[] }) => (
       albums.map((_item, group) => ({
         group,
@@ -103,10 +108,48 @@ describe('hot New Releases overlay', () => {
         { serverId: 's2', libraryId: 'l2' },
       ],
       albums: [
-        { serverId: 's1', id: 's1-fresh', name: 's1-fresh', artist: 'Artist' },
-        { serverId: 's2', id: 's2-fresh', name: 's2-fresh', artist: 'Artist' },
+        {
+          serverId: 's1',
+          id: 's1-fresh',
+          name: 's1-fresh',
+          artist: 'Artist',
+          version: 'Deluxe Edition',
+        },
+        {
+          serverId: 's2', id: 's2-fresh', name: 's2-fresh', artist: 'Artist', version: '[Remaster]',
+        },
       ],
     });
     expect(result.map(item => item.album.id).sort()).toEqual(['s1-fresh', 's2-fresh']);
+  });
+
+  it('normalizes scalar and mixed albumversion tags without dropping the overlay', async () => {
+    const now = Date.parse('2026-07-16T12:00:00Z');
+    const variants = [
+      { id: 'scalar', tags: { albumversion: 'Deluxe' }, expected: 'Deluxe' },
+      { id: 'mixed', tags: { albumversion: [null, 7, '', 'Remaster'] }, expected: 'Remaster' },
+      { id: 'null', tags: { albumversion: null }, expected: null },
+      { id: 'malformed', tags: 'unexpected', expected: null },
+    ];
+    getAlbumListForServer.mockResolvedValue(variants.map(({ id, tags }) => ({
+      ...album(id, '2026-07-16T11:00:00Z'),
+      tags,
+    })));
+    libraryResolveAlbumOverlay.mockImplementation(async ({ albums }: { albums: Array<{ version: string | null }> }) => (
+      albums.map((_item, group) => ({ group, representativeServerId: null, representativeId: null }))
+    ));
+
+    await fetchHotNewReleases([{ serverId: 's1', libraryId: 'l1' }], now);
+
+    expect(libraryResolveAlbumOverlay).toHaveBeenCalledWith({
+      scopes: [{ serverId: 's1', libraryId: 'l1' }],
+      albums: variants.map(({ id, expected }) => ({
+        serverId: 's1',
+        id,
+        name: id,
+        artist: 'Artist',
+        version: expected,
+      })),
+    });
   });
 });

--- a/src/features/album/utils/hotNewReleases.ts
+++ b/src/features/album/utils/hotNewReleases.ts
@@ -15,6 +15,18 @@ function createdAtMs(album: SubsonicAlbum): number | null {
   return Number.isFinite(value) ? value : null;
 }
 
+function albumVersionFromTags(tags: unknown): string | null {
+  if (!tags || typeof tags !== 'object' || Array.isArray(tags)) return null;
+  const albumversion = (tags as Record<string, unknown>).albumversion;
+  const values = Array.isArray(albumversion) ? albumversion : [albumversion];
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    const version = value.trim();
+    if (version) return version;
+  }
+  return null;
+}
+
 export interface ResolvedHotNewRelease {
   album: SubsonicAlbum;
   group: number;
@@ -101,10 +113,13 @@ export async function fetchHotNewReleases(
       scopes,
       albums: results.map(album => ({
         serverId: album.serverId ?? '',
-        id: album.id,
-        name: album.name,
-        artist: album.displayArtist?.trim() || album.artist?.trim() || null,
-      })),
+          id: album.id,
+          name: album.name,
+          artist: album.displayArtist?.trim() || album.artist?.trim() || null,
+          version: album.version?.trim()
+            || albumVersionFromTags(album.tags)
+            || null,
+        })),
     });
     if (resolutions.length !== results.length) return [];
     return results.map((album, index) => ({ album, ...resolutions[index]! }));

--- a/src/generated/bindings.ts
+++ b/src/generated/bindings.ts
@@ -1169,6 +1169,7 @@ export type LibraryAlbumOverlayCandidateDto = {
 	id: string,
 	name: string,
 	artist: string | null,
+	version?: string | null,
 };
 
 /**

--- a/src/lib/api/library/scopeReads.test.ts
+++ b/src/lib/api/library/scopeReads.test.ts
@@ -304,6 +304,7 @@ describe('libraryResolveAlbumOverlay', () => {
         id: 'physical-album',
         name: 'Album',
         artist: 'Artist',
+        version: 'Deluxe Edition',
       }],
     });
 
@@ -318,6 +319,7 @@ describe('libraryResolveAlbumOverlay', () => {
           id: 'physical-album',
           name: 'Album',
           artist: 'Artist',
+          version: 'Deluxe Edition',
         }],
       },
     });

--- a/src/lib/api/subsonicTypes.ts
+++ b/src/lib/api/subsonicTypes.ts
@@ -27,6 +27,10 @@ export interface SubsonicAlbum {
   isCompilation?: boolean;
   /** OpenSubsonic: release types from MusicBrainz tags (e.g. "Album", "EP", "Single", "Compilation", "Live"). */
   releaseTypes?: string[];
+  /** OpenSubsonic album edition label (e.g. "Deluxe Edition"). */
+  version?: string;
+  /** Raw Navidrome tag projection; servers vary between scalar, array, and null shapes. */
+  tags?: unknown;
   /** OpenSubsonic: structured album-artist credits (e.g. featured guests on the album). */
   artists?: SubsonicOpenArtistRef[];
   /** OpenSubsonic: single-string album-artist for display (mirrors `artists` joined). */


### PR DESCRIPTION
## Summary

- include OpenSubsonic `version` / `albumVersion` and Navidrome `tags.albumversion` in local album identity
- keep different physical releases separate while still merging the same version across servers
- preserve album-list provenance across sparse ingest/remap paths and refresh stale list metadata without starving large libraries
- normalise bracketed and Unicode version suffixes, tolerate real-world tag wire shapes, and rebuild the identity sidecar once via `NORM_VERSION = 9`

## User impact

Albums such as a standard release and a deluxe/remastered version no longer collapse into one album in combined library browse, artist discography, or Album Detail. Equivalent copies of the same version still merge across servers.

No SQLite schema migration is required. Existing installs rebuild the derived `library-cluster.db` identity keys once after updating.

## Verification

- `npm run lint`, `npm run dep:check`, `npm test`, `npm run prebuild:release-notes`, `npx tsc --noEmit` - passed (`600` files / `4574` frontend tests)
- `npx vitest run --coverage` and `bash scripts/check-frontend-hot-path-coverage.sh` - passed
- `cargo test --workspace --all-targets -- --test-threads=1` - passed (`868` library tests plus the remaining workspace suites)
- `cargo clippy --workspace --all-targets -- -D warnings` - passed
- local `cargo llvm-cov` reached `866` passing library tests but LLVM instrumentation pushed the two existing 500-row wall-clock assertions to about `1.4s`; both pass in the normal full suite, and GitHub's Rust coverage/hot-path gate passed on this head
- final GitHub checks passed, including Linux/Windows Rust tests and clippy, frontend tests/coverage, Rust coverage, and `ci-ok`
- regression coverage includes full/incremental rebuilds, Unicode and bracketed suffixes, sparse/no-album-id tracks, provenance refresh/retry, malformed/scalar tags, Album Detail, artist discography, New Releases, and cross-server same-version merging

## Runtime benchmark

- Applicability: required; identity affects album browse and detail routes
- Baseline: `81a47cc9b3d046309b328dd5d669d6988d844a75` / report `2026-08-28T23-08-38-286Z`
- Final: `491a22330e5a8ab190fa2abd1531f69253507646` / report `2026-08-29T02-31-13-238Z`
- Command: `psysonic benchmark run --scenario all-pages --runs 3 --profile realistic --json`
- Environment: Linux debug, `638x753`, DPR 2, one selected server; scope fingerprint matched
- Affected route medians: Albums `1076 -> 1078 ms` (flat); Artists `833 -> 856 ms` (+3%); New Releases `810 -> 805 ms` (-1%)
- Detail routes have no semantic readiness marker and are dominated by variable DOM quiet/background traffic. Realistic totals were Album Detail `3374 -> 3055 ms` (-9%) and Artist Detail `1373 -> 973 ms` (-29%).
- A repeated final run cleared unrelated `12-15%` fluctuations seen on the first final run; affected browse routes remained stable
- Timeouts/errors: none; requested and actual routes matched
- Expected skips: composer detail (no owned indexed composer) and label detail (no reachable labelled album)

## Contract and storage

- Tauri command/event contract: unchanged
- SQLite schema: unchanged
- Derived identity data: one-time sidecar rebuild caused by the normalization-version bump
