### PR TITLE
fix(library): remove deleted tracks after scoped resync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * In languages with long button labels, such as German, the "Install now" button of the update dialog ran past the right edge of the dialog. The dialog is wider now, and should the labels still not fit side by side, the buttons move to a second row instead of being cut off.
 
+### Library rebuilds remove tracks deleted from Navidrome again
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1497](https://github.com/Psysonic/psysonic/pull/1497)**
+
+* Albums and tracks deleted from a Navidrome server no longer remain as fragmented ghost entries after rebuilding a selected library.
+
 ## [1.52.0]
 
 ## Added

--- a/src-tauri/crates/psysonic-integration/src/navidrome/queries.rs
+++ b/src-tauri/crates/psysonic-integration/src/navidrome/queries.rs
@@ -24,14 +24,19 @@ pub async fn nd_list_songs_internal(
     start: u32,
     end: u32,
 ) -> Result<serde_json::Value, String> {
-    let url = format!(
-        "{}/api/song?_sort={}&_order={}&_start={}&_end={}",
-        server_url, sort, order, start, end
-    );
+    let mut seed = serde_json::Map::new();
+    seed.insert("missing".to_string(), serde_json::Value::Bool(false));
+    let filters = nd_build_filters(seed, None);
+    let start_s = start.to_string();
+    let end_s = end.to_string();
+    let url = format!("{}/api/song", server_url);
     let auth = format!("Bearer {token}");
     let resp = nd_retry(|| {
         let url = url.clone();
         let auth = auth.clone();
+        let filters = filters.clone();
+        let start_s = start_s.clone();
+        let end_s = end_s.clone();
         async move {
             nd_apply_request(
                 registry,
@@ -39,6 +44,13 @@ pub async fn nd_list_songs_internal(
                 &url,
                 nd_http_client()
                     .get(&url)
+                    .query(&[
+                        ("_filters", filters.as_str()),
+                        ("_sort", sort),
+                        ("_order", order),
+                        ("_start", start_s.as_str()),
+                        ("_end", end_s.as_str()),
+                    ])
                     .header("X-ND-Authorization", auth),
             )
             .send()

--- a/src-tauri/crates/psysonic-library/src/sync/initial/runner.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/initial/runner.rs
@@ -11,6 +11,7 @@ use crate::repos::{SyncStateRepository, TrackRepository};
 use crate::store::LibraryStore;
 use crate::sync::artist_index;
 use crate::sync::bandwidth::{ParallelismBudget, PlaybackHint};
+use crate::sync::budget::RequestBudget;
 use crate::sync::capability::{CapabilityFlags, NavidromeProbeCredentials};
 use crate::sync::cursor::{CursorPhase, InitialSyncCursor};
 use crate::sync::error::SyncError;
@@ -18,6 +19,7 @@ use crate::sync::now_unix_ms;
 use crate::sync::poll_stats::{ResyncSweepSkip, ResyncSweepSkipReason};
 use crate::sync::progress::{NoopProgress, Progress, ProgressEvent};
 use crate::sync::strategy::IngestStrategy;
+use crate::sync::tombstone::{TombstoneReconciler, TombstoneReport};
 
 /// Summary returned from `InitialSyncRunner::run`. Caller emits a
 /// completion event with these numbers (PR-3d).
@@ -238,18 +240,37 @@ impl<'a> InitialSyncRunner<'a> {
                 .count_resync_generation(&self.server_id, &self.library_scope, gen)
                 .map_err(SyncError::Storage)?;
             // `getScanStatus.count` is server-wide, so it cannot authorise a
-            // scoped sweep. Without a scope-visible count the safe result is to
-            // keep unconfirmed rows and let direct verification retire them.
+            // scoped sweep. Verify only the rows this scoped ingest did not
+            // re-stamp, and retire them solely after direct NotFound responses.
             let server_count = self
                 .library_scope
                 .is_empty()
                 .then_some(fresh_server_track_count)
                 .flatten();
-            let swept = if resync_sweep_is_safe(stamped, server_count) {
+            let tombstones = if !self.library_scope.is_empty() {
+                let mut reconciler =
+                    TombstoneReconciler::new(self.store, self.subsonic, &self.server_id)
+                        .with_library_scope(&self.library_scope);
+                if !self.sleep_enabled {
+                    reconciler = reconciler.with_sleep_disabled();
+                }
+                if let Some(flag) = &self.cancel {
+                    reconciler = reconciler.with_cancellation(Arc::clone(flag));
+                }
+                let report = reconciler
+                    .reconcile_resync_orphans(gen, RequestBudget::VERIFY_CHUNK_SIZE)
+                    .await?;
                 self.persist_resync_sweep_skip(&sync_state, None)?;
-                tracks
+                report
+            } else if resync_sweep_is_safe(stamped, server_count) {
+                self.persist_resync_sweep_skip(&sync_state, None)?;
+                let swept = tracks
                     .sweep_resync_orphans(&self.server_id, &self.library_scope, gen)
-                    .map_err(SyncError::Storage)?
+                    .map_err(SyncError::Storage)?;
+                TombstoneReport {
+                    checked: swept,
+                    deleted: swept,
+                }
             } else {
                 let reason = if server_count.is_some() {
                     ResyncSweepSkipReason::IncompleteIngest
@@ -273,12 +294,12 @@ impl<'a> InitialSyncRunner<'a> {
                     stamped,
                     server_count
                 );
-                0
+                TombstoneReport::default()
             };
-            if swept > 0 {
+            if tombstones.deleted > 0 {
                 self.progress.emit(ProgressEvent::Tombstoned {
-                    deleted_count: swept,
-                    checked_count: swept,
+                    deleted_count: tombstones.deleted,
+                    checked_count: tombstones.checked,
                 });
             }
             // Prune orphaned artist browse rows once, here — after the sweep has

--- a/src-tauri/crates/psysonic-library/src/sync/initial/tests/n1.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/initial/tests/n1.rs
@@ -19,6 +19,7 @@ async fn n1_ingest_paginates_navidrome_native_endpoint() {
         Mock::given(wm_method("GET"))
             .and(wm_path("/api/song"))
             .and(query_param("_start", start.to_string()))
+            .and(query_param("_filters", r#"{"missing":false}"#))
             .and(header("X-ND-Authorization", "Bearer nd-tok"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::Value::Array(songs)))
             .mount(&server)
@@ -38,12 +39,21 @@ async fn n1_ingest_paginates_navidrome_native_endpoint() {
     Mock::given(wm_method("GET"))
         .and(wm_path("/rest/getScanStatus.view"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "subsonic-response": { "status": "ok", "scanStatus": { "scanning": false } }
+            "subsonic-response": {
+                "status": "ok",
+                "scanStatus": { "scanning": false, "count": 4 }
+            }
         })))
         .mount(&server)
         .await;
 
     let store = LibraryStore::open_in_memory();
+    let sync_state = SyncStateRepository::new(&store);
+    sync_state.ensure("s1", "").unwrap();
+    sync_state.set_last_full_sync_at("s1", "", 1).unwrap();
+    TrackRepository::new(&store)
+        .upsert_batch(&[test_track_row("stale", "Stale")])
+        .unwrap();
     let nav = NavidromeProbeCredentials {
         server_url: server.uri(),
         bearer_token: "nd-tok".into(),
@@ -64,12 +74,21 @@ async fn n1_ingest_paginates_navidrome_native_endpoint() {
     assert_eq!(report.ingested_count, 4);
     let count: i64 = store
         .with_conn("misc", |c| {
-            c.query_row("SELECT COUNT(*) FROM track", [], |r| r.get(0))
+            c.query_row("SELECT COUNT(*) FROM track WHERE deleted = 0", [], |r| {
+                r.get(0)
+            })
         })
         .unwrap();
     assert_eq!(count, 4);
+    let stale_deleted: i64 = store
+        .with_read_conn(|conn| {
+            conn.query_row("SELECT deleted FROM track WHERE id = 'stale'", [], |row| {
+                row.get(0)
+            })
+        })
+        .unwrap();
+    assert_eq!(stale_deleted, 1);
 
-    let sync_state = SyncStateRepository::new(&store);
     assert_eq!(sync_state.get_local_track_count("s1", "").unwrap(), Some(4));
     assert_eq!(
         sync_state.get_sync_phase("s1", "").unwrap().as_deref(),

--- a/src-tauri/crates/psysonic-library/src/sync/initial/tests/scoped_and_artists.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/initial/tests/scoped_and_artists.rs
@@ -27,6 +27,8 @@ async fn scoped_s1_resync_preserves_other_library_on_same_server() {
         .mount(&server)
         .await;
     mount_minimal_artists(&server).await;
+    mount_song_not_found(&server, "a-stale").await;
+    mount_song_present(&server, "a-present").await;
 
     let store = LibraryStore::open_in_memory();
     seed_two_library_resync(&store, "lib-a");
@@ -43,7 +45,7 @@ async fn scoped_s1_resync_preserves_other_library_on_same_server() {
     .await
     .unwrap();
     assert_eq!(report.strategy.as_deref(), Some("s1"));
-    assert_scoped_resync_kept_unconfirmed_rows(&store, "a-new");
+    assert_scoped_resync_deleted_confirmed_missing_row(&store, "a-new");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -86,6 +88,8 @@ async fn scoped_s2_resync_preserves_other_library_on_same_server() {
         .mount(&server)
         .await;
     mount_minimal_artists(&server).await;
+    mount_song_not_found(&server, "a-stale").await;
+    mount_song_present(&server, "a-present").await;
 
     let store = LibraryStore::open_in_memory();
     seed_two_library_resync(&store, "lib-a");
@@ -102,7 +106,7 @@ async fn scoped_s2_resync_preserves_other_library_on_same_server() {
     .await
     .unwrap();
     assert_eq!(report.strategy.as_deref(), Some("s2"));
-    assert_scoped_resync_kept_unconfirmed_rows(&store, "a-new");
+    assert_scoped_resync_deleted_confirmed_missing_row(&store, "a-new");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src-tauri/crates/psysonic-library/src/sync/initial/tests/support.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/initial/tests/support.rs
@@ -140,6 +140,34 @@ pub(super) async fn mount_minimal_artists(server: &MockServer) {
         .await;
 }
 
+pub(super) async fn mount_song_not_found(server: &MockServer, id: &str) {
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/rest/getSong.view"))
+        .and(query_param("id", id))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": {
+                "status": "failed",
+                "error": { "code": 70, "message": "Song not found" }
+            }
+        })))
+        .mount(server)
+        .await;
+}
+
+pub(super) async fn mount_song_present(server: &MockServer, id: &str) {
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/rest/getSong.view"))
+        .and(query_param("id", id))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": {
+                "status": "ok",
+                "song": { "id": id, "title": "Still present", "duration": 100 }
+            }
+        })))
+        .mount(server)
+        .await;
+}
+
 pub(super) fn seed_two_library_resync(store: &LibraryStore, scope: &str) {
     let sync_state = SyncStateRepository::new(store);
     sync_state.ensure("s1", scope).unwrap();
@@ -149,7 +177,14 @@ pub(super) fn seed_two_library_resync(store: &LibraryStore, scope: &str) {
             conn.execute(
                 "INSERT INTO track (server_id, id, title, album, album_id, library_id, \
                    duration_sec, deleted, synced_at, raw_json, resync_gen) \
-                 VALUES ('s1', 'a-stale', 'A stale', 'A', 'album-a', 'lib-a', \
+                  VALUES ('s1', 'a-stale', 'A stale', 'A', 'album-a', 'lib-a', \
+                    1, 0, 1, '{}', 0)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO track (server_id, id, title, album, album_id, library_id, \
+                   duration_sec, deleted, synced_at, raw_json, resync_gen) \
+                 VALUES ('s1', 'a-present', 'A present', 'A', 'album-a', 'lib-a', \
                    1, 0, 1, '{}', 0)",
                 [],
             )?;
@@ -165,25 +200,35 @@ pub(super) fn seed_two_library_resync(store: &LibraryStore, scope: &str) {
         .unwrap();
 }
 
-pub(super) fn assert_scoped_resync_kept_unconfirmed_rows(store: &LibraryStore, new_id: &str) {
-    let (stale_deleted, other_deleted, new_library): (i64, i64, String) = store
-        .with_read_conn(|conn| {
-            Ok((
-                conn.query_row("SELECT deleted FROM track WHERE id = 'a-stale'", [], |r| {
-                    r.get(0)
-                })?,
-                conn.query_row("SELECT deleted FROM track WHERE id = 'b-keep'", [], |r| {
-                    r.get(0)
-                })?,
-                conn.query_row(
-                    "SELECT library_id FROM track WHERE id = ?1",
-                    [new_id],
-                    |r| r.get(0),
-                )?,
-            ))
-        })
-        .unwrap();
-    assert_eq!(stale_deleted, 0);
+pub(super) fn assert_scoped_resync_deleted_confirmed_missing_row(
+    store: &LibraryStore,
+    new_id: &str,
+) {
+    let (stale_deleted, present_deleted, other_deleted, new_library): (i64, i64, i64, String) =
+        store
+            .with_read_conn(|conn| {
+                Ok((
+                    conn.query_row("SELECT deleted FROM track WHERE id = 'a-stale'", [], |r| {
+                        r.get(0)
+                    })?,
+                    conn.query_row(
+                        "SELECT deleted FROM track WHERE id = 'a-present'",
+                        [],
+                        |r| r.get(0),
+                    )?,
+                    conn.query_row("SELECT deleted FROM track WHERE id = 'b-keep'", [], |r| {
+                        r.get(0)
+                    })?,
+                    conn.query_row(
+                        "SELECT library_id FROM track WHERE id = ?1",
+                        [new_id],
+                        |r| r.get(0),
+                    )?,
+                ))
+            })
+            .unwrap();
+    assert_eq!(stale_deleted, 1);
+    assert_eq!(present_deleted, 0);
     assert_eq!(other_deleted, 0);
     assert_eq!(new_library, "lib-a");
     let stats: PollStats = serde_json::from_value(
@@ -193,10 +238,7 @@ pub(super) fn assert_scoped_resync_kept_unconfirmed_rows(store: &LibraryStore, n
             .unwrap(),
     )
     .unwrap();
-    assert_eq!(
-        stats.last_resync_sweep_skip.map(|skip| skip.reason),
-        Some(ResyncSweepSkipReason::MissingExpectedCount)
-    );
+    assert_eq!(stats.last_resync_sweep_skip, None);
 }
 
 pub(super) fn current_bulk_pragmas(store: &LibraryStore) -> BulkIngestPragmas {

--- a/src-tauri/crates/psysonic-library/src/sync/tombstone.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/tombstone.rs
@@ -95,13 +95,49 @@ impl<'a> TombstoneReconciler<'a> {
         if batch_size == 0 {
             return Ok(TombstoneReport::default());
         }
-        let Some(cutoff_id) = self.capture_cutoff_id()? else {
+        let Some(cutoff_id) = self.capture_cutoff_id(None)? else {
             return Ok(TombstoneReport::default());
         };
         let mut report = TombstoneReport::default();
         let mut after_id: Option<String> = None;
         loop {
-            let ids = self.next_candidates_after(after_id.as_deref(), &cutoff_id, batch_size)?;
+            let ids =
+                self.next_candidates_after(after_id.as_deref(), &cutoff_id, batch_size, None)?;
+            if ids.is_empty() {
+                break;
+            }
+            after_id = ids.last().cloned();
+            let chunk = self.reconcile_ids(ids).await?;
+            report.checked = report.checked.saturating_add(chunk.checked);
+            report.deleted = report.deleted.saturating_add(chunk.deleted);
+        }
+        Ok(report)
+    }
+
+    /// Verify only rows a completed resync did not re-stamp. This is the
+    /// scope-safe counterpart to the generation sweep: `getSong` NotFound is
+    /// authoritative for deletion, while a row omitted by a partial ingest is
+    /// confirmed alive and retained.
+    pub async fn reconcile_resync_orphans(
+        &self,
+        resync_gen: i64,
+        batch_size: u32,
+    ) -> Result<TombstoneReport, SyncError> {
+        if batch_size == 0 {
+            return Ok(TombstoneReport::default());
+        }
+        let Some(cutoff_id) = self.capture_cutoff_id(Some(resync_gen))? else {
+            return Ok(TombstoneReport::default());
+        };
+        let mut report = TombstoneReport::default();
+        let mut after_id: Option<String> = None;
+        loop {
+            let ids = self.next_candidates_after(
+                after_id.as_deref(),
+                &cutoff_id,
+                batch_size,
+                Some(resync_gen),
+            )?;
             if ids.is_empty() {
                 break;
             }
@@ -190,13 +226,31 @@ impl<'a> TombstoneReconciler<'a> {
             .map_err(SyncError::Storage)
     }
 
-    fn capture_cutoff_id(&self) -> Result<Option<String>, SyncError> {
+    fn capture_cutoff_id(&self, resync_gen: Option<i64>) -> Result<Option<String>, SyncError> {
         self.store
             .with_conn("tombstone.capture_cutoff", |c| {
                 if self.library_scope.is_empty() {
+                    if let Some(resync_gen) = resync_gen {
+                        c.query_row(
+                            "SELECT MAX(id) FROM track \
+                             WHERE server_id = ?1 AND deleted = 0 \
+                               AND COALESCE(resync_gen, 0) != ?2",
+                            rusqlite::params![self.server_id, resync_gen],
+                            |row| row.get(0),
+                        )
+                    } else {
+                        c.query_row(
+                            "SELECT MAX(id) FROM track WHERE server_id = ?1 AND deleted = 0",
+                            rusqlite::params![self.server_id],
+                            |row| row.get(0),
+                        )
+                    }
+                } else if let Some(resync_gen) = resync_gen {
                     c.query_row(
-                        "SELECT MAX(id) FROM track WHERE server_id = ?1 AND deleted = 0",
-                        rusqlite::params![self.server_id],
+                        "SELECT MAX(id) FROM track \
+                         WHERE server_id = ?1 AND library_id = ?2 AND deleted = 0 \
+                           AND COALESCE(resync_gen, 0) != ?3",
+                        rusqlite::params![self.server_id, self.library_scope, resync_gen],
                         |row| row.get(0),
                     )
                 } else {
@@ -216,19 +270,70 @@ impl<'a> TombstoneReconciler<'a> {
         after_id: Option<&str>,
         cutoff_id: &str,
         budget: u32,
+        resync_gen: Option<i64>,
     ) -> Result<Vec<String>, SyncError> {
         self.store
             .with_conn("tombstone.next_candidates_after", |c| {
                 if self.library_scope.is_empty() {
+                    if let Some(resync_gen) = resync_gen {
+                        let mut statement = c.prepare(
+                            "SELECT id FROM track \
+                             WHERE server_id = ?1 AND deleted = 0 \
+                               AND COALESCE(resync_gen, 0) != ?2 AND id <= ?3 \
+                               AND (?4 IS NULL OR id > ?4) \
+                             ORDER BY id ASC LIMIT ?5",
+                        )?;
+                        let rows = statement
+                            .query_map(
+                                rusqlite::params![
+                                    self.server_id,
+                                    resync_gen,
+                                    cutoff_id,
+                                    after_id,
+                                    budget as i64
+                                ],
+                                |row| row.get::<_, String>(0),
+                            )?
+                            .collect();
+                        rows
+                    } else {
+                        let mut statement = c.prepare(
+                            "SELECT id FROM track \
+                             WHERE server_id = ?1 AND deleted = 0 AND id <= ?2 \
+                               AND (?3 IS NULL OR id > ?3) \
+                             ORDER BY id ASC LIMIT ?4",
+                        )?;
+                        let rows = statement
+                            .query_map(
+                                rusqlite::params![
+                                    self.server_id,
+                                    cutoff_id,
+                                    after_id,
+                                    budget as i64
+                                ],
+                                |row| row.get::<_, String>(0),
+                            )?
+                            .collect();
+                        rows
+                    }
+                } else if let Some(resync_gen) = resync_gen {
                     let mut statement = c.prepare(
                         "SELECT id FROM track \
-                         WHERE server_id = ?1 AND deleted = 0 AND id <= ?2 \
-                           AND (?3 IS NULL OR id > ?3) \
-                         ORDER BY id ASC LIMIT ?4",
+                         WHERE server_id = ?1 AND library_id = ?2 AND deleted = 0 \
+                           AND COALESCE(resync_gen, 0) != ?3 AND id <= ?4 \
+                           AND (?5 IS NULL OR id > ?5) \
+                         ORDER BY id ASC LIMIT ?6",
                     )?;
                     let rows = statement
                         .query_map(
-                            rusqlite::params![self.server_id, cutoff_id, after_id, budget as i64],
+                            rusqlite::params![
+                                self.server_id,
+                                self.library_scope,
+                                resync_gen,
+                                cutoff_id,
+                                after_id,
+                                budget as i64
+                            ],
                             |row| row.get::<_, String>(0),
                         )?
                         .collect();

--- a/src-tauri/crates/psysonic-library/src/sync/tombstone/tests/full_pass.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/tombstone/tests/full_pass.rs
@@ -85,6 +85,72 @@ async fn full_pass_checks_more_than_one_budget_and_stays_in_scope() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn resync_orphan_pass_checks_only_unstamped_rows_in_scope() {
+    let server = MockServer::start().await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/rest/getSong.view"))
+        .and(query_param("id", "a-stale"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "subsonic-response": {
+                "status": "failed",
+                "error": { "code": 70, "message": "Song not found" }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let store = LibraryStore::open_in_memory();
+    for (id, library_id, resync_gen) in [
+        ("a-stale", "lib-a", 1_i64),
+        ("a-current", "lib-a", 2_i64),
+        ("b-stale", "lib-b", 1_i64),
+    ] {
+        seed_scoped_track(&store, id, 1, Some(library_id), None);
+        store
+            .with_conn_mut("test.set_resync_generation", |conn| {
+                conn.execute(
+                    "UPDATE track SET resync_gen = ?2 WHERE id = ?1",
+                    rusqlite::params![id, resync_gen],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    let report = TombstoneReconciler::new(&store, &test_subsonic(&server.uri()), "s1")
+        .with_library_scope("lib-a")
+        .with_sleep_disabled()
+        .reconcile_resync_orphans(2, 200)
+        .await
+        .unwrap();
+    assert_eq!(report.checked, 1);
+    assert_eq!(report.deleted, 1);
+
+    let states: (i64, i64, i64) = store
+        .with_read_conn(|conn| {
+            Ok((
+                conn.query_row(
+                    "SELECT deleted FROM track WHERE id = 'a-stale'",
+                    [],
+                    |row| row.get(0),
+                )?,
+                conn.query_row(
+                    "SELECT deleted FROM track WHERE id = 'a-current'",
+                    [],
+                    |row| row.get(0),
+                )?,
+                conn.query_row(
+                    "SELECT deleted FROM track WHERE id = 'b-stale'",
+                    [],
+                    |row| row.get(0),
+                )?,
+            ))
+        })
+        .unwrap();
+    assert_eq!(states, (1, 0, 0));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn tombstone_deletion_refreshes_projection_and_identity() {
     let server = MockServer::start().await;
     Mock::given(wm_method("GET"))


### PR DESCRIPTION
## Summary
- verify unstamped tracks after a scoped Navidrome resync before retaining them in the local library
- remove only tracks confirmed missing by `getSong`, while preserving transient failures and tracks outside the active scope
- exclude server-side missing rows from Navidrome song listings so tombstone reconciliation sees only live tracks

Closes #1496.

## User impact
Deleted albums and tracks no longer remain as fragmented ghost entries after a scoped Navidrome library rebuild. Existing tracks and tracks outside the selected music-folder scope remain intact.

## Verification
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- --test-threads=1`
- focused sync tests: 37 `sync::initial::tests::*` and 12 `sync::tombstone::tests::*`
- `nix develop -c bash -lc 'npm run prebuild:release-notes'`
- `git diff --check origin/main...HEAD`

## Runtime benchmark
- Applicability: required because reconciliation can run as background library work
- Baseline: `c641e1a4` / report `2026-09-05T09-27-46-856Z`
- Final runtime source: `fdbf7235` / report `2026-09-05T09-31-27-160Z` (current head `91e111d9` adds changelog only)
- Command: `psysonic benchmark run --scenario core-pages --runs 2 --profile realistic --json`
- Environment: 1280x720 viewport, 3 selected servers, identical scope fingerprint and user agent
- Result: no errors, timeouts, wrong routes, failed interactions, or skipped routes; changed resync reconciliation did not execute during the route run
- Variance: route deltas moved in both directions and did not reproduce consistently across repeated comparable runs, so this PR makes no performance claim

## Contracts and storage
- Tauri boundary: unchanged
- SQLite schema and on-disk layout: unchanged
- Existing install migration: not required