### PR TITLE
fix(test): compare visualizer CSS independently of checkout line endings

### DIFF
--- a/src/features/visualizer/components/visualizerOverlayStyles.test.ts
+++ b/src/features/visualizer/components/visualizerOverlayStyles.test.ts
@@ -6,7 +6,12 @@ describe('expanded visualizer geometry', () => {
   const css = readFileSync(
     resolve(process.cwd(), 'src/styles/components/visualizer.css'),
     'utf8',
-  );
+  )
+    // A Windows checkout with git's default `core.autocrlf=true` rewrites this
+    // file to CRLF, while the multi-line expectation below is spelled with \n.
+    // Compare against normalized text so the test states a CSS fact rather than
+    // a fact about the checkout's line endings.
+    .replace(/\r\n/g, '\n');
 
   it('applies shell titlebar and mobile offsets only to Now Playing overlays', () => {
     expect(css).toContain(


### PR DESCRIPTION
## What changed

`visualizerOverlayStyles.test.ts` reads `src/styles/components/visualizer.css` and asserts a two-line expectation spelled with `\n`. On a Windows checkout with git's default `core.autocrlf=true` the file arrives as CRLF, that substring stops matching, and the test fails for a reason unrelated to the CSS it guards. The file content is normalized at read time so the test states a fact about the stylesheet rather than about the checkout.

Verified both directions locally by converting the stylesheet to CRLF and back:

| | CRLF checkout | LF checkout |
|---|---|---|
| before | **fails** (1 of 2) | passes |
| after | passes | passes |

Only the final assertion is newline-sensitive; the others are single-line selector substrings. The normalization only collapses `\r\n` to `\n`, so it cannot make a `not.toContain` start matching.

## Why not a `.gitattributes` rule

That would be the root fix in a clean repo, and the precedent exists (`src/generated/** text eol=lf`, added for the same class of failure in the Rust bindings-freshness test). It is deliberately not done here: **267 files under `src/` currently carry CR in the committed blob** (196 `.ts`, 70 `.css`). Any normalization rule would either produce a repo-wide diff or leave every Windows checkout reporting hundreds of files as modified until renormalized. That is a deliberate `chore` change to decide on its own, not a side effect of a test fix.

The other five tests that `readFileSync` project files (`lazyRoutes.smoke`, `startupSplashReveal`, `coverArtRegisteredSizes`, `QueuePanel`, `startupThemeAppearance`) were checked — none asserts on a multi-line literal, so none carries the same latent failure.

## Who notices

Developers on Windows with a default git configuration; the suite is currently red for them on a clean clone. No user-facing change, no production code touched — hence no CHANGELOG entry.

## Verification

`npx tsc --noEmit` clean, ESLint clean, `npx vitest run src/features/visualizer` → 11 files, 254 tests passing.
