### PR TITLE
Add global shortcuts for current-track ratings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * On Windows the update dialog now installs the new version itself, the way it already does on macOS: the installer is downloaded, its signature is checked against the key built into the app, and it runs in the background. Psysonic closes and reopens by itself when it is done.
 * Until now Windows only offered the installer as a download to run by hand. Installs of this version and later update in place; an older install still downloads the next installer once.
 
+### Rate the current track with a global shortcut
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1503](https://github.com/Psysonic/psysonic/pull/1503)**
+
+* Settings → Input → Global shortcuts now offers separate, unbound actions for assigning 1–5 stars to the current track, even while Psysonic is out of focus.
+
 ## Fixed
 
 ### Shared Top Albums pictures show their covers again

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -220,6 +220,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Timeline — replay listening history from any selected point (PR #1423)',
       'Offline downloads — slow-server tolerance, resumable transfers, owner-safe pins, and coordinated cancellation and maintenance (report: jsongerber, PR #1457)',
       'Navidrome canonical-ID upgrade — resumable migration for library, analysis, offline, cache, and persisted app state (PR #1464)',
+      'Global shortcuts for 1–5-star current-track ratings (PR #1503)',
     ],
   },
   {

--- a/src/config/shortcutActionRegistry.ts
+++ b/src/config/shortcutActionRegistry.ts
@@ -1,4 +1,4 @@
-import { queueSongStar } from '@/features/playback/store/pendingStarSync';
+import { queueSongRating, queueSongStar } from '@/features/playback/store/pendingStarSync';
 import { getSong } from '@/lib/api/subsonicLibrary';
 import { songToTrack } from '@/lib/media/songToTrack';
 import { openMiniPlayer } from '@/lib/api/miniPlayer';
@@ -32,6 +32,15 @@ function focusLiveSearchInput(): boolean {
   input.focus();
   input.select();
   return true;
+}
+
+function rateCurrentTrack(rating: number): void {
+  const track = usePlayerStore.getState().currentTrack;
+  if (!track) {
+    showToast(i18n.t('contextMenu.cliMixNeedsTrack', { defaultValue: 'Load a track first.' }), 5000, 'error');
+    return;
+  }
+  queueSongRating(track.id, rating, track.serverId);
 }
 
 
@@ -264,6 +273,36 @@ export const SHORTCUT_ACTION_REGISTRY = {
       }
       queueSongStar(track.id, true, track.serverId);
     },
+  },
+  'rate-current-track-1': {
+    getLabel: t => t('settings.shortcutRateCurrentTrack', { rating: 1 }),
+    global: { defaultBinding: null },
+    runInMiniWindow: false,
+    run: () => rateCurrentTrack(1),
+  },
+  'rate-current-track-2': {
+    getLabel: t => t('settings.shortcutRateCurrentTrack', { rating: 2 }),
+    global: { defaultBinding: null },
+    runInMiniWindow: false,
+    run: () => rateCurrentTrack(2),
+  },
+  'rate-current-track-3': {
+    getLabel: t => t('settings.shortcutRateCurrentTrack', { rating: 3 }),
+    global: { defaultBinding: null },
+    runInMiniWindow: false,
+    run: () => rateCurrentTrack(3),
+  },
+  'rate-current-track-4': {
+    getLabel: t => t('settings.shortcutRateCurrentTrack', { rating: 4 }),
+    global: { defaultBinding: null },
+    runInMiniWindow: false,
+    run: () => rateCurrentTrack(4),
+  },
+  'rate-current-track-5': {
+    getLabel: t => t('settings.shortcutRateCurrentTrack', { rating: 5 }),
+    global: { defaultBinding: null },
+    runInMiniWindow: false,
+    run: () => rateCurrentTrack(5),
   },
   'open-help': {
     getLabel: t => t('settings.shortcutOpenHelp', { defaultValue: 'Help' }),

--- a/src/config/shortcutDispatch.test.ts
+++ b/src/config/shortcutDispatch.test.ts
@@ -8,7 +8,7 @@ const hoisted = vi.hoisted(() => {
       player.volume = v;
     }),
   };
