### PR TITLE
feat(subsonic): reach servers that send no CORS headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The generated theme appears in Settings → Themes as `Desktop — <your theme's name>`, next to a **Follow desktop theme** switch. Existing installs keep the theme they already had and start with the switch off; picking any other theme by hand also turns following off, so your choice sticks.
 * Any other desktop works too: point `PSYSONIC_PALETTE_FILE` at a file of `name = "#rrggbb"` lines. Naming only a background, a foreground and an accent is enough — the rest of the theme is derived from those three.
 
+### Servers that refuse browser-style requests can be added
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1511](https://github.com/Psysonic/psysonic/pull/1511)**
+
+* Some Subsonic servers — Bandcamp's among them — answer requests normally but do not permit them from an app window. Adding one failed with "Could not connect: Network Error" even though the server was reachable the whole time. Psysonic now recognises this and sends those servers' requests the same way it already sends streams and cover art.
+* Servers that work today are unaffected: they keep the exact request path they had.
+
 ## Fixed
 
 ### Shared Top Albums pictures show their covers again

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -455,6 +455,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Artist pages — an All Tracks tab listing everything an artist performs on, with pickable sortable columns (PR #1458)',
       'Psysonic Rewind — a year-in-review story and shareable posters in four layouts (PR #1485)',
       'Windows — updates install from inside the app, signed and verified like on macOS (PR #1487)',
+      'Servers that refuse browser-style requests can be added and browsed (PR #1511)',
     ],
   },
   {

--- a/src/lib/api/subsonic.ts
+++ b/src/lib/api/subsonic.ts
@@ -22,9 +22,14 @@ import {
   SUBSONIC_CLIENT,
   api,
   apiWithCredentials,
+  isMissingHttpResponseError,
   secureRandomSalt,
   type ServerHttpHeaderProfile,
 } from '@/lib/api/subsonicClient';
+import {
+  markNativeTransportRequired,
+  nativeTransportRequiredFor,
+} from '@/lib/server/nativeTransportFallback';
 import type { PingWithCredentialsResult, SubsonicSong } from '@/lib/api/subsonicTypes';
 
 export async function ping(): Promise<boolean> {
@@ -86,7 +91,8 @@ export async function pingWithCredentialsForProfile(
   // paths that already ride these headers. Header-less servers keep the
   // lightweight WebView path below.
   const httpContext = serverHttpContextWireForProbe(profile);
-  if (httpContext) {
+
+  const probeNatively = async (): Promise<PingWithCredentialsResult> => {
     try {
       const res = await commands.probeServerConnection(base, profile.username, profile.password, httpContext);
       if (res.status === 'error') {
@@ -105,7 +111,11 @@ export async function pingWithCredentialsForProfile(
       console.warn('[psysonic] pingWithCredentialsForProfile probe threw:', endpointBaseUrl, err);
       return { ok: false, error: err instanceof Error ? err.message : undefined };
     }
-  }
+  };
+
+  // Gate headers force the native path; so does an address a previous call
+  // already found to be CORS-less (see `nativeTransportFallback`).
+  if (httpContext || nativeTransportRequiredFor(base)) return probeNatively();
 
   try {
     const salt = secureRandomSalt();
@@ -135,6 +145,15 @@ export async function pingWithCredentialsForProfile(
       error: ok ? undefined : serverMessage,
     };
   } catch (err) {
+    // No HTTP response reached the WebView. The server may still be alive and
+    // simply send no CORS headers (Bandcamp's Subsonic API, strict proxies), so
+    // retry once natively before calling the address unreachable. A success
+    // pins this address to the native transport for the rest of the session.
+    if (isMissingHttpResponseError(err)) {
+      const native = await probeNatively();
+      if (native.ok) markNativeTransportRequired(base);
+      return native;
+    }
     console.warn('[psysonic] pingWithCredentialsForProfile failed:', endpointBaseUrl, err);
     return { ok: false, error: err instanceof Error ? err.message : undefined };
   }

--- a/src/lib/api/subsonicClient.ts
+++ b/src/lib/api/subsonicClient.ts
@@ -8,6 +8,7 @@ import type { ServerProfile } from '@/store/authStoreTypes';
 import { connectBaseUrlForServer } from '@/lib/server/serverEndpoint';
 import { headersForServerRequest, serverHttpContextWireForProbe } from '@/lib/server/serverHttpHeaders';
 import { findServerByIdOrIndexKey, resolveServerIdForIndexKey } from '@/lib/server/serverLookup';
+import { nativeTransportRequiredFor } from '@/lib/server/nativeTransportFallback';
 
 export const SUBSONIC_CLIENT = SUBSONIC_CLIENT_ID;
 
@@ -116,7 +117,7 @@ async function requestViaRustProxy<T>(
   serverUrl: string,
   endpoint: string,
   params: Record<string, unknown>,
-  headerProfile: ServerHttpHeaderProfile,
+  headerProfile: ServerHttpHeaderProfile | undefined,
   timeout: number,
   postForm: boolean,
 ): Promise<T> {
@@ -126,7 +127,7 @@ async function requestViaRustProxy<T>(
     subsonicParamPairs(params),
     postForm,
     timeout,
-    serverHttpContextWireForProbe(headerProfile),
+    headerProfile ? serverHttpContextWireForProbe(headerProfile) : null,
   );
   if (res.status === 'error') throw new Error(res.error);
   let json: unknown;
@@ -139,17 +140,40 @@ async function requestViaRustProxy<T>(
 }
 
 /**
- * True when a request to `requestBaseUrl` would carry non-safelisted gate
- * headers — i.e. it must go through the native proxy, not the WebView. Reuses
- * `headersForServerRequest` so the endpoint-kind / apply-to logic stays in one
- * place: an empty header map means the WebView path is safe.
+ * True when a request to `requestBaseUrl` cannot use the WebView. Two reasons:
+ *
+ * 1. It would carry non-safelisted gate headers (Cloudflare Access, Pangolin) —
+ *    reuses `headersForServerRequest` so the endpoint-kind / apply-to logic
+ *    stays in one place: an empty header map means the WebView path is safe.
+ * 2. A previous call already proved the address sends no CORS headers, so the
+ *    WebView would discard the response (see `nativeTransportFallback`).
  */
 function requiresNativeTransport(
   headerProfile: ServerHttpHeaderProfile | undefined,
   requestBaseUrl: string,
 ): boolean {
+  if (nativeTransportRequiredFor(requestBaseUrl)) return true;
   if (!headerProfile) return false;
   return Object.keys(headersForServerRequest(headerProfile, requestBaseUrl)).length > 0;
+}
+
+/**
+ * True when the request never produced an HTTP response: the origin is
+ * unreachable, or the WebView discarded the answer because it carried no CORS
+ * headers. Both look identical from `axios` — a bare `Network Error` with no
+ * `response` — which is exactly why the native retry exists.
+ *
+ * Timeouts and caller-side aborts are excluded: they mean "took too long" or
+ * "no longer wanted", and retrying those natively would double an already slow
+ * request instead of recovering anything.
+ */
+export function isMissingHttpResponseError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const candidate = err as { response?: unknown; code?: string };
+  if (candidate.response !== undefined) return false;
+  if (candidate.code === 'ECONNABORTED' || candidate.code === 'ETIMEDOUT') return false;
+  if (candidate.code === 'ERR_CANCELED') return false;
+  return true;
 }
 
 export async function apiWithCredentials<T>(
@@ -162,7 +186,7 @@ export async function apiWithCredentials<T>(
   headerProfile?: ServerHttpHeaderProfile,
 ): Promise<T> {
   const params = { ...getAuthParams(username, password), ...extra };
-  if (headerProfile && requiresNativeTransport(headerProfile, serverUrl)) {
+  if (requiresNativeTransport(headerProfile, serverUrl)) {
     return requestViaRustProxy<T>(serverUrl, endpoint, params, headerProfile, timeout, false);
   }
   const headers = headerProfile ? headersForServerRequest(headerProfile, serverUrl) : {};
@@ -189,7 +213,7 @@ export async function apiPostFormWithCredentials<T>(
   headerProfile?: ServerHttpHeaderProfile,
 ): Promise<T> {
   const params = { ...getAuthParams(username, password), ...extra };
-  if (headerProfile && requiresNativeTransport(headerProfile, serverUrl)) {
+  if (requiresNativeTransport(headerProfile, serverUrl)) {
     return requestViaRustProxy<T>(serverUrl, endpoint, params, headerProfile, timeout, true);
   }
   const headers = {
@@ -279,7 +303,7 @@ export async function api<T>(
   // Gate-header servers: route through the native proxy (no CORS preflight).
   // `signal` isn't forwarded — the underlying request can't be aborted mid-flight,
   // but the caller's promise still settles and stale results are ignored upstream.
-  if (server && connectBase && requiresNativeTransport(server, connectBase)) {
+  if (connectBase && requiresNativeTransport(server, connectBase)) {
     return requestViaRustProxy<T>(connectBase, endpoint, { ...params, ...extra }, server, timeout, false);
   }
   const headers =

--- a/src/lib/api/subsonicNativeFallback.test.ts
+++ b/src/lib/api/subsonicNativeFallback.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Native-transport fallback for servers that answer HTTP but send no CORS
+ * headers (Bandcamp's Subsonic API, strict reverse proxies).
+ *
+ * The WebView discards such a response before any handler runs, so `axios`
+ * reports a bare "Network Error" with no `response`. These tests pin the
+ * recovery: retry once over the native command, remember the address, and keep
+ * genuinely different failures (timeouts, real HTTP errors) on their old path.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('axios', () => ({
+  default: { get: vi.fn(), post: vi.fn() },
+}));
+
+vi.mock('@/lib/network/subsonicNetworkGuard', () => ({
+  shouldAttemptSubsonicForActiveServer: () => true,
+  shouldAttemptSubsonicForServer: () => true,
+}));
+
+import axios from 'axios';
+import { onInvoke } from '@/test/mocks/tauri';
+import { pingWithCredentialsForProfile } from '@/lib/api/subsonic';
+import { apiWithCredentials } from '@/lib/api/subsonicClient';
+import { clearNativeTransportFallback } from '@/lib/server/nativeTransportFallback';
+
+const BASE = 'https://music.example.com';
+
+const PROFILE = {
+  url: BASE,
+  username: 'tester',
+  password: 'pw',
+};
+
+/** An axios rejection that never received an HTTP response (CORS / dead host). */
+function networkError(): Error {
+  return new Error('Network Error');
+}
+
+/** An axios rejection carrying a real HTTP response. */
+function httpError(status: number): Error & { response: { status: number } } {
+  return Object.assign(new Error(`Request failed with status code ${status}`), {
+    response: { status },
+  });
+}
+
+/** An axios timeout — no response either, but retrying natively is pointless. */
+function timeoutError(): Error & { code: string } {
+  return Object.assign(new Error('timeout of 15000ms exceeded'), {
+    code: 'ECONNABORTED',
+  });
+}
+
+beforeEach(() => {
+  clearNativeTransportFallback();
+  vi.mocked(axios.get).mockReset();
+  vi.mocked(axios.post).mockReset();
+});
+
+afterEach(() => {
+  clearNativeTransportFallback();
+  vi.restoreAllMocks();
+});
+
+describe('connect probe — CORS-less server', () => {
+  it('retries natively when the WebView ping dies without an HTTP response', async () => {
+    vi.mocked(axios.get).mockRejectedValue(networkError());
+    let probes = 0;
+    onInvoke('probe_server_connection', () => {
+      probes += 1;
+      return { ok: true, type: 'BandcampServer', serverVersion: '1.0', openSubsonic: true };
+    });
+
+    const result = await pingWithCredentialsForProfile(PROFILE, BASE);
+
+    expect(result.ok).toBe(true);
+    expect(result.type).toBe('BandcampServer');
+    expect(probes).toBe(1);
+  });
+
+  it('sends no header context when the profile has no custom headers', async () => {
+    vi.mocked(axios.get).mockRejectedValue(networkError());
+    let received: { httpContext: unknown } | undefined;
+    onInvoke('probe_server_connection', args => {
+      received = args as { httpContext: unknown };
+      return { ok: true, type: null, serverVersion: null, openSubsonic: false };
+    });
+
+    await pingWithCredentialsForProfile(PROFILE, BASE);
+
+    // A plain reqwest probe: no gate headers to forward, so the context is null.
+    expect(received?.httpContext).toBeNull();
+  });
+
+  it('pins the address so later probes skip the doomed WebView attempt', async () => {
+    vi.mocked(axios.get).mockRejectedValue(networkError());
+    onInvoke('probe_server_connection', () => ({
+      ok: true, type: null, serverVersion: null, openSubsonic: false,
+    }));
+
+    await pingWithCredentialsForProfile(PROFILE, BASE);
+    const callsAfterFirst = vi.mocked(axios.get).mock.calls.length;
+    await pingWithCredentialsForProfile(PROFILE, BASE);
+
+    expect(vi.mocked(axios.get).mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it('does not pin the address when the native probe also fails', async () => {
+    vi.mocked(axios.get).mockRejectedValue(networkError());
+    onInvoke('probe_server_connection', () => ({
+      ok: false, type: null, serverVersion: null, openSubsonic: false, error: 'connection refused',
+    }));
+
+    const first = await pingWithCredentialsForProfile(PROFILE, BASE);
+    await pingWithCredentialsForProfile(PROFILE, BASE);
+
+    expect(first.ok).toBe(false);
+    // Still probing over the WebView: an unreachable host must not be mistaken
+    // for a CORS-less one, or a transient outage would pin it forever.
+    expect(vi.mocked(axios.get).mock.calls.length).toBe(2);
+  });
+
+  it('leaves timeouts on the WebView path', async () => {
+    vi.mocked(axios.get).mockRejectedValue(timeoutError());
+    let probes = 0;
+    onInvoke('probe_server_connection', () => {
+      probes += 1;
+      return { ok: true, type: null, serverVersion: null, openSubsonic: false };
+    });
+
+    const result = await pingWithCredentialsForProfile(PROFILE, BASE);
+
+    expect(result.ok).toBe(false);
+    expect(probes).toBe(0);
+  });
+});
+
+describe('REST calls — once the probe pinned the address', () => {
+  // REST calls deliberately do NOT retry on their own: the connect probe runs
+  // before them (and on every reachability tick), so it is the one place that
+  // learns the property. That keeps the hot path at exactly one request — an
+  // unreachable server must not cost two attempts per call.
+
+  async function pinAddress(): Promise<void> {
+    vi.mocked(axios.get).mockRejectedValueOnce(networkError());
+    onInvoke('probe_server_connection', () => ({
+      ok: true, type: null, serverVersion: null, openSubsonic: false,
+    }));
+    await pingWithCredentialsForProfile(PROFILE, BASE);
+  }
+
+  it('routes calls through the native proxy and parses its payload', async () => {
+    await pinAddress();
+    onInvoke('subsonic_proxy_request', () =>
+      JSON.stringify({ 'subsonic-response': { status: 'ok', musicFolders: { musicFolder: [] } } }),
+    );
+
+    const data = await apiWithCredentials<{ musicFolders: unknown }>(
+      BASE, 'tester', 'pw', 'getMusicFolders.view',
+    );
+
+    expect(data.musicFolders).toEqual({ musicFolder: [] });
+    // The doomed WebView attempt is skipped entirely (only the probe's own).
+    expect(vi.mocked(axios.get).mock.calls.length).toBe(1);
+  });
+
+  it('surfaces a server-side failure from the native payload', async () => {
+    await pinAddress();
+    onInvoke('subsonic_proxy_request', () =>
+      JSON.stringify({
+        'subsonic-response': { status: 'failed', error: { code: 40, message: 'Wrong username or password' } },
+      }),
+    );
+
+    await expect(
+      apiWithCredentials(BASE, 'tester', 'pw', 'getMusicFolders.view'),
+    ).rejects.toThrow(/wrong username/i);
+  });
+
+  it('leaves untouched addresses on the WebView path', async () => {
+    await pinAddress();
+    let proxied = 0;
+    onInvoke('subsonic_proxy_request', () => {
+      proxied += 1;
+      return JSON.stringify({ 'subsonic-response': { status: 'ok' } });
+    });
+    vi.mocked(axios.get).mockResolvedValue({
+      data: { 'subsonic-response': { status: 'ok' } },
+    });
+
+    await apiWithCredentials('https://other.example.com', 'tester', 'pw', 'getGenres.view');
+
+    expect(proxied).toBe(0);
+  });
+
+  it('keeps a real HTTP error on the WebView path', async () => {
+    vi.mocked(axios.get).mockRejectedValue(httpError(500));
+    let proxied = 0;
+    onInvoke('subsonic_proxy_request', () => {
+      proxied += 1;
+      return JSON.stringify({ 'subsonic-response': { status: 'ok' } });
+    });
+
+    await expect(
+      apiWithCredentials(BASE, 'tester', 'pw', 'getMusicFolders.view'),
+    ).rejects.toThrow();
+    expect(proxied).toBe(0);
+  });
+});

--- a/src/lib/server/nativeTransportFallback.ts
+++ b/src/lib/server/nativeTransportFallback.ts
@@ -1,0 +1,48 @@
+import { normalizeServerBaseUrl } from '@/lib/server/serverAddress';
+
+/**
+ * Servers that answer HTTP but send no CORS headers (Bandcamp's Subsonic API,
+ * plain reverse proxies, self-hosted servers with a strict origin policy).
+ *
+ * The WebView discards such a response before any handler runs, so `axios`
+ * reports a bare "Network Error" with no `response` — indistinguishable from a
+ * dead host at the call site. The native `reqwest` stack has no origin policy
+ * and answers fine, which is why streaming and cover art already work against
+ * these servers while every REST call fails.
+ *
+ * Once a call has proven that an address needs the native path, it is recorded
+ * here and every later request to the same address skips the doomed WebView
+ * attempt. Deliberately **session-only and in memory**, mirroring the connect
+ * cache in `serverEndpoint.ts`: CORS is a property of the address, not of the
+ * saved profile, so it must not travel in shares, magic strings, or persisted
+ * state — and re-learning it costs exactly one failed request per address.
+ */
+const nativeTransportAddresses = new Set<string>();
+
+function addressKey(baseUrl: string): string {
+  return normalizeServerBaseUrl(baseUrl);
+}
+
+/** True when a previous call proved this address needs the native transport. */
+export function nativeTransportRequiredFor(baseUrl: string): boolean {
+  const key = addressKey(baseUrl);
+  return key !== '' && nativeTransportAddresses.has(key);
+}
+
+/** Record that this address only answers over the native stack. */
+export function markNativeTransportRequired(baseUrl: string): void {
+  const key = addressKey(baseUrl);
+  if (key !== '') nativeTransportAddresses.add(key);
+}
+
+/**
+ * Forget one address (or all). Call when a profile's addresses change, so an
+ * edited URL is probed from scratch instead of inheriting the old verdict.
+ */
+export function clearNativeTransportFallback(baseUrl?: string): void {
+  if (baseUrl === undefined) {
+    nativeTransportAddresses.clear();
+    return;
+  }
+  nativeTransportAddresses.delete(addressKey(baseUrl));
+}


### PR DESCRIPTION
## Summary

- A server that answers HTTP but sends no `Access-Control-Allow-Origin` is unreachable from the WebView: the response is discarded before any handler runs, so every REST call fails with a bare `Network Error` — while streaming and cover art keep working over native reqwest. Reported for Bandcamp's Subsonic API (#1500), but it affects any origin-restricted server.
- The connect probe now retries once through `probe_server_connection` when the WebView attempt never received an HTTP response, and records the address so later REST calls take the native path directly.
- The record is session-only and keyed by address, mirroring the connect cache — this is a property of the address, not of the saved profile, so it never travels in shares, magic strings, or persisted state.
- REST calls deliberately do not retry on their own: the probe runs before them and on every reachability tick, so an unreachable server still costs exactly one attempt per call.

## Test plan

- `src/lib/api/subsonicNativeFallback.test.ts` (new, 9 cases): native retry on a response-less failure, no header context when the profile has none, address pinning, no pinning when the native probe also fails, timeouts left on the WebView path, native routing plus server-side failure surfacing for REST calls, untouched addresses unaffected, real HTTP errors not retried.
- Each half verified by mutation: disabling the probe retry, the address record, or the transport switch turns exactly the matching cases red.
- Gates: `npx tsc --noEmit`, `npm run lint`, `npm run dep:check` clean. Full `npx vitest run`: 4658 passed, 0 failed. Targeted run of all 46 test files touching this code: 711 passed, exit 0.
- Verified against a live origin-restricted server: connect, initial sync, browse, and playback all work; the same profile fails with `Network Error` before this change.

Runtime benchmark: not applicable - transport switch only; servers that already work take an identical request path (one lookup in an empty set).

## Known gaps

Reaching the server is the transport half of #1500. Such a server may still report timestamps in a format the ingest drops (RFC 1123 rather than ISO 8601), which leaves "recently added" and the new-releases feed empty for it. That is a separate, small fix and gets its own PR, so this issue stays open until then.

Refs #1500
