### PR TITLE
fix(navidrome): send the song-list `missing` filter as a string

### DIFF
--- a/src-tauri/crates/psysonic-integration/src/navidrome/queries.rs
+++ b/src-tauri/crates/psysonic-integration/src/navidrome/queries.rs
@@ -24,9 +24,7 @@ pub async fn nd_list_songs_internal(
     start: u32,
     end: u32,
 ) -> Result<serde_json::Value, String> {
-    let mut seed = serde_json::Map::new();
-    seed.insert("missing".to_string(), serde_json::Value::Bool(false));
-    let filters = nd_build_filters(seed, None);
+    let filters = nd_build_filters(nd_song_list_filter_seed(), None);
     let start_s = start.to_string();
     let end_s = end.to_string();
     let url = format!("{}/api/song", server_url);
@@ -93,6 +91,24 @@ pub async fn nd_list_songs(
 /// Build the `_filters` JSON for native-API list calls. Optionally narrows the
 /// query to a single library — `library_id` is the same scope key the Navidrome
 /// web UI sends, and it matches the Subsonic `musicFolderId` we store per server.
+/// Filter seed for `/api/song`: skip tracks whose files Navidrome can no longer
+/// find.
+///
+/// The value is a **string**, not a JSON boolean. Navidrome's react-admin filter
+/// layer parses these values as strings, and `{"missing":false}` makes it answer
+/// HTTP 500 (reproduced against 0.63.2). That 500 reached the initial-sync N1
+/// ingest as a failed first page, which it could not distinguish from the end of
+/// the library — so the sync stopped at offset 0, reported success, and left the
+/// library empty with nothing in the log to say why.
+fn nd_song_list_filter_seed() -> serde_json::Map<String, serde_json::Value> {
+    let mut seed = serde_json::Map::new();
+    seed.insert(
+        "missing".to_string(),
+        serde_json::Value::String("false".to_string()),
+    );
+    seed
+}
+
 fn nd_build_filters(seed: serde_json::Map<String, serde_json::Value>, library_id: Option<&str>) -> String {
     let mut obj = seed;
     if let Some(lib) = library_id {
@@ -359,6 +375,21 @@ mod tests {
     fn parse_json_object(s: &str) -> serde_json::Map<String, serde_json::Value> {
         let v: serde_json::Value = serde_json::from_str(s).expect("valid JSON");
         v.as_object().expect("object").clone()
+    }
+
+    #[test]
+    fn song_list_filter_sends_missing_as_a_string_not_a_boolean() {
+        // Navidrome answers HTTP 500 to `{"missing":false}`. The initial sync
+        // read that failure as an empty first page and stopped, leaving the
+        // library empty — so the JSON type here is load-bearing, not cosmetic.
+        let out = nd_build_filters(nd_song_list_filter_seed(), None);
+        let parsed = parse_json_object(&out);
+        let missing = parsed.get("missing").expect("missing filter present");
+        assert_eq!(missing.as_str(), Some("false"));
+        assert!(
+            missing.as_bool().is_none(),
+            "a JSON boolean here makes Navidrome return HTTP 500, got {missing}"
+        );
     }
 
     #[test]

--- a/src-tauri/crates/psysonic-library/src/sync/initial/tests/n1.rs
+++ b/src-tauri/crates/psysonic-library/src/sync/initial/tests/n1.rs
@@ -19,7 +19,10 @@ async fn n1_ingest_paginates_navidrome_native_endpoint() {
         Mock::given(wm_method("GET"))
             .and(wm_path("/api/song"))
             .and(query_param("_start", start.to_string()))
-            .and(query_param("_filters", r#"{"missing":false}"#))
+            // A string, not a JSON boolean: Navidrome answers HTTP 500 to
+            // `{"missing":false}`. Pinning it here keeps the wire format under
+            // test rather than only the pagination around it.
+            .and(query_param("_filters", r#"{"missing":"false"}"#))
             .and(header("X-ND-Authorization", "Bearer nd-tok"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::Value::Array(songs)))
             .mount(&server)

--- a/src/config/settingsCredits.ts
+++ b/src/config/settingsCredits.ts
@@ -570,6 +570,13 @@ const CONTRIBUTOR_ENTRIES = [
       'Ukrainian translation, with Ukrainian Cyrillic folding in library identity keys (PR #1465)',
     ],
   },
+  {
+    github: 'starrlord',
+    since: '1.53.0',
+    contributions: [
+      'Navidrome song-list filter fix that unblocked native library sync (PR #1514)',
+    ],
+  },
 ] as const;
 
 // PR number of a contributor's first listed contribution, used as the


### PR DESCRIPTION
## What changed

`/api/song` was called with `_filters={"missing":false}`. Navidrome's
react-admin filter layer parses `_filters` values as **strings**, and a JSON
boolean makes it answer **HTTP 500**. Sending `{"missing":"false"}` returns the
full library.

Reproduced against **Navidrome 0.63.2**:

| `_filters` | Result |
| --- | --- |
| `{"missing": false}` — what we sent | **HTTP 500**, empty body |
| `{"missing": 0}` | **HTTP 500**, empty body |
| `{"missing": "false"}` | HTTP 200, `X-Total-Count: 15969` |
| `{"missing": "true"}` | HTTP 200, 0 rows |
| filter absent | HTTP 200, `X-Total-Count: 15969` |

The `"true"` row is the one that matters: the string form is genuinely honoured,
not merely tolerated, so this preserves the intent of skipping tracks whose files
Navidrome can no longer find.

## Who should notice

**End users on Navidrome**, and severely — on an affected server the initial
sync ingests nothing at all, so the app is unusable. Existing installs stuck in
this state recover on their own: the sync is still at `initial_sync` with an
empty library, and the next pass after upgrading ingests normally. No migration,
no on-disk format change.

## Why it presented as something else entirely

The 500 reached the N1 initial-sync ingest as a failed first page.
`n1_hit_deep_offset_wall` only recognises a 500 when
`offset >= n1_deep_offset_safe`, so at offset 0 it neither fell back to S1 nor
surfaced the error. The ingest stopped having written nothing and left
`sync_phase` at `initial_sync`.

Downstream:

- every artist and album rendered **"not found"** — the local library was
  literally empty (`track: 0`) while the server reported 15,969 tracks;
- `[analysis][enrichment] failed …: FOREIGN KEY constraint failed`, from
  enrichment writing against the empty `track` table;
- a ~2-minute loop of `N1 ingest server …` → `bulk ingest finalized in 2ms`,
  with nothing in the log and nothing in `sync_state.last_error`.

## The change

One value, plus a seam to test it through. The seed was inlined in an async HTTP
function, so the JSON type it produced could not be covered; it is now
`nd_song_list_filter_seed()`, beside the existing `nd_build_filters`, with a
regression test alongside the four already there. That test fails on the old code
— `as_str()` returns `None` for a boolean.

`sync::initial::tests::n1` mocks `/api/song` and matches the exact `_filters`
query string, so it pins the wire format too and is updated in the same commit.

## Verification

- `cargo test -p psysonic-integration` — passes, including the new test.
- `cargo test -p psysonic-library` — the N1 ingest test passes with the updated
  matcher.
- End to end against a 15,969-track Navidrome 0.63.2 server: initial sync now
  reaches `sync_phase=ready` with `local_track_count == server_track_count`
  (15969), `track: 15969`, `artist: 987`, `album_browse_projection: 1107`.
  Before the change, all three were 0.

**Tauri boundary:** not touched — no commands, events or payloads added, removed
or renamed. **Persisted settings / on-disk layout:** unchanged.

## Pre-existing failures on `main`, unrelated to this PR

Flagging these so they are not read as fallout, and left alone per "no unrelated
cleanup in the same PR":

- `cargo clippy --workspace --all-targets -- -D warnings` fails in
  `psysonic-audio/src/engine/output_stream.rs:144`
  (`clippy::unnecessary_lazy_evaluations`) on **rustc 1.98**. Reproduces on
  pristine `main`; CI uses `dtolnay/rust-toolchain@stable`, so it will start
  failing as runners pick 1.98 up.
- Six `repos::play_session::tests::*` failures reproduce on pristine `main`.
- `repos::track::tests::ingest::upsert_500_rows_completes_well_under_perf_budget`
  is a wall-clock budget test that fails under a loaded parallel run and passes
  standalone.

## Deliberately not fixed here

A failed first page is still indistinguishable from an empty library: a totally
failed initial sync reports success and logs nothing, which is what made this
hard to find. Worth a follow-up — log the failure, and treat an empty *first*
page as grounds to fall back to S1 rather than as completion. Happy to open that
separately if useful.
