### PR TITLE
fix(library): stop dropping the album year and RFC 1123 timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Since 1.51.0, some Linux systems played every track with continuous crackling, dropouts and a dragging sound while flooding the log with buffer-underrun errors. PipeWire output now keeps the stable buffer used by earlier releases while retaining the corrected ALSA sample-rate handling.
 
+### Release years and dates from servers that report them differently
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1512](https://github.com/Psysonic/psysonic/pull/1512)**
+
+* Albums from servers whose album data carries no year showed no release year at all, even though the tracks had one. The year from the tracks is now kept instead of being overwritten with nothing.
+* The same servers often report dates in a different standard format, which was discarded on import. That left "recently added" and the New Releases page empty for them. Both formats are now understood. Albums already in your library pick their date up on the next full library sync.
+
 ## [1.52.0]
 
 ## Added

--- a/src-tauri/crates/psysonic-library/src/scope_merge/album_detail.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge/album_detail.rs
@@ -132,7 +132,11 @@ fn overlay_priority_album_row(
     album.artist = final_name;
     album.song_count = song_count;
     album.duration_sec = duration_sec;
-    album.year = year;
+    // A standalone row without a year states nothing: not every server reports one
+    // on `getAlbum`, while its tracks carry it. Overwriting the track-derived value
+    // with that emptiness blanks the release year in the album header. `starred_at`
+    // stays unconditional below — there an absent value is a real state (unstarred).
+    album.year = year.or(album.year);
     album.genre = genre;
     album.cover_art_id = cover_art_id;
     album.starred_at = starred_at;

--- a/src-tauri/crates/psysonic-library/src/scope_merge/tests/album_detail_metadata.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge/tests/album_detail_metadata.rs
@@ -180,3 +180,95 @@ fn album_detail_preserves_priority_owner_raw_json() {
     assert_eq!(detail.album.starred_at, Some(1111));
     assert_eq!(detail.album.raw_json["recordLabel"], "Primary Records");
 }
+
+#[test]
+fn album_detail_keeps_the_track_year_when_the_album_row_carries_none() {
+    // Not every Subsonic server reports a year on `getAlbum`, but its tracks still
+    // carry one. Overlaying the empty column blanked the release year in the album
+    // header even though the index held it.
+    let store = LibraryStore::open_in_memory();
+    seed_and_rebuild(
+        &store,
+        &[track(
+            "s1",
+            "t1",
+            "Song",
+            Some("Artist"),
+            "Album",
+            "alb1",
+            Some("art1"),
+            200,
+            "lib-a",
+            Some(2024),
+            None,
+            None,
+        )],
+    );
+    store
+        .with_conn("test", |c| {
+            c.execute(
+                "INSERT INTO album (server_id, id, name, synced_at, raw_json) \
+                     VALUES ('s1', 'alb1', 'Album', 1, '{}')",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    let detail = album_detail(
+        &store,
+        &LibraryScopeAlbumDetailRequest {
+            scopes: vec![scope_pair("s1", "lib-a")],
+            album_id: "alb1".into(),
+            server_id: "s1".into(),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(detail.album.year, Some(2024));
+}
+
+#[test]
+fn album_detail_prefers_the_album_row_year_over_the_track_year() {
+    // The standalone row stays authoritative whenever it actually has a value.
+    let store = LibraryStore::open_in_memory();
+    seed_and_rebuild(
+        &store,
+        &[track(
+            "s1",
+            "t1",
+            "Song",
+            Some("Artist"),
+            "Album",
+            "alb1",
+            Some("art1"),
+            200,
+            "lib-a",
+            Some(2024),
+            None,
+            None,
+        )],
+    );
+    store
+        .with_conn("test", |c| {
+            c.execute(
+                "INSERT INTO album (server_id, id, name, year, synced_at, raw_json) \
+                     VALUES ('s1', 'alb1', 'Album', 1999, 1, '{}')",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    let detail = album_detail(
+        &store,
+        &LibraryScopeAlbumDetailRequest {
+            scopes: vec![scope_pair("s1", "lib-a")],
+            album_id: "alb1".into(),
+            server_id: "s1".into(),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(detail.album.year, Some(1999));
+}

--- a/src-tauri/crates/psysonic-library/src/sync/album_metadata.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/album_metadata.rs
@@ -8,12 +8,12 @@ use rusqlite::{params, OptionalExtension};
 use serde_json::Value;
 
 use super::error::SyncError;
-use super::mapping::{album_version_from_tags, parse_iso_ms_str};
+use super::mapping::{album_version_from_tags, parse_timestamp_ms_str};
 use crate::store::LibraryStore;
 
 fn album_starred_at_from_raw(raw_album: &Value) -> Option<Option<i64>> {
     let starred = raw_album.get("starred")?;
-    Some(starred.as_str().and_then(parse_iso_ms_str))
+    Some(starred.as_str().and_then(parse_timestamp_ms_str))
 }
 
 fn album_identity_version(raw_album: &Value) -> Option<String> {

--- a/src-tauri/crates/psysonic-library/src/sync/mapping.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping.rs
@@ -219,10 +219,10 @@ pub fn subsonic_song_to_track_row(
         bit_rate: song.bit_rate,
         size_bytes: song.size,
         cover_art_id: song.cover_art.clone(),
-        starred_at: parse_iso_ms(song.starred.as_deref()),
+        starred_at: parse_timestamp_ms(song.starred.as_deref()),
         user_rating: song.user_rating,
         play_count: song.play_count,
-        played_at: parse_iso_ms(song.played.as_deref()),
+        played_at: parse_timestamp_ms(song.played.as_deref()),
         server_path: song.path.clone(),
         library_id: song
             .library_id
@@ -244,8 +244,8 @@ pub fn subsonic_song_to_track_row(
             .and_then(|rg| rg.get("trackPeak"))
             .and_then(|v| v.as_f64()),
         content_hash: None,
-        server_updated_at: parse_raw_iso_ms(raw_value, &["updatedAt"]),
-        server_created_at: parse_raw_iso_ms(raw_value, &["created", "createdAt"]),
+        server_updated_at: parse_raw_timestamp_ms(raw_value, &["updatedAt"]),
+        server_created_at: parse_raw_timestamp_ms(raw_value, &["created", "createdAt"]),
         deleted: false,
         synced_at,
         raw_json: track_raw_json(raw_value),
@@ -325,7 +325,7 @@ pub fn navidrome_song_to_track_row(
         .and_then(|v| v.as_str())
         .unwrap_or_default()
         .to_string();
-    let server_updated_at = parse_raw_iso_ms(raw, &["updatedAt"]);
+    let server_updated_at = parse_raw_timestamp_ms(raw, &["updatedAt"]);
     let library_id = json_string_field(raw, "libraryId")
         .or_else(|| json_string_field(raw, "library_id"))
         .or_else(|| json_string_field(raw, "musicFolderId"))
@@ -351,7 +351,7 @@ pub fn navidrome_song_to_track_row(
         bit_rate: raw.get("bitRate").and_then(|v| v.as_i64()),
         size_bytes: raw.get("size").and_then(|v| v.as_i64()),
         cover_art_id: string_field(raw, "coverArtId").or_else(|| string_field(raw, "coverArt")),
-        starred_at: parse_raw_iso_ms(raw, &["starredAt"]),
+        starred_at: parse_raw_timestamp_ms(raw, &["starredAt"]),
         user_rating: raw.get("rating").and_then(|v| v.as_i64()),
         play_count: raw.get("playCount").and_then(|v| v.as_i64()),
         // Navidrome's own API calls this `playDate`; `playedAt` was never one of
@@ -368,7 +368,7 @@ pub fn navidrome_song_to_track_row(
         // key that merely holds a string would settle on an empty `playDate` —
         // which Navidrome has been seen to send for never-played rows — and
         // never look at a usable `played` beside it.
-        played_at: parse_raw_iso_ms(raw, &["playDate", "played", "playedAt"]),
+        played_at: parse_raw_timestamp_ms(raw, &["playDate", "played", "playedAt"]),
         server_path: string_field(raw, "path"),
         library_id,
         isrc: navidrome_isrc_from_raw(raw),
@@ -379,7 +379,7 @@ pub fn navidrome_song_to_track_row(
         replay_gain_peak: raw.get("rgTrackPeak").and_then(|v| v.as_f64()),
         content_hash: None,
         server_updated_at,
-        server_created_at: parse_raw_iso_ms(raw, &["createdAt"]),
+        server_created_at: parse_raw_timestamp_ms(raw, &["createdAt"]),
         deleted: false,
         synced_at,
         raw_json: track_raw_json(raw),
@@ -452,16 +452,26 @@ fn duration_seconds(raw: &Value) -> i64 {
     }
 }
 
-fn parse_iso_ms(s: Option<&str>) -> Option<i64> {
-    s.and_then(parse_iso_ms_str)
+fn parse_timestamp_ms(s: Option<&str>) -> Option<i64> {
+    s.and_then(parse_timestamp_ms_str)
 }
 
-fn parse_raw_iso_ms(raw: &Value, keys: &[&str]) -> Option<i64> {
+fn parse_raw_timestamp_ms(raw: &Value, keys: &[&str]) -> Option<i64> {
     keys.iter().find_map(|key| {
         raw.get(*key)
             .and_then(Value::as_str)
-            .and_then(parse_iso_ms_str)
+            .and_then(parse_timestamp_ms_str)
     })
+}
+
+/// Parse a server-supplied timestamp in either form we have seen in the wild:
+/// ISO 8601 (Navidrome / OpenSubsonic) or RFC 1123 (`30 Apr 2017 08:44:05 GMT`).
+///
+/// Ingest must not drop a timestamp just because the server spells it the other
+/// way: an unparsed `created` leaves `server_created_at` NULL, which empties
+/// "recently added" and the new-releases feed for that server.
+pub(crate) fn parse_timestamp_ms_str(s: &str) -> Option<i64> {
+    parse_iso_ms_str(s).or_else(|| parse_rfc1123_ms_str(s))
 }
 
 /// Lightweight ISO-8601 → epoch-ms parser. Supports the Navidrome /
@@ -508,15 +518,108 @@ pub(crate) fn parse_iso_ms_str(s: &str) -> Option<i64> {
     {
         return None;
     }
-    // Days since 1970-01-01 — Howard Hinnant's civil_from_days inverse.
+    let seconds = days_from_civil(year, month, day) * 86_400 + hour * 3600 + minute * 60 + second
+        - timezone_offset_seconds;
+    Some(seconds.saturating_mul(1000))
+}
+
+/// Days since 1970-01-01 — Howard Hinnant's `civil_from_days` inverse. Shared by
+/// the ISO and RFC 1123 parsers so both agree on the calendar by construction.
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
     let y = if month <= 2 { year - 1 } else { year };
     let era = y.div_euclid(400);
     let yoe = y - era * 400; // [0, 399]
     let m = if month > 2 { month - 3 } else { month + 9 };
     let doy = (153 * m + 2) / 5 + day - 1;
     let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    let days = era * 146_097 + doe - 719_468;
-    let seconds = days * 86_400 + hour * 3600 + minute * 60 + second - timezone_offset_seconds;
+    era * 146_097 + doe - 719_468
+}
+
+/// Month number for an English three-letter abbreviation (`Jan` … `Dec`).
+fn month_from_abbreviation(abbreviation: &str) -> Option<i64> {
+    const MONTHS: [&str; 12] = [
+        "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec",
+    ];
+    if abbreviation.len() != 3 {
+        return None;
+    }
+    let lower = abbreviation.to_ascii_lowercase();
+    MONTHS
+        .iter()
+        .position(|month| *month == lower)
+        .map(|index| index as i64 + 1)
+}
+
+/// `GMT` / `UT` / `UTC` or a numeric `+HHMM` offset (RFC 1123 / RFC 2822).
+///
+/// Alphabetic zone names beyond UTC (`EST`, `PDT`, …) are deliberately rejected
+/// rather than guessed: RFC 2822 itself calls them unreliable, and a wrong date
+/// is worse than a missing one — a missing timestamp only leaves a column NULL.
+fn parse_rfc1123_zone_seconds(zone: &str) -> Option<i64> {
+    match zone {
+        "GMT" | "UT" | "UTC" | "Z" => return Some(0),
+        _ => {}
+    }
+    let (sign, digits) = match zone.as_bytes().first()? {
+        b'+' => (1, &zone[1..]),
+        b'-' => (-1, &zone[1..]),
+        _ => return None,
+    };
+    if digits.len() != 4 || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let hours: i64 = digits[..2].parse().ok()?;
+    let minutes: i64 = digits[2..].parse().ok()?;
+    if hours > 23 || minutes > 59 {
+        return None;
+    }
+    Some(sign * (hours * 3_600 + minutes * 60))
+}
+
+/// RFC 1123 date-time — `30 Apr 2017 08:44:05 GMT`, with the weekday prefix
+/// (`Sun, `) optional because servers differ on emitting it.
+///
+/// Measured on a live Subsonic server that reports every `created` this way;
+/// the ISO parser returns `None` for it, so without this the timestamp is lost.
+fn parse_rfc1123_ms_str(s: &str) -> Option<i64> {
+    let trimmed = s.trim();
+    let without_weekday = match trimmed.split_once(',') {
+        Some((_weekday, rest)) => rest.trim_start(),
+        None => trimmed,
+    };
+    let mut fields = without_weekday.split_whitespace();
+    let day: i64 = fields.next()?.parse().ok()?;
+    let month = month_from_abbreviation(fields.next()?)?;
+    let year: i64 = fields.next()?.parse().ok()?;
+    let mut time = fields.next()?.split(':');
+    let hour: i64 = time.next()?.parse().ok()?;
+    let minute: i64 = time.next()?.parse().ok()?;
+    let second: i64 = match time.next() {
+        Some(value) => value.parse().ok()?,
+        None => 0,
+    };
+    if time.next().is_some() {
+        return None;
+    }
+    // A missing zone is read as UTC, matching the ISO parser's behaviour for a
+    // bare `2024-01-01T00:00:00`.
+    let timezone_offset_seconds = match fields.next() {
+        Some(zone) => parse_rfc1123_zone_seconds(zone)?,
+        None => 0,
+    };
+    if fields.next().is_some() {
+        return None;
+    }
+    if !(1970..=2100).contains(&year)
+        || !(1..=31).contains(&day)
+        || !(0..=23).contains(&hour)
+        || !(0..=59).contains(&minute)
+        || !(0..=60).contains(&second)
+    {
+        return None;
+    }
+    let seconds = days_from_civil(year, month, day) * 86_400 + hour * 3600 + minute * 60 + second
+        - timezone_offset_seconds;
     Some(seconds.saturating_mul(1000))
 }
 

--- a/src-tauri/crates/psysonic-library/src/sync/mapping/tests/rows.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping/tests/rows.rs
@@ -29,6 +29,20 @@ fn subsonic_song_maps_hot_columns_and_keeps_raw_json() {
 }
 
 #[test]
+fn subsonic_song_maps_rfc1123_created_into_server_created_at() {
+    // Some Subsonic servers report `created` in RFC 1123 rather than ISO 8601.
+    // Dropping it leaves `server_created_at` NULL, which empties "recently
+    // added" and the new-releases feed for every track from that server.
+    let raw = json!({
+        "id": "tr_1", "title": "Hello", "artist": "World",
+        "created": "30 Apr 2017 08:44:05 GMT"
+    });
+    let song: Song = serde_json::from_value(raw.clone()).unwrap();
+    let row = subsonic_song_to_track_row("s1", &song, &raw, 1_000, None);
+    assert_eq!(row.server_created_at, Some(1_493_541_845_000));
+}
+
+#[test]
 fn sparse_typed_fallback_does_not_invent_explicit_nulls() {
     let song: Song = serde_json::from_value(json!({ "id": "tr_1", "title": "Hello" })).unwrap();
     let raw = sparse_song_raw_fallback(&song);

--- a/src-tauri/crates/psysonic-library/src/sync/mapping/tests/timestamps.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/mapping/tests/timestamps.rs
@@ -31,3 +31,54 @@ fn parse_iso_rejects_garbage() {
     assert!(parse_iso_ms_str("9999-99-99").is_none());
     assert!(parse_iso_ms_str("2024-01-01T00:00:00+24:00").is_none());
 }
+
+// RFC 1123 timestamps — the shape a Subsonic server may send instead of ISO
+// 8601. The reference values come from an independent implementation, not from
+// this parser, so a shared calendar bug cannot make them agree.
+
+#[test]
+fn parse_timestamp_handles_rfc1123_without_weekday() {
+    // The exact shape measured on a live server: no weekday, always GMT.
+    let ms = parse_timestamp_ms_str("30 Apr 2017 08:44:05 GMT").unwrap();
+    assert_eq!(ms, 1_493_541_845_000);
+}
+
+#[test]
+fn parse_timestamp_handles_rfc1123_with_weekday() {
+    let ms = parse_timestamp_ms_str("Sun, 30 Apr 2017 08:44:05 GMT").unwrap();
+    assert_eq!(ms, 1_493_541_845_000);
+}
+
+#[test]
+fn parse_timestamp_handles_rfc1123_numeric_offset() {
+    let ms = parse_timestamp_ms_str("30 Apr 2017 08:44:05 +0200").unwrap();
+    assert_eq!(ms, 1_493_534_645_000);
+}
+
+#[test]
+fn parse_timestamp_handles_rfc1123_epoch_start() {
+    let ms = parse_timestamp_ms_str("1 Jan 1970 00:00:00 GMT").unwrap();
+    assert_eq!(ms, 0);
+}
+
+#[test]
+fn parse_timestamp_still_prefers_iso() {
+    let ms = parse_timestamp_ms_str("2024-01-01T00:00:00Z").unwrap();
+    assert_eq!(ms, 1_704_067_200_000);
+}
+
+#[test]
+fn parse_timestamp_rejects_unreliable_zone_names() {
+    // A guessed offset would write a wrong date; a missing one only leaves NULL.
+    assert!(parse_timestamp_ms_str("30 Apr 2017 08:44:05 EST").is_none());
+    assert!(parse_timestamp_ms_str("30 Apr 2017 08:44:05 PDT").is_none());
+}
+
+#[test]
+fn parse_timestamp_rejects_malformed_rfc1123() {
+    assert!(parse_timestamp_ms_str("30 Foo 2017 08:44:05 GMT").is_none());
+    assert!(parse_timestamp_ms_str("30 Apr 2017 25:44:05 GMT").is_none());
+    assert!(parse_timestamp_ms_str("30 Apr 2017 08:44:05 GMT extra").is_none());
+    assert!(parse_timestamp_ms_str("30 Apr 2017").is_none());
+    assert!(parse_timestamp_ms_str("Apr 2017 08:44:05 GMT").is_none());
+}


### PR DESCRIPTION
## Summary

Two metadata losses with the same root: a server that reports less than Navidrome, and code that reads an absent field as "empty value" rather than "the server said nothing". Both were measured against a live server, not inferred.

- **Timestamps in RFC 1123.** A server may report `created` as `30 Apr 2017 08:44:05 GMT` instead of ISO 8601. The ingest parser only understood ISO, so the value was dropped and `server_created_at` stayed NULL — leaving "recently added" and the new-releases feed empty for that server. Server timestamps now pass one parser that accepts both forms, covering `created`, `createdAt`, `updatedAt` and `starred` on every ingest path; both parsers share the calendar arithmetic so they cannot drift.
- **Album year.** Album detail aggregates the year from the album's tracks, then overlays the standalone `album` row unconditionally. A `getAlbum` without a year therefore replaced a correct value with nothing and the header showed no year. It is now applied only when the row has one.
- Alphabetic zone names beyond UTC (`EST`, `PDT`) are rejected rather than guessed — a wrong date is worse than a missing one.
- `starred_at` keeps its unconditional assignment on purpose: an absent value there is a real state, and un-starring has to reach the UI.

## Test plan

- New: 7 parser cases (both forms, weekday optional, numeric offset, epoch start, unreliable zones rejected, malformed input rejected), 1 behaviour case asserting `server_created_at` is populated through `subsonic_song_to_track_row`, and 2 album-detail cases (track year survives an empty column; a populated column still wins). Reference epoch values come from an independent implementation, not from this parser.
- Mutation-checked: removing the RFC fallback turns exactly the 5 matching cases red; removing the year fallback turns exactly the one case red while the precedence case stays green.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean. `cargo test --workspace --no-fail-fast`: 8 crates, 887 passed, 1 failed — `upsert_500_rows_completes_well_under_perf_budget`, the known wall-clock flake, verified green in isolation on this same head.
- Verified end to end against a live server that exhibits both shapes: its tracks carry a year the album payload omits, and every `created` arrives in RFC 1123.

Runtime benchmark: not applicable - parsing and one conditional assignment on the album-detail path; no query, route, or render change.

## Known gaps

- Existing rows keep their NULL `server_created_at` until their next full sync. The offset reconcile shipped earlier does not cover this shape (both parsers return `None` for it, so there is nothing for it to correct), and a dedicated backfill would be its own change.
- `genre`, `song_count`, `duration_sec` and `cover_art_id` are assigned the same unconditional way in that overlay. No server we measured omits them, so they are left untouched rather than changed on speculation.
