### PR TITLE
feat(nowPlaying): let the tour prompt be dismissed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Some Subsonic servers — Bandcamp's among them — answer requests normally but do not permit them from an app window. Adding one failed with "Could not connect: Network Error" even though the server was reachable the whole time. Psysonic now recognises this and sends those servers' requests the same way it already sends streams and cover art.
 * Servers that work today are unaffected: they keep the exact request path they had.
 
+### Dismiss the tour dates prompt in the info tab
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), suggested by [@Trip7274](https://github.com/Trip7274), PR [#1513](https://github.com/Psysonic/psysonic/pull/1513)**
+
+* The info tab in the right sidebar offers tour dates as an optional feature, but the prompt could not be turned down. It now has a close button that hides it for good, and a short message points to **Settings → Integrations** in case you want the feature later.
+
 ## Fixed
 
 ### Shared Top Albums pictures show their covers again

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -456,6 +456,7 @@ const CONTRIBUTOR_ENTRIES = [
       'Psysonic Rewind — a year-in-review story and shareable posters in four layouts (PR #1485)',
       'Windows — updates install from inside the app, signed and verified like on macOS (PR #1487)',
       'Servers that refuse browser-style requests can be added and browsed (PR #1511)',
+      'Info tab — the tour dates prompt can be dismissed for good (PR #1513)',
     ],
   },
   {

--- a/src/features/nowPlaying/components/NowPlayingInfo.tsx
+++ b/src/features/nowPlaying/components/NowPlayingInfo.tsx
@@ -3,7 +3,7 @@ import { getArtistInfoForServer } from '@/lib/api/subsonicArtists';
 import type { SubsonicArtistInfo, SubsonicSong } from '@/lib/api/subsonicTypes';
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Info } from 'lucide-react';
+import { Info, X } from 'lucide-react';
 import { open as shellOpen } from '@tauri-apps/plugin-shell';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
 import { useAuthStore } from '@/store/authStore';
@@ -12,6 +12,7 @@ import { fetchBandsintownEvents, type BandsintownEvent } from '@/lib/api/bandsin
 import CachedImage from '@/ui/CachedImage';
 import OverlayScrollArea from '@/ui/OverlayScrollArea';
 import { primaryTrackArtistRef } from '@/features/playback/utils/playback/trackArtistRefs';
+import { showToast } from '@/lib/dom/toast';
 
 const TOUR_LIMIT = 5;
 const BIO_CLAMP_LINES = 4;
