### PR TITLE
chore(aur): bump PKGBUILD to 1.52.0

### DIFF
--- a/packages/aur/PKGBUILD
+++ b/packages/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Psychotoxic <psychotoxic@gmx.de>
 pkgname=psysonic
-pkgver=1.51.0
+pkgver=1.52.0
 pkgrel=1
 pkgdesc="Desktop music player for Subsonic API-compatible servers (Navidrome, Gonic, etc.)"
 arch=('x86_64')


### PR DESCRIPTION
Bumps the in-repo AUR PKGBUILD to the released version. The repo copy has to track the
release, otherwise it drifts against the AUR clone and the next maintainer push starts
from a stale file.

- `pkgver` 1.51.0 -> 1.52.0, `pkgrel` stays 1
- No other change. The clone still carries the pre-transfer `url`/`source` host, so this
  bump is also what ships the current repository URL from #1429 to the AUR package.

Runtime benchmark: not applicable - packaging metadata only, no application code path.

## Test plan

`makepkg` on Arch against the published `app-v1.52.0` tag, once the release is public —
`source` resolves to the tag archive, so it cannot be verified before publishing.
