### PR TITLE
fix(lyrics): reassemble synced lyrics split across repeated tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Standard, deluxe, remastered and other physical versions of the same album no longer collapse into one release in combined libraries, artist discographies or Album Detail. Matching copies of the same version still merge across servers.
 * Existing libraries rebuild their derived identity keys once after updating; the library database and user state are unchanged.
 
+### Synced lyrics in FLAC files show every line
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), issue reported by [@Naharie](https://github.com/Naharie), PR [#1474](https://github.com/Psysonic/psysonic/pull/1474)**
+
+* A FLAC whose lyrics tag is written one field per line only showed the first line, while the same lyrics in an MP3 displayed in full. Every part of the lyrics is now reassembled, whether the tag was written line by line, verse by verse or as a single block.
+* Word-by-word highlighting keeps pointing at the right words across the reassembled lines, and a malformed lyrics response no longer leaves the panel stuck loading.
+
 ## [1.51.0] - 2026-08-17
 
 ## Added

--- a/src/lib/api/subsonicLyrics.test.ts
+++ b/src/lib/api/subsonicLyrics.test.ts
@@ -60,6 +60,108 @@ describe('pickMainStructuredLyrics', () => {
   });
 });
 
+// A FLAC whose LYRICS vorbis comment is repeated once per line: the server maps
+// each tag value to its own entry, so one layer arrives as N single-line entries
+// with the same lang and sync state. Shape taken from a Navidrome 0.63.2
+// response. Picking only the first entry showed one line (issue #1472).
+describe('pickMainStructuredLyrics with a layer split across entries', () => {
+  const split = [
+    lyrics({ lang: 'xxx', synced: true, line: [{ start: 1000, value: 'line one' }] }),
+    lyrics({ lang: 'xxx', synced: true, line: [{ start: 5000, value: 'line two' }] }),
+    lyrics({ lang: 'xxx', synced: true, line: [{ start: 9000, value: 'line three' }] }),
+  ];
+
+  it('concatenates the entries into one layer', () => {
+    expect(pickMainStructuredLyrics(split)?.line).toEqual([
+      { start: 1000, value: 'line one' },
+      { start: 5000, value: 'line two' },
+      { start: 9000, value: 'line three' },
+    ]);
+  });
+
+  it('leaves a single multi-line entry untouched', () => {
+    // The same tag written as one multi-line value — the shape that already worked.
+    const whole = lyrics({
+      lang: 'xxx',
+      synced: true,
+      line: [
+        { start: 1000, value: 'line one' },
+        { start: 5000, value: 'line two' },
+      ],
+    });
+    expect(pickMainStructuredLyrics([whole])).toBe(whole);
+  });
+
+  it('does not absorb a translation sharing the language', () => {
+    const translation = lyrics({
+      kind: 'translation',
+      lang: 'xxx',
+      synced: true,
+      line: [{ start: 1000, value: 'translated' }],
+    });
+    expect(pickMainStructuredLyrics([...split, translation])?.line).toHaveLength(3);
+  });
+
+  it('keeps kinds apart when no entry is main', () => {
+    // The only path where `kind` decides the grouping: with no main layer the
+    // pool is unfiltered, so translation and pronunciation reach it together
+    // and must not be concatenated into one.
+    const translation = lyrics({ kind: 'translation', lang: 'xxx', synced: true, line: [{ start: 1000, value: 'translated' }] });
+    const pronunciation = lyrics({ kind: 'pronunciation', lang: 'xxx', synced: true, line: [{ start: 1000, value: 'spoken' }] });
+    const picked = pickMainStructuredLyrics([translation, pronunciation]);
+    expect(picked?.line).toEqual([{ start: 1000, value: 'translated' }]);
+  });
+
+  it('does not absorb an unsynced entry of the same language', () => {
+    const unsynced = lyrics({ lang: 'xxx', line: [{ value: 'plain' }] });
+    expect(pickMainStructuredLyrics([...split, unsynced])?.line).toHaveLength(3);
+  });
+
+  it('keeps a different language as its own layer', () => {
+    const other = lyrics({ lang: 'eng', synced: true, line: [{ start: 1000, value: 'english' }] });
+    expect(pickMainStructuredLyrics([...split, other])?.line).toHaveLength(3);
+  });
+
+  it('shifts cue line indexes onto the concatenated line positions', () => {
+    // Without the shift every appended cue line would point at line 0 and
+    // highlight the wrong words.
+    const withCues = split.map((entry, i) =>
+      lyrics({ ...entry, cueLine: [{ index: 0, value: entry.line[0].value, cue: [
+        { start: (i + 1) * 1000, value: entry.line[0].value, byteStart: 0, byteEnd: 7 },
+      ] }] }),
+    );
+    expect(pickMainStructuredLyrics(withCues)?.cueLine?.map(c => c.index)).toEqual([0, 1, 2]);
+  });
+
+  it('reassembles fields of uneven length', () => {
+    // A tag field can hold a whole verse, so the pieces are not one line each.
+    // Shape measured on Navidrome 0.63.2 for three fields, the middle one
+    // holding two lines.
+    const uneven = [
+      lyrics({ lang: 'xxx', synced: true, line: [{ start: 1000, value: 'line one' }] }),
+      lyrics({ lang: 'xxx', synced: true, line: [
+        { start: 5000, value: 'line two' }, { start: 7000, value: 'line two b' },
+      ] }),
+      lyrics({ lang: 'xxx', synced: true, line: [{ start: 9000, value: 'line three' }] }),
+    ];
+    expect(pickMainStructuredLyrics(uneven)?.line).toHaveLength(4);
+  });
+
+  it('ignores entries whose line array is missing', () => {
+    // Raw server JSON: `line` is required by the type but can be absent in
+    // practice. Reaching `parseStructuredLyrics` with one throws out of the
+    // fetch pipeline uncaught, which would hang the pane on "loading".
+    const malformed = { lang: 'xxx', synced: true } as unknown as SubsonicStructuredLyrics;
+    expect(() => pickMainStructuredLyrics([malformed, ...split])).not.toThrow();
+    expect(pickMainStructuredLyrics([malformed, ...split])?.line).toHaveLength(3);
+  });
+
+  it('returns null when no entry has a usable line array', () => {
+    const malformed = { lang: 'xxx', synced: true } as unknown as SubsonicStructuredLyrics;
+    expect(pickMainStructuredLyrics([malformed])).toBeNull();
+  });
+});
+
 describe('getLyricsBySongId', () => {
   it('omits the enhanced parameter by default', async () => {
     apiMock.mockResolvedValue({ lyricsList: { structuredLyrics: [lyrics()] } });

--- a/src/lib/api/subsonicLyrics.ts
+++ b/src/lib/api/subsonicLyrics.ts
@@ -1,5 +1,5 @@
 import { api, apiForServer } from '@/lib/api/subsonicClient';
-import type { SubsonicStructuredLyrics } from '@/lib/api/subsonicTypes';
+import type { SubsonicLyricCueLine, SubsonicStructuredLyrics } from '@/lib/api/subsonicTypes';
 
 export interface GetLyricsOptions {
   /**
@@ -20,6 +20,49 @@ export function isMainLyricsKind(lyrics: SubsonicStructuredLyrics): boolean {
   return !lyrics.kind || lyrics.kind === 'main';
 }
 
+function isSynced(lyrics: SubsonicStructuredLyrics): boolean {
+  return !!(lyrics.synced ?? lyrics.issynced);
+}
+
+/**
+ * Identity of the layer an entry belongs to. Entries sharing it are the same
+ * layer arriving in pieces; anything else is a layer of its own. A missing
+ * `kind` folds into `main` so v1 and v2 responses compare alike.
+ */
+function layerKey(lyrics: SubsonicStructuredLyrics): string {
+  const kind = isMainLyricsKind(lyrics) ? 'main' : lyrics.kind;
+  return `${kind}|${lyrics.lang ?? ''}|${isSynced(lyrics)}`;
+}
+
+/**
+ * Merge sibling entries into the chosen one, keeping server order.
+ *
+ * `cueLine.index` addresses positions in `line`, so every appended entry shifts
+ * its cue lines by the number of lines already collected — otherwise word
+ * highlighting would point at the wrong text. Everything else, `agents`
+ * included, is taken from the first entry: agent ids are local to the document
+ * they were parsed from, so unioning rosters across entries would silently
+ * reassign a cue line's `agentId` to a different voice.
+ */
+function mergeStructuredLyrics(
+  entries: readonly SubsonicStructuredLyrics[],
+): SubsonicStructuredLyrics {
+  const line = [...entries[0].line];
+  const cueLine: SubsonicLyricCueLine[] = [...(entries[0].cueLine ?? [])];
+
+  for (const entry of entries.slice(1)) {
+    const offset = line.length;
+    line.push(...entry.line);
+    for (const cue of entry.cueLine ?? []) cueLine.push({ ...cue, index: cue.index + offset });
+  }
+
+  return {
+    ...entries[0],
+    line,
+    ...(cueLine.length > 0 ? { cueLine } : {}),
+  };
+}
+
 /**
  * Choose the layer to display, preferring synced over unsynced.
  *
@@ -28,14 +71,45 @@ export function isMainLyricsKind(lyrics: SubsonicStructuredLyrics): boolean {
  * layers, and those must never be shown in place of the original text. The
  * fallback to the unfiltered list only matters for a server that labels every
  * entry as non-main — showing something then beats showing nothing.
+ *
+ * One layer can arrive split across several entries: a server maps each lyrics
+ * tag value to its own entry, and Vorbis comments (FLAC, Ogg) allow the tag to
+ * repeat, so a taggant that writes one field per line yields one entry per line.
+ * ID3 has a single frame and never splits, which is why this only shows up on
+ * FLAC. Entries of the same layer are therefore concatenated; picking just the
+ * first would drop all but its lines (issue #1472).
+ *
+ * Splitting is not per line — one field can hold a whole verse — so the pieces
+ * are only recognisable by their shared kind, language and sync state, and any
+ * count-based test for "is this a fragment" breaks a file whose fields are
+ * unevenly sized. Line order is no signal either: LRC timestamps legitimately
+ * step backwards at overlapping vocal lines.
+ *
+ * The accepted cost is that two distinct layers of one identity read as one.
+ * Measured on Navidrome 0.63.2: a sidecar replaces the tag lyrics rather than
+ * adding to them, and identical values across the aliased tags (`lyrics`,
+ * `unsyncedlyrics`, `uslt:description`) collapse into a single entry — so the
+ * duplicate-text case cannot arise. What remains is *differing* text in two of
+ * those tags, which is genuinely indistinguishable from a split and gets
+ * concatenated. Showing both beats the previous behaviour of silently keeping
+ * whichever came first.
  */
 export function pickMainStructuredLyrics(
   list: readonly SubsonicStructuredLyrics[],
 ): SubsonicStructuredLyrics | null {
-  if (list.length === 0) return null;
-  const main = list.filter(isMainLyricsKind);
-  const pool = main.length > 0 ? main : list;
-  return pool.find(l => l.synced || l.issynced) ?? pool[0] ?? null;
+  // Raw server JSON: `line` is required by the type but servers do omit it.
+  // Dropping those entries up front keeps both the merge below and
+  // `parseStructuredLyrics` from dereferencing an absent array — a throw there
+  // escapes the fetch pipeline uncaught and leaves the pane loading forever.
+  const usable = list.filter(l => Array.isArray(l.line));
+  if (usable.length === 0) return null;
+  const main = usable.filter(isMainLyricsKind);
+  const pool = main.length > 0 ? main : usable;
+  const chosen = pool.find(isSynced) ?? pool[0];
+
+  const key = layerKey(chosen);
+  const siblings = pool.filter(l => layerKey(l) === key);
+  return siblings.length > 1 ? mergeStructuredLyrics(siblings) : chosen;
 }
 
 /**


### PR DESCRIPTION
Closes #1472

A server maps each lyrics tag value to its own `structuredLyrics` entry, and Vorbis comments allow the tag to repeat, so a tagger writing one field per line yields one entry per line. `pickMainStructuredLyrics` returned a single entry, so the pane showed only its lines. ID3 carries one frame and never splits, which is why only FLAC was affected.

- Entries agreeing on kind, language and sync state are concatenated instead of one being picked; a single entry is still returned unchanged.
- `cueLine.index` addresses positions in `line`, so appended cue lines are shifted by the lines already collected - otherwise word highlighting points at the wrong text.
- Entries without a `line` array are dropped before the pick: a throw in `parseStructuredLyrics` escapes the fetch pipeline uncaught and leaves the pane loading forever.
- Known limit, unchanged from before: fragments the server classifies with a different sync state fall outside the group and are not appended. Also note `isSynced` now uses `??` rather than `||`, matching `isSyncedLyrics` in the parser, so the picker and the parser can no longer disagree.

## Test plan

Eleven unit tests covering reassembly, uneven field sizes, layer separation by kind/language/sync state, cue index shifting and malformed entries. Each verified by mutation against the unfixed code.

End to end against a local Navidrome 0.63.2 across eight tag shapes - repeated fields, one multi-line field, unevenly sized fields, blank and timestamp-only entries, sidecar files, and identical vs differing values in the aliased lyrics tags. In every shape the pane renders as many lines as the server sent.

`tsc`, `eslint`, `dep:check` and the full vitest suite (600 files, 4584 tests) pass.

Runtime benchmark: not applicable - lyrics response adapter only, no route, browse, query or cache path touched.
