### PR TITLE
fix(album): show OpenSubsonic disc subtitles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Albums and tracks deleted from a Navidrome server no longer remain as fragmented ghost entries after rebuilding a selected library.
 
+### Multi-disc album subtitles appear again
+
+**By [@cucadmuh](https://github.com/cucadmuh), reported by [@BjarneMJ](https://github.com/BjarneMJ), PR [#1498](https://github.com/Psysonic/psysonic/pull/1498)**
+
+* Album Detail now shows OpenSubsonic per-disc subtitles returned by Navidrome, such as "The demos", instead of falling back to only "Disc 3" and "Disc 4" after loading the album from the local library index.
+
 ## [1.52.0]
 
 ## Added

--- a/src/features/album/hooks/useAlbumServerMetadataReconcile.ts
+++ b/src/features/album/hooks/useAlbumServerMetadataReconcile.ts
@@ -26,7 +26,7 @@ interface Args {
 
 /**
  * After album detail paints from the local index, reconcile album-level
- * favorite + rating against the server in the background.
+ * album metadata against the server in the background.
  */
 export function useAlbumServerMetadataReconcile({
   serverId,
@@ -89,7 +89,12 @@ export function useAlbumServerMetadataReconcile({
 
         patchAlbumStarToIndexFromReconcile(serverId, albumId, patch);
 
-        onReconcileApplied?.(albumId);
+        if (
+          patch.userRating !== albumUserRating(current)
+          || 'starred' in patch
+        ) {
+          onReconcileApplied?.(albumId);
+        }
         reconciledKeyRef.current = reconcileKey;
       } catch {
         /* offline / transient — keep local; allow retry */

--- a/src/lib/library/albumServerMetadataReconcile.test.ts
+++ b/src/lib/library/albumServerMetadataReconcile.test.ts
@@ -39,6 +39,22 @@ describe('albumServerMetadataReconcile', () => {
     expect(diffAlbumServerMetadata(local, server)).toEqual({ userRating: 5 });
   });
 
+  it('applies disc subtitles returned by a fresh getAlbum response', () => {
+    const discTitles = [
+      { disc: 3, title: 'The demos' },
+      { disc: 4, title: 'The demos' },
+    ];
+    const patch = diffAlbumServerMetadata(base, { ...base, discTitles });
+
+    expect(patch).toEqual({ userRating: 0, discTitles });
+    expect(applyAlbumServerMetadataPatch(base, patch!)).toMatchObject({ discTitles });
+  });
+
+  it('does not clear cached disc subtitles when the server omits the field', () => {
+    const local = { ...base, discTitles: [{ disc: 2, title: 'Bonus tracks' }] };
+    expect(diffAlbumServerMetadata(local, base)).toBeNull();
+  });
+
   it('applyAlbumServerMetadataPatch clears unrated stars', () => {
     const patched = applyAlbumServerMetadataPatch(
       { ...base, userRating: 2, starred: 'x' },

--- a/src/lib/library/albumServerMetadataReconcile.ts
+++ b/src/lib/library/albumServerMetadataReconcile.ts
@@ -1,12 +1,23 @@
 import { getAlbumForServer } from '@/lib/api/subsonicLibrary';
 import { parseSubsonicEntityStarRating } from '@/lib/api/subsonicRatings';
-import type { SubsonicAlbum } from '@/lib/api/subsonicTypes';
+import type { SubsonicAlbum, SubsonicDiscTitle } from '@/lib/api/subsonicTypes';
 import { patchLibraryAlbumOnUse } from '@/lib/library/patchOnUse';
 
 export type AlbumServerMetadataPatch = {
   userRating: number;
   starred?: string;
+  discTitles?: SubsonicDiscTitle[];
 };
+
+function discTitlesEqual(
+  local: SubsonicDiscTitle[] | undefined,
+  server: SubsonicDiscTitle[],
+): boolean {
+  const localTitles = local ?? [];
+  return localTitles.length === server.length && localTitles.every((entry, index) => (
+    entry.disc === server[index]?.disc && entry.title === server[index]?.title
+  ));
+}
 
 export function albumIsStarred(album: SubsonicAlbum): boolean {
   return !!album.starred;
@@ -25,10 +36,19 @@ export function diffAlbumServerMetadata(
   const localRating = albumUserRating(local);
   const serverStarred = albumIsStarred(server);
   const localStarred = albumIsStarred(local);
-  if (serverRating === localRating && serverStarred === localStarred) return null;
+  const discTitlesChanged = server.discTitles !== undefined
+    && !discTitlesEqual(local.discTitles, server.discTitles);
+  if (
+    serverRating === localRating
+    && serverStarred === localStarred
+    && !discTitlesChanged
+  ) return null;
   const patch: AlbumServerMetadataPatch = { userRating: serverRating };
   if (serverStarred !== localStarred) {
     patch.starred = server.starred;
+  }
+  if (discTitlesChanged) {
+    patch.discTitles = server.discTitles;
   }
   return patch;
 }
@@ -41,6 +61,7 @@ export function applyAlbumServerMetadataPatch(
     ...album,
     userRating: patch.userRating > 0 ? patch.userRating : undefined,
     ...('starred' in patch ? { starred: patch.starred } : {}),
+    ...('discTitles' in patch ? { discTitles: patch.discTitles } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- reconcile `discTitles` returned by the fresh background `getAlbum` response into Album Detail
- preserve cached disc subtitles when a server omits the optional field
- avoid clearing unrelated optimistic rating/favourite overrides for a disc-title-only refresh
- add the 1.53.0 changelog entry with PR and issue-reporter attribution

Fixes #1494

## Verification
- `npm run lint`
- `npm run dep:check`
- `npm test` (604 files, 4644 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`
- `git diff --check`

## Runtime benchmark
- Applicability: final smoke required because Album Detail behaviour changes
- Benchmarked code: `213bfde5`; current PR head `8a921244` adds only `CHANGELOG.md`
- Report: `2026-09-05T10-32-11-752Z`
- Command: `psysonic benchmark run --scenario all-pages --runs 2 --profile realistic --json`
- Environment: Linux debug, 1160x694 viewport, 3 selected servers, stable library scope
- Album Detail: actual route matched; cold 1660 ms, warm 1559 ms; no errors or timeouts
- Skips: label detail only, because no reachable owned album with a record label was available
- Comparison: ignored because the preceding report was captured with a false offline state and a different viewport

## Contracts
- Tauri boundary: unchanged
- Persisted settings / on-disk schema: unchanged