### PR TITLE
fix(audio): restore stable Linux PipeWire buffering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Switching to another application no longer leaves the Now Playing visualizer consuming rendering time in the background. It pauses by default and resumes when Psysonic regains focus.
 * The behaviour can be changed under **Settings → Appearance → Visualizer**. Waveform progress continues to update while the window is unfocused.
 
+### Linux playback stays clean under PipeWire again
+
+**By [@cucadmuh](https://github.com/cucadmuh), reported by [@thiagonl](https://github.com/thiagonl), PR [#1509](https://github.com/Psysonic/psysonic/pull/1509)**
+
+* Since 1.51.0, some Linux systems played every track with continuous crackling, dropouts and a dragging sound while flooding the log with buffer-underrun errors. PipeWire output now keeps the stable buffer used by earlier releases while retaining the corrected ALSA sample-rate handling.
+
 ## [1.52.0]
 
 ## Added

--- a/src-tauri/crates/psysonic-audio/src/engine/output_stream.rs
+++ b/src-tauri/crates/psysonic-audio/src/engine/output_stream.rs
@@ -44,8 +44,10 @@ fn open_stream_with_verified_rate(
     }
 
     #[cfg(target_os = "linux")]
-    let builder = rodio::DeviceSinkBuilder::default()
-        .with_device(device.clone())
+    // Preserve Rodio's stability-focused fixed buffer while overriding the
+    // fields whose exact ALSA-negotiated values the mixer must use.
+    let builder = rodio::DeviceSinkBuilder::from_device(device.clone())
+        .map_err(|error| format!("failed to configure audio output device: {error}"))?
         .with_channels(
             std::num::NonZeroU16::new(config.channels())
                 .ok_or_else(|| "audio output configuration has zero channels".to_string())?,


### PR DESCRIPTION
## Summary
- restore Rodio's stability-focused fixed output buffer on Linux
- retain the ALSA-negotiated sample rate, channel count, and sample format handling added in #1398
- prevent short PipeWire ALSA periods from producing continuous underruns during ordinary playback

Closes #1489.

## Root cause
The Linux stream path changed from `DeviceSinkBuilder::from_device()` to `DeviceSinkBuilder::default()` in 1.51.0 while adding explicit ALSA rate verification. That preserved the selected stream format but dropped Rodio's approximately 50 ms fixed buffer policy.

With the pinned Rodio 0.22.2 / CPAL 0.17.3 stack on PipeWire 1.6.8, the 1.51 path opens at `512/48000`; the restored path opens at `2048/48000`. Setting `PIPEWIRE_LATENCY=4096/48000` leaves the default-buffer stream at `512/48000`, so the existing environment hint does not restore the lost headroom.

## Verification
- `nix develop -c bash -lc 'cargo test --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- --test-threads=1'`
- `nix develop -c bash -lc 'cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings'`
- custom silent Rodio 0.22.2 / CPAL 0.17.3 PipeWire probe at 44.1 and 48 kHz
- 20-second fixed-buffer probe during `openssl speed -seconds 20 -multi 16 -bytes 8192 sha256`: zero stream errors

## Runtime benchmark
- Applicability: required custom audio-output evidence; the route benchmark harness does not exercise native playback
- Baseline: `3ee3c5ab`, equivalent 1.51 Linux builder configuration
- Final: `b2d0f824` (audio change `d46f260f`; final follow-up is changelog only)
- Environment: PipeWire 1.6.8, `PipeWire Sound Server` ALSA device, stereo `f32`
- Baseline result: `BufferSize::Default` -> `512/44100` and `512/48000`
- Final result: Rodio fixed buffer -> `2048/44100` and `2048/48000`
- Stress result: zero stream errors in both local runs; the affected hardware-specific underrun could not be reproduced locally, so reporter verification remains useful
- Errors/timeouts: none

## Tauri boundary
No commands, events, arguments, payloads, or frontend mocks changed.
