### PR TITLE
Fix playlist scroll restoration after detail navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Album Detail now shows OpenSubsonic per-disc subtitles returned by Navidrome, such as "The demos", instead of falling back to only "Disc 3" and "Disc 4" after loading the album from the local library index.
 
+### Playlist pages return to where you left off
+
+**By [@cucadmuh](https://github.com/cucadmuh), reported by MrMiniblock on Discord, PR [#1499](https://github.com/Psysonic/psysonic/pull/1499)**
+
+* Opening an album or artist from a long playlist and then going back now restores the previous scroll position instead of returning to the top.
+
 ## [1.52.0]
 
 ## Added

--- a/src/features/playlist/components/PlaylistArtistCell.test.tsx
+++ b/src/features/playlist/components/PlaylistArtistCell.test.tsx
@@ -71,6 +71,7 @@ describe('PlaylistArtistCell', () => {
       <PlaylistArtistCell song={song({
         artist: 'Primary feat. Guest', artistId: 'a1', serverId: 'srv-owner',
       })} />,
+      { route: '/playlists/pl-1?server=srv-owner' },
     );
 
     await waitFor(() => expect(resolveArtistIds).toHaveBeenCalledWith('srv-owner', ['Guest']));
@@ -78,10 +79,14 @@ describe('PlaylistArtistCell', () => {
     expect(guest).toHaveAttribute('tabindex', '0');
 
     fireEvent.keyDown(guest, { key: 'Enter' });
-    expect(navigate).toHaveBeenCalledWith('/artist/ar-guest?server=srv-owner');
+    expect(navigate).toHaveBeenCalledWith('/artist/ar-guest?server=srv-owner', {
+      state: { returnTo: '/playlists/pl-1?server=srv-owner', playlistDetailScrollTop: 0 },
+    });
 
     navigate.mockClear();
     fireEvent.keyDown(guest, { key: ' ' });
-    expect(navigate).toHaveBeenCalledWith('/artist/ar-guest?server=srv-owner');
+    expect(navigate).toHaveBeenCalledWith('/artist/ar-guest?server=srv-owner', {
+      state: { returnTo: '/playlists/pl-1?server=srv-owner', playlistDetailScrollTop: 0 },
+    });
   });
 });

--- a/src/features/playlist/components/PlaylistArtistCell.tsx
+++ b/src/features/playlist/components/PlaylistArtistCell.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import type { SubsonicSong } from '@/lib/api/subsonicTypes';
 import { resolveTrackArtistRefs } from '@/features/playback/utils/playback/trackArtistRefs';
 import { useAuthStore } from '@/store/authStore';
-import { buildArtistDetailPath } from '@/lib/navigation/detailServerScope';
 import { ResolvedArtistRefInline } from '@/ui/ResolvedArtistRefInline';
