### PR TITLE
fix(export): keep prefixed cover ids intact in share exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 >
 
 
+## [1.53.0]
+
+## Fixed
+
+### Shared Top Albums pictures show their covers again
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1478](https://github.com/Psysonic/psysonic/pull/1478)**
+
+* The picture created from Statistics → Most Played Albums drew every album as an empty tile, showing only the rank and the play count. The New Albums export lost its covers the same way.
+* Covers now come from the same place the album cards get theirs, so a shared picture also reuses artwork that is already on screen instead of fetching it a second time.
+
 ## [1.52.0]
 
 ## Added

--- a/src/cover/integrations/export.test.ts
+++ b/src/cover/integrations/export.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { albumExportCoverRef } from './export';
+import { albumCoverRef } from '../ref';
+
+describe('albumExportCoverRef', () => {
+  it('keeps an already-prefixed Navidrome coverArt id intact', () => {
+    // Regression: passing coverArt as both ids rewrote this to `al-al-abc123_0`,
+    // which no server resolves — every exported tile rendered as an empty panel.
+    const ref = albumExportCoverRef({ id: 'abc123', coverArt: 'al-abc123' });
+    expect(ref?.fetchCoverArtId).toBe('al-abc123');
+    expect(ref?.cacheEntityId).toBe('abc123');
+  });
+
+  it('lands on the same cache slot as the album cards', () => {
+    expect(albumExportCoverRef({ id: 'abc123', coverArt: 'al-abc123' }))
+      .toEqual(albumCoverRef('abc123', 'al-abc123'));
+  });
+
+  it('derives the Navidrome fetch id when the server sends no coverArt', () => {
+    expect(albumExportCoverRef({ id: 'abc123' })?.fetchCoverArtId).toBe('al-abc123_0');
+  });
+
+  it('returns null when the album carries no usable id', () => {
+    expect(albumExportCoverRef({ id: '', coverArt: '' })).toBeNull();
+  });
+});

--- a/src/cover/integrations/export.test.ts
+++ b/src/cover/integrations/export.test.ts
@@ -20,7 +20,10 @@ describe('albumExportCoverRef', () => {
     expect(albumExportCoverRef({ id: 'abc123' })?.fetchCoverArtId).toBe('al-abc123_0');
   });
 
-  it('returns null when the album carries no usable id', () => {
+  it('returns null without an album id, instead of rebuilding the broken ref', () => {
+    // `coverArt` as a stand-in id would rewrite back to `al-al-abc_0`.
+    expect(albumExportCoverRef({ id: '', coverArt: 'al-abc' })).toBeNull();
+    expect(albumExportCoverRef({ id: '   ', coverArt: 'al-abc' })).toBeNull();
     expect(albumExportCoverRef({ id: '', coverArt: '' })).toBeNull();
   });
 });

--- a/src/cover/integrations/export.ts
+++ b/src/cover/integrations/export.ts
@@ -6,23 +6,30 @@ import type { CoverArtRef } from '../types';
 import type { SubsonicAlbum } from '@/lib/api/subsonicTypes';
 
 /**
- * Cover ref for canvas exports — built the same way the album cards build
- * theirs (album id + the server's `coverArt` id), so an export reuses the cache
- * slot the grid already filled instead of opening a second one.
+ * Cover ref for canvas exports — built from the same three inputs an album card
+ * resolves its ref from: album id, the server's cover id, and the owner server
+ * scope. Sharing that shape is what lets an export reuse the disk slot the grid
+ * already filled instead of opening a second one.
  *
  * Passing `coverArt` as *both* ids (the old `coverArtRef(album.coverArt)`
  * shortcut) makes `resolveAlbumCoverEntry` take its bare-album-id branch and
- * rewrite an already-prefixed Navidrome id into `al-al-<id>_0` — an id no
- * server resolves, so every tile fell back to an empty panel.
+ * rewrite an already prefixed Navidrome id into `al-al-<id>_0` — an id no
+ * server resolves, so every tile fell back to an empty panel. An album with no
+ * id cannot reach the card's slot at all, so it yields `null` rather than
+ * falling back to `coverArt` and reintroducing that rewrite.
+ *
+ * Per-disc artwork is deliberately not requested: `resolveDistinctDiscCoversForAlbum`
+ * is keyed per server here but written per server in `AlbumDetail`, so an unscoped
+ * ask misses today, and asking for it also suppresses the `al-<id>_0` fetch id that
+ * an album without a server-side `coverArt` needs. Card and export therefore both
+ * leave it at its default; the two have to change together, not one of them here.
  */
 export function albumExportCoverRef(
   album: Pick<SubsonicAlbum, 'id' | 'coverArt' | 'serverId'>,
 ): CoverArtRef | null {
   const albumId = album.id?.trim();
-  const coverArt = album.coverArt?.trim();
-  const entityId = albumId || coverArt;
-  if (!entityId) return null;
-  return albumCoverRef(entityId, coverArt, coverServerScopeForServerId(album.serverId));
+  if (!albumId) return null;
+  return albumCoverRef(albumId, album.coverArt, coverServerScopeForServerId(album.serverId));
 }
 
 /** Canvas/export helper — resolves tier from CSS px then returns a Blob. */

--- a/src/cover/integrations/export.ts
+++ b/src/cover/integrations/export.ts
@@ -1,6 +1,29 @@
+import { albumCoverRef } from '../ref';
 import { ensureCoverTierJs } from '../resolveJs';
+import { coverServerScopeForServerId } from '../serverScope';
 import { resolveCoverDisplayTier } from '../tiers';
 import type { CoverArtRef } from '../types';
+import type { SubsonicAlbum } from '@/lib/api/subsonicTypes';
+
+/**
+ * Cover ref for canvas exports — built the same way the album cards build
+ * theirs (album id + the server's `coverArt` id), so an export reuses the cache
+ * slot the grid already filled instead of opening a second one.
+ *
+ * Passing `coverArt` as *both* ids (the old `coverArtRef(album.coverArt)`
+ * shortcut) makes `resolveAlbumCoverEntry` take its bare-album-id branch and
+ * rewrite an already-prefixed Navidrome id into `al-al-<id>_0` — an id no
+ * server resolves, so every tile fell back to an empty panel.
+ */
+export function albumExportCoverRef(
+  album: Pick<SubsonicAlbum, 'id' | 'coverArt' | 'serverId'>,
+): CoverArtRef | null {
+  const albumId = album.id?.trim();
+  const coverArt = album.coverArt?.trim();
+  const entityId = albumId || coverArt;
+  if (!entityId) return null;
+  return albumCoverRef(entityId, coverArt, coverServerScopeForServerId(album.serverId));
+}
 
 /** Canvas/export helper — resolves tier from CSS px then returns a Blob. */
 export async function loadCoverBlobForExport(

--- a/src/features/album/utils/exportAlbumCard.ts
+++ b/src/features/album/utils/exportAlbumCard.ts
@@ -1,8 +1,7 @@
 import type { SubsonicAlbum } from '@/lib/api/subsonicTypes';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { coverArtRef } from '@/cover/ref';
-import { loadCoverBlobForExport } from '@/cover/integrations/export';
+import { albumExportCoverRef, loadCoverBlobForExport } from '@/cover/integrations/export';
 import PsysonicLogo from '@/ui/PsysonicLogo';
 
 export type ExportFormat = 'story' | 'square' | 'twitter';
@@ -62,9 +61,10 @@ function isLight(hex: string): boolean {
 }
 
 async function loadAlbumCover(album: SubsonicAlbum, displayCssPx: number, signal?: AbortSignal): Promise<ImageBitmap | null> {
-  if (!album.coverArt) return null;
+  const ref = albumExportCoverRef(album);
+  if (!ref) return null;
   try {
-    const blob = await loadCoverBlobForExport(coverArtRef(album.coverArt), displayCssPx, signal);
+    const blob = await loadCoverBlobForExport(ref, displayCssPx, signal);
     if (!blob) return null;
     return await createImageBitmap(blob);
   } catch {

--- a/src/features/album/utils/exportNewAlbums.ts
+++ b/src/features/album/utils/exportNewAlbums.ts
@@ -1,6 +1,5 @@
 import { getAlbumList } from '@/lib/api/subsonicLibrary';
-import { coverArtRef } from '@/cover/ref';
-import { loadCoverBlobForExport } from '@/cover/integrations/export';
+import { albumExportCoverRef, loadCoverBlobForExport } from '@/cover/integrations/export';
 import type { SubsonicAlbum } from '@/lib/api/subsonicTypes';
 import { albumArtistDisplayName } from '@/features/album/utils/deriveAlbumHeaderArtistRefs';
 import { writeFile } from '@tauri-apps/plugin-fs';
@@ -41,9 +40,10 @@ function clampText(ctx: CanvasRenderingContext2D, text: string, maxW: number): s
 }
 
 async function loadAlbumCoverBitmap(album: SubsonicAlbum): Promise<ImageBitmap | null> {
-  if (!album.coverArt) return null;
+  const ref = albumExportCoverRef(album);
+  if (!ref) return null;
   try {
-    const blob = await loadCoverBlobForExport(coverArtRef(album.coverArt), COVER_SIZE);
+    const blob = await loadCoverBlobForExport(ref, COVER_SIZE);
     if (!blob) return null;
     return await createImageBitmap(blob);
   } catch { return null; }


### PR DESCRIPTION
## What changed

The Statistics "Top Albums" share image rendered every tile as an empty panel — rank and play counts drew fine, only the covers were missing. The New Albums export had the same defect.

Both built their cover ref from `coverArt` alone (`coverArtRef(album.coverArt)`), which passes one id as *both* the album id and the cover id. `resolveAlbumCoverEntry` then takes its bare-album-id branch and rewrites an already prefixed Navidrome id into `al-al-<id>_0` — an id no server resolves. `loadAlbumCover` swallows the miss and returns `null`, so the renderer drew its fallback panel.

Measured against a real library: `album.id = 4AMwB6uQopat15KeZodYA8`, `cover_art_id = al-4AMwB6uQopat15KeZodYA8_6a90abc2` — the already-prefixed case. Servers that report `coverArt` equal to the bare album id were never affected, which is why this stayed unnoticed.

Both exports now go through a shared `albumExportCoverRef()` that builds the ref the way the album cards already do: album id + the server's cover id + the owner server scope from `album.serverId`, so multi-server rows resolve against their own server. Side effect: an export now hits the same cache slot as the grid and reuses covers the UI already warmed instead of refetching them.

Broken since the `al-<id>_0` fetch id landed in #1280; the export call itself dates back to #870.

## Who notices

End users. Anyone using Statistics → share Top Albums, or the New Albums export. Dev-only otherwise — no API, command, event or storage change.

## Manual verification

1. Statistics → Meistgespielte Alben → share icon: the 3×3 preview shows covers.
2. Save the PNG — the covers are in the written file.
3. New Albums export from the sidebar — covers render in the rows.

Verified on Windows against a Navidrome server in the dev build: covers are back in both the preview and the saved PNG.

## Tests

New `src/cover/integrations/export.test.ts` pins the id building: prefixed ids stay intact, the ref matches what `albumCoverRef` produces for the cards, a missing `coverArt` still derives `al-<id>_0`, and an album with no usable id yields `null`.

Local sweep green: `npm test` (Vitest + node scripts + css-import + barrel checks) and `npm run build` (tsc + vite).