-  return { player, queueSongRating: vi.fn() };
+  return { player, queueSongRating: vi.fn(), queueSongStar: vi.fn() };
 });
 
 vi.mock('@/features/playback/store/playerStore', () => ({
@@ -16,9 +16,16 @@ vi.mock('@/features/playback/store/playerStore', () => ({
 }));
 vi.mock('@/features/playback/store/pendingStarSync', () => ({
   queueSongRating: hoisted.queueSongRating,
+  queueSongStar: hoisted.queueSongStar,
 }));
 
-import { executeCliPlayerCommand } from '@/config/shortcutDispatch';
+import {
+  DEFAULT_GLOBAL_SHORTCUTS,
+  GLOBAL_SHORTCUT_ACTIONS,
+  executeCliPlayerCommand,
+  executeRuntimeAction,
+  type GlobalAction,
+} from '@/config/shortcutActions';
 
 const navigate = vi.fn();
 
@@ -69,5 +76,30 @@ describe('executeCliPlayerCommand set-rating-current', () => {
     });
 
     expect(hoisted.queueSongRating).toHaveBeenCalledWith('shared', 4, 'srv-b');
+  });
+});
+
+const CURRENT_TRACK_RATING_ACTIONS = [1, 2, 3, 4, 5].map(
+  rating => [`rate-current-track-${rating}` as GlobalAction, rating] as const,
+);
+
+describe('current track rating shortcut actions', () => {
+  it.each(CURRENT_TRACK_RATING_ACTIONS)('routes %s to the current track owner', (action, rating) => {
+    hoisted.player.currentTrack = { id: 'shared', serverId: 'srv-b' };
+
+    executeRuntimeAction(action, { navigate, previewPolicy: 'ignore' });
+
+    expect(hoisted.queueSongRating).toHaveBeenCalledWith('shared', rating, 'srv-b');
+  });
+
+  it('exposes every rating as an unbound global shortcut', () => {
+    const ratingActions = GLOBAL_SHORTCUT_ACTIONS
+      .filter(({ id }) => id.startsWith('rate-current-track-'))
+      .map(({ id, defaultBinding }) => [id, defaultBinding]);
+
+    expect(ratingActions).toEqual(CURRENT_TRACK_RATING_ACTIONS.map(([id]) => [id, null]));
+    for (const [id] of CURRENT_TRACK_RATING_ACTIONS) {
+      expect(DEFAULT_GLOBAL_SHORTCUTS).not.toHaveProperty(id);
+    }
   });
 });

