### PR TITLE
fix(updater): keep the update dialog buttons inside the modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The picture created from Statistics → Most Played Albums drew every album as an empty tile, showing only the rank and the play count. The New Albums export lost its covers the same way.
 * Covers now come from the same place the album cards get theirs, so a shared picture also reuses artwork that is already on screen instead of fetching it a second time.
 
+### Update dialog buttons stay inside the dialog
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1488](https://github.com/Psysonic/psysonic/pull/1488)**
+
+* In languages with long button labels, such as German, the "Install now" button of the update dialog ran past the right edge of the dialog. The buttons now move to a second row when they do not fit side by side.
+
 ## [1.52.0]
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1488](https://github.com/Psysonic/psysonic/pull/1488)**
 
-* In languages with long button labels, such as German, the "Install now" button of the update dialog ran past the right edge of the dialog. The buttons now move to a second row when they do not fit side by side.
+* In languages with long button labels, such as German, the "Install now" button of the update dialog ran past the right edge of the dialog. The dialog is wider now, and should the labels still not fit side by side, the buttons move to a second row instead of being cut off.
 
 ## [1.52.0]
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -80,13 +80,15 @@ Rules:
    - Nix verification
    - opens PR to bump `main` to next minor `-dev`
 
-### Windows installer and updater manifest (manual, per RC and stable)
+### Windows installer and updater manifest (manual)
 
 CI builds the Windows installer as an unsigned compile check. The installer that ships is built and code-signed by a maintainer and uploaded to the release by hand, replacing the CI asset under the same name (`Psysonic_X.Y.Z_x64-setup.exe`). Wait until the channel workflow has finished — it uploads `latest.json` last — then:
 
 1. Upload the signed installer: `gh release upload app-vX.Y.Z Psysonic_X.Y.Z_x64-setup.exe --clobber`.
 2. Run workflow: **Sign Windows updater** with the release tag. It signs the uploaded installer with the updater key and writes the `windows-x86_64` entry into `latest.json`. Without this entry the in-app updater on Windows has nothing to install.
 3. Re-run it whenever the installer asset is replaced — the updater signature covers the exact bytes on the release.
+
+Step 2 is required for every stable release. The in-app updater reads `releases/latest`, which never resolves to a pre-release, so for an RC it is only needed when testing the updater against that RC directly.
 
 ### Step E: Move `main` forward
 

--- a/src/features/updater/components/AppUpdater.tsx
+++ b/src/features/updater/components/AppUpdater.tsx
@@ -87,6 +87,7 @@ export default function AppUpdater() {
   return (
     <Modal
       open
+      size="lg"
       onClose={() => setDismissed(true)}
       icon={<ArrowUpCircle size={18} />}
       title={t('common.updaterModalTitle')}

--- a/src/features/updater/components/AppUpdater.tsx
+++ b/src/features/updater/components/AppUpdater.tsx
@@ -29,21 +29,22 @@ export default function AppUpdater() {
         <button className="btn btn-surface" onClick={handleSkip}>
           {t('common.updaterSkipBtn')}
         </button>
-        <div style={{ flex: 1 }} />
-        <button
-          className={`btn ${showInstallBtn ? 'btn-surface' : 'btn-primary'}`}
-          onClick={() => setDismissed(true)}
-        >
-          {t('common.updaterRemindBtn')}
-        </button>
-        {showInstallBtn && (
-          <button className="btn btn-primary" onClick={handleDownload}>
-            <Download size={14} />
-            {useTauriUpdater
-              ? t('common.updaterInstallNow', { defaultValue: 'Install now' })
-              : t('common.updaterDownloadBtn')}
+        <div className="update-modal-footer-actions">
+          <button
+            className={`btn ${showInstallBtn ? 'btn-surface' : 'btn-primary'}`}
+            onClick={() => setDismissed(true)}
+          >
+            {t('common.updaterRemindBtn')}
           </button>
-        )}
+          {showInstallBtn && (
+            <button className="btn btn-primary" onClick={handleDownload}>
+              <Download size={14} />
+              {useTauriUpdater
+                ? t('common.updaterInstallNow', { defaultValue: 'Install now' })
+                : t('common.updaterDownloadBtn')}
+            </button>
+          )}
+        </div>
       </>
     );
   } else if (dlState === 'done' && updaterPlatform === 'macos') {

--- a/src/styles/components/ui-modal.css
+++ b/src/styles/components/ui-modal.css
@@ -90,6 +90,10 @@
 
 .ui-modal-footer {
   display: flex;
+  /* Buttons never shrink (.btn is nowrap). Long labels — three German
+     buttons at 520px — must wrap onto a second row instead of running past
+     the modal edge. */
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--space-2);
   padding: 12px 18px;

--- a/src/styles/layout/update-toast.css
+++ b/src/styles/layout/update-toast.css
@@ -282,6 +282,14 @@
 }
 /* WinGet update hint — shown alongside the Windows installer download, mirrors
    the AUR hint styling with a little top gap to separate it from the asset. */
+/* Right-hand action pair of the modal footer. margin-left:auto keeps it
+   right-aligned on its own row when the footer wraps. */
+.update-modal-footer-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-left: auto;
+}
 .update-modal-winget {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- The update dialog's footer ran past the modal edge when its three buttons are wider than the card — with German labels the "Install now" button was cut off. The dialog now uses the wide modal size (720px), so the buttons fit side by side.
- Fallback for even longer labels: the shared modal footer wraps (`flex-wrap`), and the "Remind me later" / "Install now" pair is a right-aligned group that moves to a second row instead of overflowing. The update dialog is the only consumer of that footer today.

Tauri boundary: not touched.
Runtime benchmark: not applicable - CSS and markup of one dialog, no route or shared UI primitive with render impact.

## Test plan

- `npx tsc --noEmit`, `npm run lint`, `npm run dep:check`, `npm run check:css-imports`, updater tests green locally.
- Headless layout check with the button widths measured from the screenshot: at 520px the last button overflowed the card, the wrap fallback keeps every button inside; at 720px all three fit on one row.
- Visual check on Windows in a local build.