+import { navigateToArtistDetail } from '@/lib/navigation/albumDetailNavigation';
 
 /**
  * Multi-artist credit for playlist track rows (main list + suggestions).
@@ -16,6 +16,7 @@ import { ResolvedArtistRefInline } from '@/ui/ResolvedArtistRefInline';
  */
 export function PlaylistArtistCell({ song }: { song: SubsonicSong }) {
   const navigate = useNavigate();
+  const location = useLocation();
   const activeServerId = useAuthStore(s => s.activeServerId ?? '');
   const artistRefs = useMemo(() => resolveTrackArtistRefs(song), [song]);
   return (
@@ -24,7 +25,12 @@ export function PlaylistArtistCell({ song }: { song: SubsonicSong }) {
         refs={artistRefs}
         serverId={song.serverId ?? activeServerId}
         fallbackName={song.artist}
-        onGoArtist={id => navigate(buildArtistDetailPath(id, { serverId: song.serverId }))}
+        onGoArtist={id => navigateToArtistDetail(
+          navigate,
+          location,
+          id,
+          { serverId: song.serverId },
+        )}
         as="none"
         linkTag="span"
         plainClassName="track-artist"

--- a/src/features/playlist/components/PlaylistSuggestions.tsx
+++ b/src/features/playlist/components/PlaylistSuggestions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { ChevronRight, Heart, Play, Plus, RefreshCw, Square } from 'lucide-react';
 import type { ColDef } from '@/lib/hooks/useTracklistColumns';
 import type { SubsonicSong } from '@/lib/api/subsonicTypes';
@@ -21,8 +21,8 @@ import { COVER_ARTIST_TOP_TRACK_CSS_PX } from '@/cover/layoutSizes';
 import { useWarmTrackListAlbumCovers } from '@/cover/useWarmTrackListAlbumCovers';
 import { useTrackListCoverArtEnabled } from '@/cover/useTrackListCoverArtSettings';
 import { ownedOverrideValue } from '@/lib/util/ownedEntityKey';
-import { appendServerQuery } from '@/lib/navigation/detailServerScope';
 import { useResolvedTracklistBpm } from '@/lib/hooks/useResolvedTracklistBpm';
+import { navigateToAlbumDetail } from '@/lib/navigation/albumDetailNavigation';
 
 const PL_CENTERED = new Set(['favorite', 'rating', 'duration', 'playCount', 'bpm']);
 
@@ -58,6 +58,7 @@ export default function PlaylistSuggestions({
 }: Props) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
   const openContextMenu = usePlayerStore(s => s.openContextMenu);
   const starredOverrides = usePlayerStore(s => s.starredOverrides);
   const userRatingOverrides = usePlayerStore(s => s.userRatingOverrides);
@@ -200,8 +201,9 @@ export default function PlaylistSuggestions({
                       <span className={`track-artist${song.albumId ? ' track-artist-link' : ''}`} style={{ cursor: song.albumId ? 'pointer' : 'default' }} onClick={e => {
                         if (!song.albumId) return;
                         e.stopPropagation();
-                        const query = appendServerQuery(undefined, song.serverId);
-                        navigate(`/album/${song.albumId}${query ? `?${query}` : ''}`);
+                        navigateToAlbumDetail(navigate, location, song.albumId, {
+                          serverId: song.serverId,
+                        });
                       }}>{song.album}</span>
                     </div>
                   );

--- a/src/features/playlist/components/PlaylistTracklist.tsx
+++ b/src/features/playlist/components/PlaylistTracklist.tsx
@@ -5,7 +5,7 @@ import { TracklistColumnPicker } from '@/ui/TracklistColumnPicker';
 import { useTranslation } from 'react-i18next';
 import { APP_MAIN_SCROLL_VIEWPORT_ID } from '@/constants/appScroll';
 import { useElementClientHeightById } from '@/lib/hooks/useResizeClientHeight';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import {
   ListPlus, Search, Trash2, X,
 } from 'lucide-react';
@@ -24,7 +24,7 @@ import { COVER_ARTIST_TOP_TRACK_CSS_PX } from '@/cover/layoutSizes';
 import { useWarmTrackListAlbumCovers } from '@/cover/useWarmTrackListAlbumCovers';
 import { useTrackListCoverArtEnabled } from '@/cover/useTrackListCoverArtSettings';
 import { ownedOverrideValue } from '@/lib/util/ownedEntityKey';
-import { appendServerQuery } from '@/lib/navigation/detailServerScope';
+import { navigateToAlbumDetail } from '@/lib/navigation/albumDetailNavigation';
 
 const PL_CENTERED = new Set(['favorite', 'rating', 'duration', 'playCount', 'bpm']);
 
@@ -105,6 +105,7 @@ export default function PlaylistTracklist({
 }: Props) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
   const currentTrack = usePlayerStore(s => s.currentTrack);
   const isPlaying = usePlayerStore(s => s.isPlaying);
   const playTrack = usePlayerStore(s => s.playTrack);
@@ -122,7 +123,7 @@ export default function PlaylistTracklist({
     selectedIds, orbitActive, displayedTracks, isFiltered, id, songs, serverId,
     toggleSelect, handleRowMouseDown, handleRowMouseEnter, handleToggleStar,
     handleRate, removeSong, playTrack, openContextMenu, setContextMenuSongId,
-    navigate, queueHint, addTrackToOrbit,
+    navigate, location, queueHint, addTrackToOrbit,
   };
   const latest = useRef(latestVals);
   latest.current = latestVals;
@@ -178,8 +179,8 @@ export default function PlaylistTracklist({
     rate: (songId, r) => latest.current.handleRate(songId, r),
     remove: (rIdx) => latest.current.removeSong(rIdx),
     navAlbum: (albumId) => {
-      const query = appendServerQuery(undefined, latest.current.serverId);
-      latest.current.navigate(`/album/${albumId}${query ? `?${query}` : ''}`);
+      const L = latest.current;
+      navigateToAlbumDetail(L.navigate, L.location, albumId, { serverId: L.serverId });
     },
   }), []);
 

--- a/src/features/playlist/components/PlaylistTracklist.tsx
+++ b/src/features/playlist/components/PlaylistTracklist.tsx
@@ -25,6 +25,7 @@ import { useWarmTrackListAlbumCovers } from '@/cover/useWarmTrackListAlbumCovers
 import { useTrackListCoverArtEnabled } from '@/cover/useTrackListCoverArtSettings';
 import { ownedOverrideValue } from '@/lib/util/ownedEntityKey';
 import { navigateToAlbumDetail } from '@/lib/navigation/albumDetailNavigation';
+import { usePlaylistTracklistScrollReset } from '@/features/playlist/hooks/usePlaylistTracklistScrollReset';
 
 const PL_CENTERED = new Set(['favorite', 'rating', 'duration', 'playCount', 'bpm']);
 
@@ -219,13 +220,7 @@ export default function PlaylistTracklist({
     getItemKey: i => `${displayedSongs[i].id}:${i}`,
   });
 
-  const firstRender = useRef(true);
-  useEffect(() => {
-    if (firstRender.current) { firstRender.current = false; return; }
-    const sc = document.getElementById(APP_MAIN_SCROLL_VIEWPORT_ID);
-    if (sc) sc.scrollTop = scrollMargin;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, hasActiveFilter]);
+  usePlaylistTracklistScrollReset({ id, hasActiveFilter, scrollMargin });
 
   const autoScrollRef = useRef(0);
   const pointerYRef = useRef(0);

--- a/src/features/playlist/hooks/usePlaylistDetailScrollRestore.test.ts
+++ b/src/features/playlist/hooks/usePlaylistDetailScrollRestore.test.ts
@@ -1,0 +1,58 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const navigate = vi.hoisted(() => vi.fn());
+const restoreMainViewportScroll = vi.hoisted(() => vi.fn());
+const location = vi.hoisted(() => ({
+  pathname: '/playlists/pl-1',
+  search: '?server=srv-a',
+  hash: '',
+  state: { playlistDetailScrollTop: 864 } as unknown,
+}));
+
+vi.mock('react-router', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-router')>()),
+  useLocation: () => location,
+  useNavigate: () => navigate,
+}));
+
+vi.mock('@/lib/navigation/restoreMainViewportScroll', () => ({
+  restoreMainViewportScroll,
+}));
+
+import { usePlaylistDetailScrollRestore } from './usePlaylistDetailScrollRestore';
+
+describe('usePlaylistDetailScrollRestore', () => {
+  beforeEach(() => {
+    navigate.mockReset();
+    restoreMainViewportScroll.mockReset();
+    restoreMainViewportScroll.mockImplementation((_scrollTop, onComplete) => {
+      onComplete();
+      return vi.fn();
+    });
+    location.state = { playlistDetailScrollTop: 864 };
+  });
+
+  it('waits until playlist content is ready', () => {
+    renderHook(() => usePlaylistDetailScrollRestore(false));
+    expect(restoreMainViewportScroll).not.toHaveBeenCalled();
+  });
+
+  it('restores scroll and clears the one-shot navigation state', () => {
+    renderHook(() => usePlaylistDetailScrollRestore(true));
+    expect(restoreMainViewportScroll).toHaveBeenCalledWith(864, expect.any(Function));
+    expect(navigate).toHaveBeenCalledWith('/playlists/pl-1?server=srv-a', {
+      replace: true,
+      state: null,
+    });
+  });
+
+  it('does not navigate when an unfinished restore is cancelled on unmount', () => {
+    restoreMainViewportScroll.mockImplementation((_scrollTop, onComplete) => () => onComplete());
+    const { unmount } = renderHook(() => usePlaylistDetailScrollRestore(true));
+
+    unmount();
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/playlist/hooks/usePlaylistDetailScrollRestore.ts
+++ b/src/features/playlist/hooks/usePlaylistDetailScrollRestore.ts
@@ -1,0 +1,29 @@
+import { useLayoutEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { readPlaylistDetailScrollTop } from '@/lib/navigation/albumDetailNavigation';
+import { restoreMainViewportScroll } from '@/lib/navigation/restoreMainViewportScroll';
+
+/** Restore Playlist Detail's main viewport after its virtual track list is ready. */
+export function usePlaylistDetailScrollRestore(contentReady: boolean): void {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const scrollTop = readPlaylistDetailScrollTop(location.state);
+
+  useLayoutEffect(() => {
+    if (!contentReady || scrollTop === null) return;
+    const returnTo = `${location.pathname}${location.search}${location.hash}`;
+    let active = true;
+    const finish = () => {
+      if (active) navigate(returnTo, { replace: true, state: null });
+    };
+    if (scrollTop <= 0) {
+      finish();
+      return;
+    }
+    const cancel = restoreMainViewportScroll(scrollTop, finish);
+    return () => {
+      active = false;
+      cancel();
+    };
+  }, [contentReady, location.pathname, location.search, location.hash, navigate, scrollTop]);
+}

--- a/src/features/playlist/hooks/usePlaylistTracklistScrollReset.test.tsx
+++ b/src/features/playlist/hooks/usePlaylistTracklistScrollReset.test.tsx
@@ -1,0 +1,35 @@
+import { StrictMode } from 'react';
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { APP_MAIN_SCROLL_VIEWPORT_ID } from '@/constants/appScroll';
+import { usePlaylistTracklistScrollReset } from './usePlaylistTracklistScrollReset';
+
+describe('usePlaylistTracklistScrollReset', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('preserves restored scroll through StrictMode effect replay', () => {
+    const viewport = document.createElement('div');
+    viewport.id = APP_MAIN_SCROLL_VIEWPORT_ID;
+    viewport.scrollTop = 864;
+    document.body.appendChild(viewport);
+
+    const { rerender } = renderHook(
+      ({ hasActiveFilter }) => usePlaylistTracklistScrollReset({
+        id: 'pl-1',
+        hasActiveFilter,
+        scrollMargin: 120,
+      }),
+      {
+        initialProps: { hasActiveFilter: false },
+        wrapper: StrictMode,
+      },
+    );
+
+    expect(viewport.scrollTop).toBe(864);
+
+    rerender({ hasActiveFilter: true });
+    expect(viewport.scrollTop).toBe(120);
+  });
+});

--- a/src/features/playlist/hooks/usePlaylistTracklistScrollReset.ts
+++ b/src/features/playlist/hooks/usePlaylistTracklistScrollReset.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react';
+import { APP_MAIN_SCROLL_VIEWPORT_ID } from '@/constants/appScroll';
+
+interface PlaylistTracklistScrollResetInputs {
+  id: string | undefined;
+  hasActiveFilter: boolean;
+  scrollMargin: number;
+}
+
+/** Scroll to the tracklist only when the playlist or active filter actually changes. */
+export function usePlaylistTracklistScrollReset({
+  id,
+  hasActiveFilter,
+  scrollMargin,
+}: PlaylistTracklistScrollResetInputs): void {
+  const previousInputsRef = useRef({ id, hasActiveFilter });
+
+  useEffect(() => {
+    const previous = previousInputsRef.current;
+    previousInputsRef.current = { id, hasActiveFilter };
+    if (previous.id === id && previous.hasActiveFilter === hasActiveFilter) return;
+
+    const viewport = document.getElementById(APP_MAIN_SCROLL_VIEWPORT_ID);
+    if (viewport) viewport.scrollTop = scrollMargin;
+  }, [id, hasActiveFilter, scrollMargin]);
+}

--- a/src/features/playlist/pages/PlaylistDetail.tsx
+++ b/src/features/playlist/pages/PlaylistDetail.tsx
@@ -47,6 +47,7 @@ import { offlineActionPolicy } from '@/features/offline';
 import { readDetailServerId } from '@/lib/navigation/detailServerScope';
 import { ownedEntityKey } from '@/lib/util/ownedEntityKey';
 import { useResolvedTracklistBpm } from '@/lib/hooks/useResolvedTracklistBpm';
+import { usePlaylistDetailScrollRestore } from '@/features/playlist/hooks/usePlaylistDetailScrollRestore';
 
 // ── Column configuration ──────────────────────────────────────────────────────
 const PL_COLUMNS: readonly ColDef[] = [
@@ -309,6 +310,8 @@ export default function PlaylistDetail() {
   const { handlePlayAll, handleShuffleAll, handleEnqueueAll } = usePlaylistBulkPlayCallbacks({
     songsLength: songs.length, id, tracks, playTrack, enqueue,
   });
+
+  usePlaylistDetailScrollRestore(!loading && playlist !== null);
 
   // ── Render ────────────────────────────────────────────────────
   if (loading) {

--- a/src/lib/navigation/albumDetailNavigation.test.ts
+++ b/src/lib/navigation/albumDetailNavigation.test.ts
@@ -18,6 +18,7 @@ import { useAdvancedSearchSessionStore } from '@/store/advancedSearchSessionStor
 describe('albumDetailNavigation', () => {
   afterEach(() => {
     useAdvancedSearchSessionStore.getState().clearLeaveScrollSnapshot();
+    document.body.replaceChildren();
   });
 
   it('reads returnTo from location state', () => {
@@ -48,6 +49,28 @@ describe('albumDetailNavigation', () => {
     );
     expect(navigate).toHaveBeenCalledWith('/album/alb-1?server=srv-b', {
       state: { returnTo: '/search?q=album' },
+    });
+  });
+
+  it('captures playlist scroll when navigating to an album', () => {
+    const viewport = document.createElement('div');
+    viewport.id = 'app-main-scroll-viewport';
+    viewport.scrollTop = 864;
+    document.body.appendChild(viewport);
+    const navigate = vi.fn();
+
+    navigateToAlbumDetail(
+      navigate,
+      { pathname: '/playlists/pl-1', search: '?server=srv-a', hash: '', state: null },
+      'alb-1',
+      { serverId: 'srv-a' },
+    );
+
+    expect(navigate).toHaveBeenCalledWith('/album/alb-1?server=srv-a', {
+      state: {
+        returnTo: '/playlists/pl-1?server=srv-a',
+        playlistDetailScrollTop: 864,
+      },
     });
   });
 
@@ -186,6 +209,19 @@ describe('albumDetailNavigation', () => {
     });
   });
 
+  it('returns to a playlist with its saved scroll position', () => {
+    const navigate = vi.fn();
+    navigateAlbumDetailBack(navigate, {
+      state: {
+        returnTo: '/playlists/pl-1?server=srv-a',
+        playlistDetailScrollTop: 864,
+      },
+    });
+    expect(navigate).toHaveBeenCalledWith('/playlists/pl-1?server=srv-a', {
+      state: { playlistDetailScrollTop: 864 },
+    });
+  });
+
   it('navigates to artist with returnTo snapshot from Advanced Search', () => {
     const navigate = vi.fn();
     navigateToArtistDetail(
@@ -258,6 +294,17 @@ describe('albumDetailNavigation', () => {
   it('skips main scroll reset when Search session restore is pending', () => {
     expect(shouldSkipMainScrollResetOnRouteChange('/search', { advancedSearchRestore: true })).toBe(true);
     expect(shouldSkipMainScrollResetOnRouteChange('/tracks', { advancedSearchRestore: true })).toBe(true);
+  });
+
+  it('skips main scroll reset when Playlist Detail scroll restore is pending', () => {
+    expect(shouldSkipMainScrollResetOnRouteChange(
+      '/playlists/pl-1',
+      { playlistDetailScrollTop: 864 },
+    )).toBe(true);
+    expect(shouldSkipMainScrollResetOnRouteChange(
+      '/albums',
+      { playlistDetailScrollTop: 864 },
+    )).toBe(false);
   });
 
   it('skips main scroll reset when Advanced Search vertical scroll restore is pending', () => {

--- a/src/lib/navigation/albumDetailNavigation.ts
+++ b/src/lib/navigation/albumDetailNavigation.ts
@@ -7,6 +7,7 @@ import {
   isAlbumDetailPath,
   isArtistDetailPath,
   isComposerDetailPath,
+  isPlaylistDetailPath,
 } from '@/lib/navigation/detailRoutePaths';
 import {
   peekPersistedAdvancedSearchLeaveSnapshot,
@@ -18,10 +19,12 @@ import {
   buildComposerDetailPath,
   type ArtistDetailPathOptions,
 } from '@/lib/navigation/detailServerScope';
+import { APP_MAIN_SCROLL_VIEWPORT_ID } from '@/constants/appScroll';
 
 export type AlbumDetailLocationState = {
   returnTo?: string;
   returnState?: AlbumDetailLocationState;
+  playlistDetailScrollTop?: number;
 };
 
 export type AlbumsBrowseRestoreLocationState = {
@@ -29,6 +32,7 @@ export type AlbumsBrowseRestoreLocationState = {
   artistBrowseRestore?: boolean;
   composerBrowseRestore?: boolean;
   advancedSearchRestore?: boolean;
+  playlistDetailScrollTop?: number;
 };
 
 export function readAlbumDetailReturnTo(state: unknown): string | null {
@@ -54,6 +58,12 @@ export function readAdvancedSearchRestore(state: unknown): boolean {
   return (state as AlbumsBrowseRestoreLocationState | null)?.advancedSearchRestore === true;
 }
 
+export function readPlaylistDetailScrollTop(state: unknown): number | null {
+  const scrollTop = (state as AlbumDetailLocationState | null)?.playlistDetailScrollTop;
+  if (typeof scrollTop !== 'number' || !Number.isFinite(scrollTop)) return null;
+  return Math.max(0, scrollTop);
+}
+
 export function buildReturnToFromLocation(
   location: Pick<Location, 'pathname' | 'search' | 'hash'>,
 ): string {
@@ -74,6 +84,12 @@ export function composerBrowseRestoreNavigationState(): AlbumsBrowseRestoreLocat
 
 export function advancedSearchRestoreNavigationState(): AlbumsBrowseRestoreLocationState {
   return { advancedSearchRestore: true };
+}
+
+export function playlistDetailRestoreNavigationState(
+  scrollTop: number,
+): AlbumsBrowseRestoreLocationState {
+  return { playlistDetailScrollTop: Math.max(0, scrollTop) };
 }
 
 export function shouldRestoreAdvancedSearchSession(
@@ -113,6 +129,7 @@ export function shouldSkipMainScrollResetOnRouteChange(
   if (readArtistBrowseRestore(locationState)) return true;
   if (readComposerBrowseRestore(locationState)) return true;
   if (readAdvancedSearchRestore(locationState)) return true;
+  if (isPlaylistDetailPath(pathname) && readPlaylistDetailScrollTop(locationState) !== null) return true;
   const leave = useAdvancedSearchSessionStore.getState().peekLeaveScrollSnapshot();
   if ((leave?.scrollTop ?? 0) > 0) return true;
   const stash = useAdvancedSearchSessionStore.getState().peekReturnStash();
@@ -149,13 +166,28 @@ function isGenreDetailReturnPath(path: string): boolean {
   return /^\/genres\/[^/]+$/.test(bare);
 }
 
-function browseReturnRestoreState(returnTo: string): AlbumsBrowseRestoreLocationState | undefined {
+function browseReturnRestoreState(
+  returnTo: string,
+  detailState: unknown,
+): AlbumsBrowseRestoreLocationState | undefined {
   if (isAlbumGridBrowseReturnPath(returnTo)) return albumBrowseRestoreNavigationState();
   if (isGenreDetailReturnPath(returnTo)) return albumBrowseRestoreNavigationState();
   if (isArtistsBrowseReturnPath(returnTo)) return artistBrowseRestoreNavigationState();
   if (isComposersBrowseReturnPath(returnTo)) return composerBrowseRestoreNavigationState();
   if (isSearchReturnPath(returnTo)) return advancedSearchRestoreNavigationState();
+  if (isPlaylistDetailPath(returnTo)) {
+    const scrollTop = readPlaylistDetailScrollTop(detailState);
+    if (scrollTop !== null) return playlistDetailRestoreNavigationState(scrollTop);
+  }
   return undefined;
+}
+
+function playlistDetailScrollTopForLocation(pathname: string): number | null {
+  if (!isPlaylistDetailPath(pathname)) return null;
+  const scrollTop = typeof document === 'undefined'
+    ? 0
+    : (document.getElementById(APP_MAIN_SCROLL_VIEWPORT_ID)?.scrollTop ?? 0);
+  return Number.isFinite(scrollTop) ? Math.max(0, scrollTop) : 0;
 }
 
 function buildDetailLocationState(
@@ -166,9 +198,15 @@ function buildDetailLocationState(
     || isArtistDetailPath(location.pathname)
     || isComposerDetailPath(location.pathname);
   const existing = readAlbumDetailReturnTo(location.state);
+  const playlistDetailScrollTop = playlistDetailScrollTopForLocation(location.pathname);
   return onDetail && existing
     ? { returnTo, returnState: location.state as AlbumDetailLocationState }
-    : { returnTo };
+    : {
+      returnTo,
+      ...(playlistDetailScrollTop !== null
+        ? { playlistDetailScrollTop }
+        : {}),
+    };
 }
 
 function saveSearchLeaveIfNeeded(
@@ -237,7 +275,7 @@ export function navigateAlbumDetailBack(
 ): void {
   const returnTo = readAlbumDetailReturnTo(location.state);
   if (returnTo) {
-    const restoreState = browseReturnRestoreState(returnTo);
+    const restoreState = browseReturnRestoreState(returnTo, location.state);
     const returnState = (location.state as AlbumDetailLocationState | null)?.returnState;
     const state = readAlbumDetailReturnTo(returnState) ? returnState : restoreState;
     navigate(returnTo, state ? { state } : undefined);

--- a/src/lib/navigation/detailRoutePaths.ts
+++ b/src/lib/navigation/detailRoutePaths.ts
@@ -19,3 +19,8 @@ export function isArtistDetailPath(pathname: string): boolean {
 export function isComposerDetailPath(pathname: string): boolean {
   return /^\/composer\/[^/]+\/?$/.test(pathname);
 }
+
+/** True when pathname is a single playlist detail route (`/playlists/:id`). */
+export function isPlaylistDetailPath(pathname: string): boolean {
+  return /^\/playlists\/[^/]+\/?$/.test(pathname.split('?')[0]?.replace(/\/$/, '') || pathname);
+}


### PR DESCRIPTION
## Summary
- preserve Playlist Detail scroll position when opening an album or artist
- restore the main viewport after playlist content is ready, then clear the one-shot route state
- keep the playlist tracklist scroll-reset effect from overwriting restoration during React StrictMode replay
- route playlist track and suggestion links through the shared detail navigation helpers

## Verification
- `npm run lint`
- `npm run dep:check`
- `npm test` (606 files, 4651 tests passed)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`
- focused navigation and playlist restore tests: 40 passed
- StrictMode regression test verifies restored scroll remains at 864 while a real filter change still scrolls to the tracklist

## Manual check
1. Open a playlist long enough to scroll.
2. Scroll down and open an album or artist from a track row.
3. Use the detail-page back control.
4. Confirm the playlist returns to the previous vertical position.

## Runtime benchmark
- Applicability: final smoke required because Playlist Detail route behaviour changed
- Baseline: `effae217` / report `2026-09-05T10-32-11-752Z`
- Final code: `5f543357` / reports `2026-09-05T12-08-50-862Z`, `2026-09-05T12-11-00-301Z`
- Command: `psysonic benchmark run --scenario all-pages --runs 2 --profile realistic --json`
- Environment: 1160x694 viewport, 3 selected servers, matching stable scope fingerprint
- Playlist Detail median total: 2133 ms baseline -> 2405 ms first final run / 1910 ms confirmation run
- Errors/timeouts/interaction failures: none
- Skips: label detail only, because no reachable owned album had a record label
- Route timings remained noisy between consecutive runs; the affected Playlist Detail route completed cleanly

## Tauri boundary
- No commands, events, or payloads changed.