@@ -86,6 +87,8 @@ export default function NowPlayingInfo() {
   const currentTrack = usePlayerStore(s => s.currentTrack);
   const enableBandsintown = useAuthStore(s => s.enableBandsintown);
   const setEnableBandsintown = useAuthStore(s => s.setEnableBandsintown);
+  const bandsintownPromptDismissed = useAuthStore(s => s.bandsintownPromptDismissed);
+  const setBandsintownPromptDismissed = useAuthStore(s => s.setBandsintownPromptDismissed);
   const subsonicServerId = usePlaybackServerId();
   const subsonicReady = Boolean(subsonicServerId);
 
@@ -214,6 +217,7 @@ export default function NowPlayingInfo() {
         artistId,
         songId,
         enableBandsintown,
+        bandsintownPromptDismissed,
         tourLoading,
         tourEvents.length,
         showAllTours,
@@ -278,8 +282,10 @@ export default function NowPlayingInfo() {
         </section>
       )}
 
-      {/* Tour: prompt to opt-in when off, list when on */}
-      {!enableBandsintown ? (
+      {/* Tour: prompt to opt-in when off, list when on. A dismissed prompt shows
+          nothing — declining an optional feature has to stick — and Settings →
+          Integrations stays the way back in. */}
+      {!enableBandsintown && !bandsintownPromptDismissed && (
         <section className="np-info-section">
           <div className="np-info-bandsintown-prompt">
             <div className="np-info-bandsintown-prompt-title">
@@ -294,6 +300,18 @@ export default function NowPlayingInfo() {
               >
                 <Info size={13} />
               </span>
+              <button
+                type="button"
+                className="np-info-bandsintown-prompt-dismiss"
+                onClick={() => {
+                  setBandsintownPromptDismissed(true);
+                  showToast(t('nowPlayingInfo.bandsintownPromptDismissed'));
+                }}
+                data-tooltip={t('nowPlayingInfo.dismissBandsintownPrompt')}
+                aria-label={t('nowPlayingInfo.dismissBandsintownPrompt')}
+              >
+                <X size={13} />
+              </button>
             </div>
             <div className="np-info-bandsintown-prompt-desc">
               {t('nowPlayingInfo.enableBandsintownPromptDesc', 'Optional. Loads concerts for the current artist via Bandsintown.')}
@@ -307,7 +325,8 @@ export default function NowPlayingInfo() {
             </button>
           </div>
         </section>
-      ) : (
+      )}
+      {enableBandsintown && (
         <section className="np-info-section">
           <div className="np-info-section-title">{t('nowPlayingInfo.onTour', 'On tour')}</div>
           {tourLoading && tourEvents.length === 0 && (

--- a/src/features/nowPlaying/components/NowPlayingInfoBandsintownPrompt.test.tsx
+++ b/src/features/nowPlaying/components/NowPlayingInfoBandsintownPrompt.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * The info tab's Bandsintown opt-in prompt can be declined for good.
+ *
+ * The prompt is how the feature is discovered, so it stays in place — but an
+ * "optional" prompt the user cannot say no to is the complaint behind #1510.
+ * Declining hides it permanently and points at Settings → Integrations, which
+ * remains the way to turn the feature on later.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '@/test/helpers/renderWithProviders';
+import { resetAuthStore } from '@/test/helpers/storeReset';
+import { useAuthStore } from '@/store/authStore';
+import { usePlayerStore } from '@/features/playback/store/playerStore';
+import NowPlayingInfo from '@/features/nowPlaying/components/NowPlayingInfo';
+
+vi.mock('@/lib/api/subsonicArtists', () => ({
+  getArtistInfoForServer: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/lib/api/subsonicLibrary', () => ({
+  getSongForServer: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/lib/api/bandsintown', () => ({
+  fetchBandsintownEvents: vi.fn().mockResolvedValue([]),
+}));
+
+const showToast = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/dom/toast', () => ({ showToast }));
+
+const PROMPT = '.np-info-bandsintown-prompt';
+const DISMISS = '.np-info-bandsintown-prompt-dismiss';
+
+beforeEach(() => {
+  resetAuthStore();
+  showToast.mockClear();
+  usePlayerStore.setState({
+    currentTrack: { id: 't1', title: 'Song', artist: 'Artist' },
+  } as never);
+});
+
+describe('Bandsintown opt-in prompt', () => {
+  it('is shown while the feature is off and was never declined', () => {
+    const { container } = renderWithProviders(<NowPlayingInfo />);
+    expect(container.querySelector(PROMPT)).not.toBeNull();
+    expect(container.querySelector(DISMISS)).not.toBeNull();
+  });
+
+  it('declining hides it, remembers the choice, and names the way back', () => {
+    const { container } = renderWithProviders(<NowPlayingInfo />);
+
+    fireEvent.click(container.querySelector(DISMISS)!);
+
+    expect(container.querySelector(PROMPT)).toBeNull();
+    expect(useAuthStore.getState().bandsintownPromptDismissed).toBe(true);
+    expect(showToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays hidden on a later mount', () => {
+    useAuthStore.getState().setBandsintownPromptDismissed(true);
+    const { container } = renderWithProviders(<NowPlayingInfo />);
+    expect(container.querySelector(PROMPT)).toBeNull();
+  });
+
+  it('does not suppress the tour list once the feature is enabled', () => {
+    // Declining the prompt must not read as "never show tour dates": the
+    // Settings toggle stays authoritative for the feature itself.
+    useAuthStore.getState().setBandsintownPromptDismissed(true);
+    useAuthStore.getState().setEnableBandsintown(true);
+    const { container } = renderWithProviders(<NowPlayingInfo />);
+    expect(container.querySelector(PROMPT)).toBeNull();
+    expect(container.textContent).toContain('On tour');
+  });
+});

--- a/src/locales/bg/nowPlayingInfo.ts
+++ b/src/locales/bg/nowPlayingInfo.ts
@@ -16,6 +16,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: 'По избор. Зарежда концерти за текущия изпълнител чрез публичното Bandsintown API.',
   enableBandsintownPrivacy: 'Когато е активирано, името на текущо пуснатия изпълнител се изпраща към Bandsintown API за извличане на дати от турнета. Никакви акаунти или лични данни не напускат вашето устройство.',
   enableBandsintownAction: 'Активирай',
+  dismissBandsintownPrompt: 'Да не се показва отново',
+  bandsintownPromptDismissed: 'Датите от турнета остават скрити. Можеш да ги включиш от Настройки → Интеграции.',
   role: {
     artist: 'Изпълнител',
     albumArtist: 'Изпълнител на албум',

--- a/src/locales/de/nowPlayingInfo.ts
+++ b/src/locales/de/nowPlayingInfo.ts
@@ -16,6 +16,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: 'Optional. Lädt Tourdaten der aktuellen Künstler*in über die öffentliche Bandsintown-API.',
   enableBandsintownPrivacy: 'Beim Aktivieren wird der Name der aktuell gespielten Künstler*in an die Bandsintown-API übertragen, um Tourdaten abzurufen. Es werden keine Konto- oder persönlichen Daten gesendet.',
   enableBandsintownAction: 'Aktivieren',
+  dismissBandsintownPrompt: 'Nicht mehr anzeigen',
+  bandsintownPromptDismissed: 'Tourdaten bleiben ausgeblendet. Du kannst sie unter Einstellungen → Integrationen aktivieren.',
   role: {
     artist: 'Hauptkünstler*in',
     albumArtist: 'Album-Künstler*in',

--- a/src/locales/en/nowPlayingInfo.ts
+++ b/src/locales/en/nowPlayingInfo.ts
@@ -16,6 +16,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: 'Optional. Loads concerts for the current artist via the public Bandsintown API.',
   enableBandsintownPrivacy: 'When enabled, the name of the currently playing artist is sent to the Bandsintown API to fetch tour dates. No account or personal data leaves your device.',
   enableBandsintownAction: 'Enable',
+  dismissBandsintownPrompt: 'Don’t show this again',
+  bandsintownPromptDismissed: 'Tour dates stay hidden. You can turn them on under Settings → Integrations.',
   role: {
     artist: 'Artist',
     albumArtist: 'Album artist',

--- a/src/locales/es/nowPlayingInfo.ts
+++ b/src/locales/es/nowPlayingInfo.ts
@@ -16,6 +16,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: 'Opcional. Carga conciertos del artista actual vía la API pública de Bandsintown.',
   enableBandsintownPrivacy: 'Al activar, el nombre del artista actual se envía a la API de Bandsintown para obtener fechas de gira. No se envían datos de cuenta ni personales.',
   enableBandsintownAction: 'Activar',
+  dismissBandsintownPrompt: 'No volver a mostrar',
+  bandsintownPromptDismissed: 'Las fechas de gira permanecen ocultas. Puedes activarlas en Ajustes → Integraciones.',
   role: {
     artist: 'Artista',
     albumArtist: 'Artista del álbum',

--- a/src/locales/fr/nowPlayingInfo.ts
+++ b/src/locales/fr/nowPlayingInfo.ts
@@ -16,6 +16,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: 'Optionnel. Charge les concerts de l\'artiste via l\'API publique Bandsintown.',
   enableBandsintownPrivacy: 'Lors de l\'activation, le nom de l\'artiste en cours de lecture est envoyé à l\'API Bandsintown pour récupérer les dates de tournée. Aucun compte ni données personnelles ne quittent votre appareil.',
   enableBandsintownAction: 'Activer',
+  dismissBandsintownPrompt: 'Ne plus afficher',
+  bandsintownPromptDismissed: 'Les dates de tournée restent masquées. Vous pouvez les activer dans Paramètres → Intégrations.',
   role: {
     artist: 'Artiste',
     albumArtist: 'Artiste de l\'album',

--- a/src/locales/hu/nowPlayingInfo.ts
+++ b/src/locales/hu/nowPlayingInfo.ts
@@ -16,6 +16,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: 'Opcionális. Az aktuális előadó koncertjeit tölti be a nyilvános Bandsintown API-n keresztül.',
   enableBandsintownPrivacy: 'Bekapcsolva az éppen szóló előadó neve elküldésre kerül a Bandsintown API-nak a turnédátumok lekéréséhez. Fiók vagy személyes adat nem hagyja el az eszközödet.',
   enableBandsintownAction: 'Bekapcsolás',
+  dismissBandsintownPrompt: 'Ne jelenjen meg többé',
+  bandsintownPromptDismissed: 'A turnédátumok rejtve maradnak. A Beállítások → Integrációk menüben kapcsolhatod be őket.',
   role: {
     artist: 'Előadó',
     albumArtist: 'Album előadója',

--- a/src/locales/it/nowPlayingInfo.ts
+++ b/src/locales/it/nowPlayingInfo.ts
@@ -16,6 +16,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: 'Opzionale. Carica i concerti dell\'artista corrente tramite l\'API pubblica di Bandsintown.',
   enableBandsintownPrivacy: 'Quando questa funzione è attivata, il nome dell\'artista attualmente in riproduzione viene inviato all\'API di Bandsintown per recuperare le date del tour. Nessun account né dato personale viene trasmesso al di fuori del tuo dispositivo.',
   enableBandsintownAction: 'Abilita',
+  dismissBandsintownPrompt: 'Non mostrare più',
+  bandsintownPromptDismissed: 'Le date del tour restano nascoste. Puoi attivarle in Impostazioni → Integrazioni.',
   role: {
     artist: 'Artista',
     albumArtist: 'Album artista',

--- a/src/locales/ja/nowPlayingInfo.ts
+++ b/src/locales/ja/nowPlayingInfo.ts
@@ -16,6 +16,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: '任意です。公開 Bandsintown API から現在のアーティストの公演情報を読み込みます。',
   enableBandsintownPrivacy: '有効にすると、ツアー日程取得のため現在再生中のアーティスト名が Bandsintown API に送信されます。アカウント情報や個人データはデバイス外へ送信されません。',
   enableBandsintownAction: '有効化',
+  dismissBandsintownPrompt: '今後は表示しない',
+  bandsintownPromptDismissed: 'ツアー日程は非表示のままです。設定 → 連携 から有効にできます。',
   role: {
     artist: 'アーティスト',
     albumArtist: 'アルバムアーティスト',

--- a/src/locales/nb/nowPlayingInfo.ts
+++ b/src/locales/nb/nowPlayingInfo.ts
@@ -16,6 +16,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: 'Valgfritt. Henter konserter for gjeldende artist via det offentlige Bandsintown-API-et.',
   enableBandsintownPrivacy: 'Ved aktivering sendes navnet på artisten som spilles av til Bandsintown-API-et for å hente turnédatoer. Ingen konto- eller personopplysninger forlater enheten din.',
   enableBandsintownAction: 'Aktiver',
+  dismissBandsintownPrompt: 'Ikke vis dette igjen',
+  bandsintownPromptDismissed: 'Turnédatoer forblir skjult. Du kan slå dem på under Innstillinger → Integrasjoner.',
   role: {
     artist: 'Artist',
     albumArtist: 'Albumartist',

--- a/src/locales/nl/nowPlayingInfo.ts
+++ b/src/locales/nl/nowPlayingInfo.ts
@@ -16,6 +16,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: 'Optioneel. Laadt concerten van de huidige artiest via de openbare Bandsintown-API.',
   enableBandsintownPrivacy: 'Bij inschakelen wordt de naam van de huidige artiest naar de Bandsintown-API gestuurd om tourdata op te halen. Er worden geen account- of persoonlijke gegevens verzonden.',
   enableBandsintownAction: 'Inschakelen',
+  dismissBandsintownPrompt: 'Niet meer weergeven',
+  bandsintownPromptDismissed: 'Tourdata blijven verborgen. Je kunt ze inschakelen bij Instellingen → Integraties.',
   role: {
     artist: 'Artiest',
     albumArtist: 'Albumartiest',

--- a/src/locales/pl/nowPlayingInfo.ts
+++ b/src/locales/pl/nowPlayingInfo.ts
@@ -16,6 +16,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: 'Opcjonalne. Ładuje koncerty bieżącego wykonawcy przez publiczne API Bandsintown.',
   enableBandsintownPrivacy: 'Po włączeniu nazwa aktualnie odtwarzanego wykonawcy jest wysyłana do API Bandsintown w celu pobrania dat koncertów. Żadne konto ani dane osobowe nie opuszczają Twojego urządzenia.',
   enableBandsintownAction: 'Włącz',
+  dismissBandsintownPrompt: 'Nie pokazuj ponownie',
+  bandsintownPromptDismissed: 'Daty tras pozostaną ukryte. Możesz je włączyć w Ustawienia → Integracje.',
   role: {
     artist: 'Wykonawca',
     albumArtist: 'Wykonawca albumu',

--- a/src/locales/ro/nowPlayingInfo.ts
+++ b/src/locales/ro/nowPlayingInfo.ts
@@ -16,6 +16,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: 'Opțional. Încarcă concertele pentru artistul curent prin API-ul public Bandsintown.',
   enableBandsintownPrivacy: 'Când este pornit, numele artistului piesei curente redate este trimis către API-ul Bandsintown pentru a prelua datele turneelor. Nimic din datele personale sau ale contului nu părăsesc dispozitivul.',
   enableBandsintownAction: 'Pornește',
+  dismissBandsintownPrompt: 'Nu mai afișa',
+  bandsintownPromptDismissed: 'Datele turneelor rămân ascunse. Le poți activa din Setări → Integrări.',
   role: {
     artist: 'Artist',
     albumArtist: 'Artist album',

--- a/src/locales/ru/nowPlayingInfo.ts
+++ b/src/locales/ru/nowPlayingInfo.ts
@@ -18,6 +18,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: 'Опционально. Загружает концерты текущего исполнителя через публичный API Bandsintown.',
   enableBandsintownPrivacy: 'При включении имя текущего исполнителя отправляется в API Bandsintown для получения дат концертов. Аккаунт и личные данные не передаются.',
   enableBandsintownAction: 'Включить',
+  dismissBandsintownPrompt: 'Больше не показывать',
+  bandsintownPromptDismissed: 'Даты туров останутся скрытыми. Их можно включить в Настройки → Интеграции.',
   role: {
     artist: 'Исполнитель',
     albumArtist: 'Исполнитель альбома',

--- a/src/locales/uk/nowPlayingInfo.ts
+++ b/src/locales/uk/nowPlayingInfo.ts
@@ -18,6 +18,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: 'Необов’язково. Завантажує концерти для поточного виконавця через публічний API Bandsintown.',
   enableBandsintownPrivacy: 'Якщо ввімкнено, ім’я поточного виконавця надсилається до API Bandsintown для отримання дат турів. Жодні облікові або особисті дані не передаються.',
   enableBandsintownAction: 'Увімкнути',
+  dismissBandsintownPrompt: 'Більше не показувати',
+  bandsintownPromptDismissed: 'Дати турів залишаться прихованими. Їх можна увімкнути в Налаштування → Інтеграції.',
   role: {
     artist: 'Виконавець',
     albumArtist: 'Виконавець альбому',

--- a/src/locales/zh/nowPlayingInfo.ts
+++ b/src/locales/zh/nowPlayingInfo.ts
@@ -16,6 +16,8 @@ export const nowPlayingInfo = {
   enableBandsintownPromptDesc: '可选。通过公开的 Bandsintown API 加载当前艺术家的演出。',
   enableBandsintownPrivacy: '启用后，当前播放的艺术家名称将发送到 Bandsintown API 以获取巡演日期。不会发送任何账户或个人数据。',
   enableBandsintownAction: '启用',
+  dismissBandsintownPrompt: '不再显示',
+  bandsintownPromptDismissed: '巡演日期将保持隐藏。你可以在设置 → 集成中启用。',
   role: {
     artist: '艺术家',
     albumArtist: '专辑艺术家',

--- a/src/store/authDiscordSettingsActions.ts
+++ b/src/store/authDiscordSettingsActions.ts
@@ -11,6 +11,7 @@ export function createDiscordSettingsActions(set: SetState): Pick<
   | 'setDiscordCoverSource'
   | 'setCoverSources'
   | 'setEnableBandsintown'
+  | 'setBandsintownPromptDismissed'
   | 'setDiscordTemplateDetails'
   | 'setDiscordTemplateState'
   | 'setDiscordTemplateLargeText'
@@ -21,6 +22,7 @@ export function createDiscordSettingsActions(set: SetState): Pick<
     setDiscordCoverSource: (v) => set({ discordCoverSource: v }),
     setCoverSources: (v: CoverSourcePref[]) => set({ coverSources: v }),
     setEnableBandsintown: (v) => set({ enableBandsintown: v }),
+    setBandsintownPromptDismissed: (v) => set({ bandsintownPromptDismissed: v }),
     setDiscordTemplateDetails: (v) => set({ discordTemplateDetails: v }),
     setDiscordTemplateState: (v) => set({ discordTemplateState: v }),
     setDiscordTemplateLargeText: (v) => set({ discordTemplateLargeText: v }),

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -102,6 +102,7 @@ export const useAuthStore = create<AuthState>()(
       discordCoverSource: DEFAULT_DISCORD_COVER_SOURCE,
       coverSources: DEFAULT_COVER_SOURCES,
       enableBandsintown: false,
+      bandsintownPromptDismissed: false,
       discordTemplateDetails: '{artist}',
       discordTemplateState: '{title}',
       discordTemplateLargeText: '{album}',

--- a/src/store/authStoreTypes.ts
+++ b/src/store/authStoreTypes.ts
@@ -233,6 +233,12 @@ export interface AuthState {
   coverSources: CoverSourcePref[];
   /** Opt-in: fetch upcoming tour dates from Bandsintown for the Now-Playing info panel. */
   enableBandsintown: boolean;
+  /**
+   * The info tab's opt-in prompt for {@link enableBandsintown} was dismissed.
+   * Declining an optional feature has to stick, so the prompt stays hidden; the
+   * feature itself remains reachable through Settings → Integrations.
+   */
+  bandsintownPromptDismissed: boolean;
   discordTemplateDetails: string;
   discordTemplateState: string;
   discordTemplateLargeText: string;
@@ -479,6 +485,7 @@ export interface AuthState {
   setDiscordCoverSource: (v: DiscordCoverSource) => void;
   setCoverSources: (v: CoverSourcePref[]) => void;
   setEnableBandsintown: (v: boolean) => void;
+  setBandsintownPromptDismissed: (v: boolean) => void;
   setDiscordTemplateDetails: (v: string) => void;
   setDiscordTemplateState: (v: string) => void;
   setDiscordTemplateLargeText: (v: string) => void;

--- a/src/styles/components/mini-player-window.css
+++ b/src/styles/components/mini-player-window.css
@@ -851,6 +851,27 @@ html[data-perf-disable-home-artwork-clip="true"] .home-lite-artwork .song-card-c
   background: color-mix(in srgb, var(--accent) 12%, transparent);
   outline: none;
 }
+/* Decline control. Sits at the end of the title row rather than absolutely
+   positioned, so it cannot overlap a wrapped title in a narrow sidebar. */
+.np-info-bandsintown-prompt-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;
+  padding: 2px;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 50%;
+  transition: color 0.15s, background 0.15s;
+}
+.np-info-bandsintown-prompt-dismiss:hover,
+.np-info-bandsintown-prompt-dismiss:focus-visible {
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--text-primary) 12%, transparent);
+  outline: none;
+}
 .np-info-bandsintown-prompt-desc {
   font-size: 12px;
   color: var(--text-secondary);


### PR DESCRIPTION
Closes #1510

## Summary

- The info tab presents Bandsintown tour dates as optional, but the prompt could not be declined: the section rendered whenever the feature was off. Saying no to something labelled optional was impossible.
- The prompt now has a close control. Dismissing it hides the section permanently and raises a toast naming the way back — Settings → Integrations, where the feature toggle already lives, so no second setting is introduced.
- Dismissal and the feature stay separate: enabling Bandsintown later still shows the tour list. The prompt itself remains in place until dismissed, since it is how the feature is discovered.
- Two new strings, filled in all 15 locales.

## Test plan

- `NowPlayingInfoBandsintownPrompt.test.tsx` (new): prompt visible while the feature is off and undismissed · dismissing hides it, persists the choice and toasts · stays hidden on a later mount · does not suppress the tour list once the feature is enabled.
- Mutation-checked: ignoring the dismissal flag turns exactly the two matching cases red.
- `npx tsc --noEmit`, `npm run lint`, `npm run dep:check` clean. Full `npx vitest run`: 620 files, 4760 tests, all passing.
- Verified in the running dev build.

Runtime benchmark: not applicable - a conditional section plus one button in the queue panel's info tab; no route, query, or shared-render path changes, and the dismissed state renders strictly less DOM.