--- a/src/locales/bg/settings.ts
+++ b/src/locales/bg/settings.ts
@@ -677,6 +677,7 @@ export const settings = {
   shortcutOpenNowPlaying: 'Отвори „В момента звучи“',
   shortcutShowLyrics: 'Покажи текста',
   shortcutFavoriteCurrentTrack: 'Добави текущата песен в любими',
+  shortcutRateCurrentTrack: 'Оцени текущата песен: {{rating}}★',
   shortcutOpenHelp: 'Помощ',
   playbackTitle: 'Възпроизвеждане',
   replayGain: 'Replay Gain',

--- a/src/locales/de/settings.ts
+++ b/src/locales/de/settings.ts
@@ -578,6 +578,7 @@ export const settings = {
   shortcutOpenNowPlaying: '„Now Playing" öffnen',
   shortcutShowLyrics: 'Songtexte anzeigen',
   shortcutFavoriteCurrentTrack: 'Aktuellen Titel zu Favoriten hinzufügen',
+  shortcutRateCurrentTrack: 'Aktuellen Titel bewerten: {{rating}}★',
   shortcutOpenHelp: 'Hilfe',
   tabSystem: 'System',
   loggingTitle: 'Protokollierung',

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -677,6 +677,7 @@ export const settings = {
   shortcutOpenNowPlaying: 'Open "Now Playing"',
   shortcutShowLyrics: 'Show Lyrics',
   shortcutFavoriteCurrentTrack: 'Add current track to favorites',
+  shortcutRateCurrentTrack: 'Rate current track: {{rating}}★',
   shortcutOpenHelp: 'Help',
   playbackTitle: 'Playback',
   replayGain: 'Replay Gain',

--- a/src/locales/es/settings.ts
+++ b/src/locales/es/settings.ts
@@ -609,6 +609,7 @@ export const settings = {
   shortcutOpenNowPlaying: 'Abrir "Reproduciendo ahora"',
   shortcutShowLyrics: 'Mostrar letra',
   shortcutFavoriteCurrentTrack: 'Añadir pista actual a favoritos',
+  shortcutRateCurrentTrack: 'Puntuar pista actual: {{rating}}★',
   shortcutOpenHelp: 'Ayuda',
   playbackTitle: 'Reproducción',
   replayGain: 'Replay Gain',

--- a/src/locales/fr/settings.ts
+++ b/src/locales/fr/settings.ts
@@ -565,6 +565,7 @@ export const settings = {
   shortcutOpenNowPlaying: 'Ouvrir « En cours »',
   shortcutShowLyrics: 'Afficher les paroles',
   shortcutFavoriteCurrentTrack: 'Ajouter la piste actuelle aux favoris',
+  shortcutRateCurrentTrack: 'Noter la piste actuelle : {{rating}}★',
   shortcutOpenHelp: 'Aide',
   tabSystem: 'Système',
   loggingTitle: 'Journalisation',

--- a/src/locales/hu/settings.ts
+++ b/src/locales/hu/settings.ts
@@ -677,6 +677,7 @@ export const settings = {
   shortcutOpenNowPlaying: 'A „Most szól" megnyitása',
   shortcutShowLyrics: 'Dalszöveg megjelenítése',
   shortcutFavoriteCurrentTrack: 'Aktuális szám hozzáadása a kedvencekhez',
+  shortcutRateCurrentTrack: 'Aktuális szám értékelése: {{rating}}★',
   shortcutOpenHelp: 'Súgó',
   playbackTitle: 'Lejátszás',
   replayGain: 'Replay Gain',

--- a/src/locales/it/settings.ts
+++ b/src/locales/it/settings.ts
@@ -677,6 +677,7 @@ export const settings = {
   shortcutOpenNowPlaying: 'Apri "In riproduzione"',
   shortcutShowLyrics: 'Mostra testi',
   shortcutFavoriteCurrentTrack: 'Aggiungi il brano corrente ai preferiti',
+  shortcutRateCurrentTrack: 'Valuta il brano corrente: {{rating}}★',
   shortcutOpenHelp: 'Guida',
   playbackTitle: 'Riproduzione',
   replayGain: 'Replay Gain',

--- a/src/locales/ja/settings.ts
+++ b/src/locales/ja/settings.ts
@@ -671,6 +671,7 @@ export const settings = {
   shortcutOpenNowPlaying: '"Now Playing" を開く',
   shortcutShowLyrics: '歌詞を表示',
   shortcutFavoriteCurrentTrack: '現在のトラックをお気に入りに追加',
+  shortcutRateCurrentTrack: '現在のトラックを評価: {{rating}}★',
   shortcutOpenHelp: 'ヘルプ',
   playbackTitle: '再生',
   replayGain: 'Replay Gain',

--- a/src/locales/nb/settings.ts
+++ b/src/locales/nb/settings.ts
@@ -596,6 +596,7 @@ export const settings = {
   shortcutOpenNowPlaying: 'Åpne "Spilles nå"',
   shortcutShowLyrics: 'Vis sangtekst',
   shortcutFavoriteCurrentTrack: 'Legg gjeldende spor til favoritter',
+  shortcutRateCurrentTrack: 'Vurder gjeldende spor: {{rating}}★',
   shortcutOpenHelp: 'Hjelp',
   playbackTitle: 'Avspilling',
   replayGain: 'Replay Gain',

--- a/src/locales/nl/settings.ts
+++ b/src/locales/nl/settings.ts
@@ -565,6 +565,7 @@ export const settings = {
   shortcutOpenNowPlaying: '"Nu speelt" openen',
   shortcutShowLyrics: 'Songtekst tonen',
   shortcutFavoriteCurrentTrack: 'Huidig nummer aan favorieten toevoegen',
+  shortcutRateCurrentTrack: 'Huidig nummer beoordelen: {{rating}}★',
   shortcutOpenHelp: 'Help',
   tabSystem: 'Systeem',
   loggingTitle: 'Logboek',

--- a/src/locales/pl/settings.ts
+++ b/src/locales/pl/settings.ts
@@ -677,6 +677,7 @@ export const settings = {
   shortcutOpenNowPlaying: 'Otwórz "Teraz odtwarzane"',
   shortcutShowLyrics: 'Pokaż tekst utworu',
   shortcutFavoriteCurrentTrack: 'Dodaj bierzący utwór do ulubionych',
+  shortcutRateCurrentTrack: 'Oceń bieżący utwór: {{rating}}★',
   shortcutOpenHelp: 'Pomoc',
   playbackTitle: 'Odtwarzanie',
   replayGain: 'Replay Gain',

--- a/src/locales/ro/settings.ts
+++ b/src/locales/ro/settings.ts
@@ -612,6 +612,7 @@ export const settings = {
   shortcutOpenNowPlaying: 'Deschide "Now Playing"',
   shortcutShowLyrics: 'Arată Versurile',
   shortcutFavoriteCurrentTrack: 'Adaugă piesa curentă la favorite',
+  shortcutRateCurrentTrack: 'Evaluează piesa curentă: {{rating}}★',
   shortcutOpenHelp: 'Ajutor',
   playbackTitle: 'Redare',
   replayGain: 'Replay Gain',

--- a/src/locales/ru/settings.ts
+++ b/src/locales/ru/settings.ts
@@ -699,6 +699,7 @@ export const settings = {
   shortcutOpenNowPlaying: 'Открыть «Сейчас играет»',
   shortcutShowLyrics: 'Показать текст песни',
   shortcutFavoriteCurrentTrack: 'Добавить текущий трек в избранное',
+  shortcutRateCurrentTrack: 'Оценить текущий трек: {{rating}}★',
   shortcutOpenHelp: 'Справка',
   playbackTitle: 'Воспроизведение',
   replayGain: 'Replay Gain',

--- a/src/locales/uk/settings.ts
+++ b/src/locales/uk/settings.ts
@@ -680,6 +680,7 @@ export const settings = {
   shortcutOpenNowPlaying: 'Відкрити «Хто слухає»',
   shortcutShowLyrics: 'Показати текст пісні',
   shortcutFavoriteCurrentTrack: 'Додати поточний трек до улюблених',
+  shortcutRateCurrentTrack: 'Оцінити поточний трек: {{rating}}★',
   shortcutOpenHelp: 'Довідка',
   playbackTitle: 'Відтворення',
   replayGain: 'ReplayGain',

--- a/src/locales/zh/settings.ts
+++ b/src/locales/zh/settings.ts
@@ -596,6 +596,7 @@ export const settings = {
   shortcutOpenNowPlaying: '打开"正在播放"',
   shortcutShowLyrics: '显示歌词',
   shortcutFavoriteCurrentTrack: '将当前曲目添加到收藏',
+  shortcutRateCurrentTrack: '为当前曲目评分：{{rating}}★',
   shortcutOpenHelp: '帮助',
   playbackTitle: '播放',
   replayGain: '回放增益',


### PR DESCRIPTION
## Summary

- add five configurable global shortcut actions for rating the current track from 1 to 5 stars
- keep every new action unbound by default and route ratings through the current track's owner server
- localize the shortcut labels across all shipped locales and cover registry dispatch/defaults with tests

Closes #1493.

## Verification

- `npm run lint`
- `npm run dep:check`
- `npm test` (606 files, 4,657 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npm run test:coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh` (15/15 files passed)

### Runtime benchmark

- Applicability: smoke; `/settings` is covered by `all-pages` and gains five shortcut rows
- Final: `d8f42463` / report `2026-09-06T17-17-33-136Z`
- Command: `psysonic benchmark run --scenario all-pages --runs 2 --profile realistic --json`
- Environment: 1318x694 viewport, device pixel ratio 2, 3 selected servers, stable local scope fingerprint
- Affected route: `/settings` completed cold and warm samples with no errors or timeouts
- Result: smoke passed; no performance claim and the unrelated historical comparison was not used

## Manual verification

1. Open **Settings -> Input -> Global shortcuts**.
2. Assign shortcuts to one or more **Rate current track: N★** actions.
3. Start playback, move Psysonic out of focus, and press each assigned shortcut.
4. Confirm the current track receives the selected rating on its owning server.

## Scope notes

- Tauri command and event contracts are unchanged.
- Existing persisted global shortcut mappings remain compatible; the new actions have no default binding.
- The optional compound "rate and play next" action is intentionally outside this focused change.
