### PR TITLE
fix(lyrics): let a track's lyrics be reloaded from the source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Albums from servers whose album data carries no year showed no release year at all, even though the tracks had one. The year from the tracks is now kept instead of being overwritten with nothing.
 * The same servers often report dates in a different standard format, which was discarded on import. That left "recently added" and the New Releases page empty for them. Both formats are now understood. Albums already in your library pick their date up on the next full library sync.
 
+### Lyrics edited on the server can be reloaded
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1516](https://github.com/Psysonic/psysonic/pull/1516)**
+
+* Lyrics were kept locally for 90 days once fetched, and nothing refreshed them — editing them on the server, rescanning and even a full library sync all left the old version on screen. The lyrics pane now has a "Refresh lyrics" action below the text that discards the stored copy for that track and fetches it again.
+* Useful for switching a track to word-synced lyrics, fixing a typo, or picking up lyrics added after Psysonic already looked and found none.
+
 ## [1.52.0]
 
 ## Added

--- a/src/features/lyrics/components/LyricsPane.tsx
+++ b/src/features/lyrics/components/LyricsPane.tsx
@@ -1,4 +1,5 @@
 import { getSmoothPlaybackTime, subscribeSmoothPlaybackTime } from '@/features/playback';
+import { RotateCcw } from 'lucide-react';
 import { useEffect, useRef, useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { usePlayerStore } from '@/features/playback/store/playerStore';
@@ -23,7 +24,7 @@ interface Props {
 export default function LyricsPane({ currentTrack }: Props) {
   const { t } = useTranslation();
 
-  const { syncedLines, wordLines, plainLyrics, source, loading, notFound } = useLyrics(currentTrack);
+  const { syncedLines, wordLines, plainLyrics, source, loading, notFound, refresh } = useLyrics(currentTrack);
   const { staticOnly, sidebarLyricsStyle, lyricsSources } = useAuthStore(useShallow(s => ({
     staticOnly: s.lyricsStaticOnly,
     sidebarLyricsStyle: s.sidebarLyricsStyle,
@@ -172,96 +173,113 @@ export default function LyricsPane({ currentTrack }: Props) {
   );
 
   return (
-    <OverlayScrollArea
-      className="lyrics-pane"
-      viewportClassName="lyrics-pane__viewport"
-      viewportRef={setContainerRef}
-      measureDeps={[
-        currentTrack?.id,
-        loading,
-        notFound,
-        source,
-        useWords,
-        hasSynced,
-        staticOnly,
-        sidebarLyricsStyle,
-        plainLyrics?.length ?? 0,
-        syncedLines?.length ?? 0,
-        wordLines?.length ?? 0,
-      ]}
-      railInset="panel"
-      viewportOnWheel={handleUserScroll}
-      viewportOnTouchMove={handleUserScroll}
-    >
-      {loading && <p className="lyrics-status">{t('player.lyricsLoading')}</p>}
-      {notFound && !loading && <p className="lyrics-status">{t('player.lyricsNotFound')}</p>}
+    <div className="lyrics-pane-wrap">
+      <OverlayScrollArea
+        className="lyrics-pane"
+        viewportClassName="lyrics-pane__viewport"
+        viewportRef={setContainerRef}
+        measureDeps={[
+          currentTrack?.id,
+          loading,
+          notFound,
+          source,
+          useWords,
+          hasSynced,
+          staticOnly,
+          sidebarLyricsStyle,
+          plainLyrics?.length ?? 0,
+          syncedLines?.length ?? 0,
+          wordLines?.length ?? 0,
+        ]}
+        railInset="panel"
+        viewportOnWheel={handleUserScroll}
+        viewportOnTouchMove={handleUserScroll}
+      >
+        {loading && <p className="lyrics-status">{t('player.lyricsLoading')}</p>}
+        {notFound && !loading && <p className="lyrics-status">{t('player.lyricsNotFound')}</p>}
 
-      {useWords && (
-        <div className="lyrics-synced lyrics-word-synced">
-          {(wordLines as WordLyricsLine[]).map((line, i) => (
-            <div
-              key={i}
-              ref={el => { lineRefs.current[i] = el; }}
-              className="lyrics-line"
-              onClick={() => { if (duration > 0) seek(line.time / duration); }}
-              style={{ cursor: 'pointer' }}
-            >
-              {line.words.length > 0 ? line.words.map((w, j) => (
-                <span
-                  key={j}
-                  className="lyrics-word"
-                  ref={el => {
-                    if (!wordRefs.current[i]) wordRefs.current[i] = [];
-                    if (el) wordRefs.current[i][j] = el;
-                  }}
-                >
-                  {w.text}
-                </span>
-              )) : (line.text || '\u00A0')}
-            </div>
-          ))}
-        </div>
-      )}
+        {useWords && (
+          <div className="lyrics-synced lyrics-word-synced">
+            {(wordLines as WordLyricsLine[]).map((line, i) => (
+              <div
+                key={i}
+                ref={el => { lineRefs.current[i] = el; }}
+                className="lyrics-line"
+                onClick={() => { if (duration > 0) seek(line.time / duration); }}
+                style={{ cursor: 'pointer' }}
+              >
+                {line.words.length > 0 ? line.words.map((w, j) => (
+                  <span
+                    key={j}
+                    className="lyrics-word"
+                    ref={el => {
+                      if (!wordRefs.current[i]) wordRefs.current[i] = [];
+                      if (el) wordRefs.current[i][j] = el;
+                    }}
+                  >
+                    {w.text}
+                  </span>
+                )) : (line.text || '\u00A0')}
+              </div>
+            ))}
+          </div>
+        )}
 
-      {hasSynced && !useWords && (
-        <div className="lyrics-synced">
-          {(syncedLines as LrcLine[]).map((line, i) => (
-            <div
-              key={i}
-              ref={el => { lineRefs.current[i] = el; }}
-              className="lyrics-line"
-              onClick={() => { if (duration > 0) seek(line.time / duration); }}
-              style={{ cursor: 'pointer' }}
-            >
-              {line.text || '\u00A0'}
-            </div>
-          ))}
-        </div>
-      )}
+        {hasSynced && !useWords && (
+          <div className="lyrics-synced">
+            {(syncedLines as LrcLine[]).map((line, i) => (
+              <div
+                key={i}
+                ref={el => { lineRefs.current[i] = el; }}
+                className="lyrics-line"
+                onClick={() => { if (duration > 0) seek(line.time / duration); }}
+                style={{ cursor: 'pointer' }}
+              >
+                {line.text || '\u00A0'}
+              </div>
+            ))}
+          </div>
+        )}
 
-      {renderAsStatic && (
-        <div className="lyrics-plain">
-          {((syncedLines ?? []).length > 0
-            ? (syncedLines as LrcLine[]).map(l => l.text)
-            : (wordLines as WordLyricsLine[]).map(l => l.text)
-          ).map((text, i) => (
-            <p key={i} className="lyrics-plain-line">{text || '\u00A0'}</p>
-          ))}
-        </div>
-      )}
+        {renderAsStatic && (
+          <div className="lyrics-plain">
+            {((syncedLines ?? []).length > 0
+              ? (syncedLines as LrcLine[]).map(l => l.text)
+              : (wordLines as WordLyricsLine[]).map(l => l.text)
+            ).map((text, i) => (
+              <p key={i} className="lyrics-plain-line">{text || '\u00A0'}</p>
+            ))}
+          </div>
+        )}
 
-      {!renderAsStatic && !useWords && !hasSynced && plainLyrics && (
-        <div className="lyrics-plain">
-          {plainLyrics.split('\n').map((line, i) => (
-            <p key={i} className="lyrics-plain-line">{line || '\u00A0'}</p>
-          ))}
-        </div>
-      )}
+        {!renderAsStatic && !useWords && !hasSynced && plainLyrics && (
+          <div className="lyrics-plain">
+            {plainLyrics.split('\n').map((line, i) => (
+              <p key={i} className="lyrics-plain-line">{line || '\u00A0'}</p>
+            ))}
+          </div>
+        )}
 
-      {sourceLabel && !loading && !notFound && (
-        <p className="lyrics-source">{sourceLabel}</p>
-      )}
-    </OverlayScrollArea>
+      </OverlayScrollArea>
+
+      {/* Pinned below the scrolling text: the refresh action stays reachable
+          without scrolling to the end of a long song, and the source label
+          keeps its place directly under it. */}
+      <div className="lyrics-pane-footer">
+        <button
+          type="button"
+          className="lyrics-refresh-btn"
+          onClick={refresh}
+          disabled={loading}
+        >
+          <RotateCcw size={14} className={loading ? 'spin' : ''} aria-hidden="true" />
+          <span>{t('player.lyricsRefresh')}</span>
+        </button>
+        {sourceLabel && !loading && !notFound && (
+          <p className="lyrics-source">{sourceLabel}</p>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/src/features/lyrics/hooks/useLyrics.refresh.test.ts
+++ b/src/features/lyrics/hooks/useLyrics.refresh.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Track } from '@/lib/media/trackTypes';
+import type { CachedLyrics } from '@/features/lyrics/types';
+import { useAuthStore } from '@/store/authStore';
+import { lyricsCache, useLyrics } from '@/features/lyrics/hooks/useLyrics';
+import { lyricsCacheKey } from '@/features/lyrics/utils/lyricsPersistentCache';
+
+// The persistent layer is backed by a real Map here, not by resolved values:
+// the point of the refresh action is that the L2 entry is actually gone, so a
+// mock that always reports a miss on the second read would pass even if the
+// delete never happened (issue #1506).
+const mocks = vi.hoisted(() => ({
+  getLyricsBySongId: vi.fn(),
+  store: new Map<string, unknown>(),
+}));
+
+vi.mock('@/lib/api/subsonicLyrics', () => ({ getLyricsBySongId: mocks.getLyricsBySongId }));
+vi.mock('@/features/lyrics/utils/lyricsPersistentCache', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/features/lyrics/utils/lyricsPersistentCache')>();
+  return {
+    ...actual,
+    getCachedLyrics: vi.fn(async (key: string) => (mocks.store.get(key) ?? null) as CachedLyrics | null),
+    putCachedLyrics: vi.fn(async (key: string, payload: CachedLyrics) => { mocks.store.set(key, payload); }),
+    deleteCachedLyrics: vi.fn(async (key: string) => { mocks.store.delete(key); }),
+  };
+});
+
+const track: Track = {
+  id: 'song-1',
+  title: 'Song',
+  artist: 'Artist',
+  album: 'Album',
+  albumId: 'album-1',
+  duration: 120,
+  serverId: 'srv-1',
+};
+
+const CACHE_KEY = lyricsCacheKey('srv-1', 'song-1');
+
+const staleEntry: CachedLyrics = {
+  syncedLines: null,
+  wordLines: null,
+  plainLyrics: 'Stale cached lyrics',
+  source: 'server',
+  notFound: false,
+};
+
+beforeEach(() => {
+  lyricsCache.clear();
+  mocks.store.clear();
+  mocks.getLyricsBySongId.mockReset();
+  useAuthStore.setState({
+    activeServerId: 'srv-1',
+    servers: [],
+    lyricsSources: [
+      { id: 'server', enabled: true },
+      { id: 'lrclib', enabled: false },
+      { id: 'netease', enabled: false },
+    ],
+  });
+});
+
+describe('useLyrics refresh', () => {
+  it('drops both cache levels and refetches lyrics edited server-side', async () => {
+    mocks.store.set(CACHE_KEY, staleEntry);
+
+    const { result } = renderHook(() => useLyrics(track));
+
+    // The persisted copy is served without asking the server at all — this is
+    // the state a user is stuck in for the full TTL after editing the lyrics.
+    await waitFor(() => expect(result.current.plainLyrics).toBe('Stale cached lyrics'));
+    expect(mocks.getLyricsBySongId).not.toHaveBeenCalled();
+    expect(lyricsCache.has(CACHE_KEY)).toBe(true);
+
+    mocks.getLyricsBySongId.mockResolvedValue({
+      line: [{ start: 0, value: 'Fresh server lyrics' }],
+      synced: false,
+    });
+
+    act(() => result.current.refresh());
+
+    await waitFor(() => expect(result.current.plainLyrics).toBe('Fresh server lyrics'));
+    expect(mocks.getLyricsBySongId).toHaveBeenCalledWith('song-1', { enhanced: false, serverId: 'srv-1' });
+    // Refetched content replaces the persisted copy rather than leaving a hole.
+    expect(mocks.store.get(CACHE_KEY)).toMatchObject({ plainLyrics: 'Fresh server lyrics' });
+  });
+
+  it('refetches after a not-found result so later-added lyrics are picked up', async () => {
+    mocks.store.set(CACHE_KEY, {
+      syncedLines: null,
+      wordLines: null,
+      plainLyrics: null,
+      source: null,
+      notFound: true,
+    });
+
+    const { result } = renderHook(() => useLyrics(track));
+    await waitFor(() => expect(result.current.notFound).toBe(true));
+
+    mocks.getLyricsBySongId.mockResolvedValue({
+      line: [{ start: 0, value: 'Added later' }],
+      synced: false,
+    });
+
+    act(() => result.current.refresh());
+
+    await waitFor(() => expect(result.current.plainLyrics).toBe('Added later'));
+    expect(result.current.notFound).toBe(false);
+  });
+});

--- a/src/features/lyrics/hooks/useLyrics.ts
+++ b/src/features/lyrics/hooks/useLyrics.ts
@@ -1,6 +1,6 @@
 import { getLyricsBySongId } from '@/lib/api/subsonicLyrics';
 import type { Track } from '@/lib/media/trackTypes';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { commands } from '@/generated/bindings';
 import { fetchLyrics } from '@/features/lyrics/api/lrclib';
 import { parseEnhancedLrc, parseLrc } from '@/features/lyrics/utils/lrc';
@@ -8,7 +8,7 @@ import { fetchNeteaselyrics } from '@/features/lyrics/api/netease';
 import { useAuthStore } from '@/store/authStore';
 import { useOfflineStore } from '@/features/offline';
 import { useHotCacheStore } from '@/features/playback/store/hotCacheStore';
-import { getCachedLyrics, putCachedLyrics, lyricsCacheKey } from '@/features/lyrics/utils/lyricsPersistentCache';
+import { deleteCachedLyrics, getCachedLyrics, putCachedLyrics, lyricsCacheKey } from '@/features/lyrics/utils/lyricsPersistentCache';
 import { parseStructuredLyrics, parseStructuredWordLines } from '@/features/lyrics/utils/structuredLyrics';
 import { FEATURE_ENHANCED_LYRICS } from '@/lib/serverCapabilities/catalog';
 import { isFeatureActiveForServer } from '@/lib/serverCapabilities/storeView';
@@ -27,6 +27,12 @@ export interface UseLyricsResult {
   source: LyricsSource | null;
   loading: boolean;
   notFound: boolean;
+  /**
+   * Drops both cache levels for the current track and refetches. Lyrics edited
+   * server-side are otherwise served from L2 for its full TTL — no sync path
+   * invalidates it (issue #1506).
+   */
+  refresh: () => void;
 }
 
 export function useLyrics(currentTrack: Track | null): UseLyricsResult {
@@ -44,6 +50,17 @@ export function useLyrics(currentTrack: Track | null): UseLyricsResult {
   const [plainLyrics, setPlainLyrics] = useState<string | null>(cached?.plainLyrics ?? null);
   const [source, setSource]           = useState<LyricsSource | null>(cached?.source ?? null);
   const [notFound, setNotFound]       = useState(cached?.notFound ?? false);
+  // Bumped by `refresh()` to re-run the fetch effect for an unchanged track.
+  const [reloadNonce, setReloadNonce] = useState(0);
+
+  const refresh = useCallback(() => {
+    if (!cacheKey) return;
+    lyricsCache.delete(cacheKey);
+    setLoading(true);
+    // Bump only once L2 is actually gone, otherwise the effect can re-read the
+    // entry it is meant to replace.
+    void deleteCachedLyrics(cacheKey).finally(() => setReloadNonce(n => n + 1));
+  }, [cacheKey]);
 
   useEffect(() => {
     if (!currentTrack) return;
@@ -216,7 +233,7 @@ export function useLyrics(currentTrack: Track | null): UseLyricsResult {
     })();
 
     return () => { cancelled = true; };
-  }, [cacheKey, currentTrack?.id, lyricsSources, ownerServerId, ownerServerKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [cacheKey, currentTrack?.id, lyricsSources, ownerServerId, ownerServerKey, reloadNonce]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  return { syncedLines, wordLines, plainLyrics, source, loading, notFound };
+  return { syncedLines, wordLines, plainLyrics, source, loading, notFound, refresh };
 }

--- a/src/features/lyrics/utils/lyricsPersistentCache.ts
+++ b/src/features/lyrics/utils/lyricsPersistentCache.ts
@@ -100,6 +100,26 @@ export async function putCachedLyrics(key: string, payload: CachedLyrics): Promi
   }
 }
 
+/**
+ * Drops the entry for a single track. Used by the per-track refresh action:
+ * lyrics edited server-side are otherwise served from here for the full
+ * 90-day TTL, since no sync path touches this store (issue #1506).
+ */
+export async function deleteCachedLyrics(key: string): Promise<void> {
+  try {
+    const database = await openDB();
+    if (!database) return;
+    await new Promise<void>(resolve => {
+      const tx = database.transaction(STORE_NAME, 'readwrite');
+      tx.objectStore(STORE_NAME).delete(key);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => resolve();
+    });
+  } catch {
+    // Ignore — the RAM cache is cleared regardless, so the refetch still runs.
+  }
+}
+
 /** Wipes all entries — exposed for a future "clear cache" Settings action. */
 export async function clearLyricsCache(): Promise<void> {
   try {

--- a/src/locales/bg/player.ts
+++ b/src/locales/bg/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: 'Източник: сървър',
   lyricsSourceLrclib: 'Източник: LRCLIB',
   lyricsSourceNetease: 'Източник: Netease',
+  lyricsRefresh: 'Обнови текста',
   showDuration: 'Покажи времетраенето',
   showRemainingTime: 'Покажи оставащото време',
   scrobbleStatus: 'Състояние на скробването',

--- a/src/locales/de/player.ts
+++ b/src/locales/de/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: 'Quelle: Server',
   lyricsSourceLrclib: 'Quelle: LRCLIB',
   lyricsSourceNetease: 'Quelle: Netease',
+  lyricsRefresh: 'Lyrics neu laden',
   showDuration: 'Dauer anzeigen',
   showRemainingTime: 'Verbleibende Zeit anzeigen',
   scrobbleStatus: 'Scrobble-Status',

--- a/src/locales/en/player.ts
+++ b/src/locales/en/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: 'Source: Server',
   lyricsSourceLrclib: 'Source: LRCLIB',
   lyricsSourceNetease: 'Source: Netease',
+  lyricsRefresh: 'Refresh lyrics',
   showDuration: 'Show duration',
   showRemainingTime: 'Show remaining time',
   scrobbleStatus: 'Scrobble status',

--- a/src/locales/es/player.ts
+++ b/src/locales/es/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: 'Fuente: Servidor',
   lyricsSourceLrclib: 'Fuente: LRCLIB',
   lyricsSourceNetease: 'Fuente: Netease',
+  lyricsRefresh: 'Actualizar las letras',
   showDuration: 'Mostrar duración',
   showRemainingTime: 'Mostrar tiempo restante',
   scrobbleStatus: 'Estado del scrobble',

--- a/src/locales/fr/player.ts
+++ b/src/locales/fr/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: 'Source : Serveur',
   lyricsSourceLrclib: 'Source : LRCLIB',
   lyricsSourceNetease: 'Source : Netease',
+  lyricsRefresh: 'Actualiser les paroles',
   showDuration: 'Afficher la durée',
   showRemainingTime: 'Afficher le temps restant',
   scrobbleStatus: 'État du scrobble',

--- a/src/locales/hu/player.ts
+++ b/src/locales/hu/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: 'Forrás: szerver',
   lyricsSourceLrclib: 'Forrás: LRCLIB',
   lyricsSourceNetease: 'Forrás: Netease',
+  lyricsRefresh: 'Dalszöveg frissítése',
   showDuration: 'Hossz megjelenítése',
   showRemainingTime: 'Hátralévő idő megjelenítése',
   scrobbleStatus: 'Scrobble állapota',

--- a/src/locales/it/player.ts
+++ b/src/locales/it/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: 'Fonte: Server',
   lyricsSourceLrclib: 'Fonte: LRCLIB',
   lyricsSourceNetease: 'Fonte: Netease',
+  lyricsRefresh: 'Aggiorna i testi',
   showDuration: 'Mostra durata',
   showRemainingTime: 'Mostra tempo rimanente',
   scrobbleStatus: 'Stato dello scrobble',

--- a/src/locales/ja/player.ts
+++ b/src/locales/ja/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: 'ソース: サーバー',
   lyricsSourceLrclib: 'ソース: LRCLIB',
   lyricsSourceNetease: 'ソース: Netease',
+  lyricsRefresh: '歌詞を再読み込み',
   showDuration: '長さを表示',
   showRemainingTime: '残り時間を表示',
   scrobbleStatus: 'Scrobble の状態',

--- a/src/locales/nb/player.ts
+++ b/src/locales/nb/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: 'Kilde: Server',
   lyricsSourceLrclib: 'Kilde: LRCLIB',
   lyricsSourceNetease: 'Kilde: Netease',
+  lyricsRefresh: 'Oppdater sangteksten',
   showDuration: 'Vis varighet',
   showRemainingTime: 'Vis gjenværende tid',
   scrobbleStatus: 'Scrobble-status',

--- a/src/locales/nl/player.ts
+++ b/src/locales/nl/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: 'Bron: Server',
   lyricsSourceLrclib: 'Bron: LRCLIB',
   lyricsSourceNetease: 'Bron: Netease',
+  lyricsRefresh: 'Songtekst vernieuwen',
   showDuration: 'Toon duur',
   showRemainingTime: 'Toon resterende tijd',
   scrobbleStatus: 'Scrobble-status',

--- a/src/locales/pl/player.ts
+++ b/src/locales/pl/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: 'Źródło: Serwer',
   lyricsSourceLrclib: 'Źródło: LRCLIB',
   lyricsSourceNetease: 'Źródło: Netease',
+  lyricsRefresh: 'Odśwież tekst utworu',
   showDuration: 'Pokaż czas trwania',
   showRemainingTime: 'Pokaż pozostały czas',
   scrobbleStatus: 'Stan scrobble',

--- a/src/locales/ro/player.ts
+++ b/src/locales/ro/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: 'Sursa: Server',
   lyricsSourceLrclib: 'Sursa: LRCLIB',
   lyricsSourceNetease: 'Sursa: Netease',
+  lyricsRefresh: 'Reîmprospătează versurile',
   showDuration: 'Arată durata',
   showRemainingTime: 'Arată timpul rămas',
   scrobbleStatus: 'Starea scrobble-ului',

--- a/src/locales/ru/player.ts
+++ b/src/locales/ru/player.ts
@@ -64,6 +64,7 @@ export const player = {
   lyricsSourceServer: 'Источник: Сервер',
   lyricsSourceLrclib: 'Источник: LRCLIB',
   lyricsSourceNetease: 'Источник: Netease',
+  lyricsRefresh: 'Обновить текст',
   fsLyricsToggle: 'Текст в полноэкранном режиме',
   showDuration: 'Показать длительность',
   showRemainingTime: 'Показать оставшееся время',

--- a/src/locales/uk/player.ts
+++ b/src/locales/uk/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: 'Джерело: Сервер',
   lyricsSourceLrclib: 'Джерело: LRCLIB',
   lyricsSourceNetease: 'Джерело: Netease',
+  lyricsRefresh: 'Оновити текст пісні',
   showDuration: 'Показувати тривалість',
   showRemainingTime: 'Показувати час, що залишився',
   scrobbleStatus: 'Статус скробблінгу',

--- a/src/locales/zh/player.ts
+++ b/src/locales/zh/player.ts
@@ -65,6 +65,7 @@ export const player = {
   lyricsSourceServer: '来源：服务器',
   lyricsSourceLrclib: '来源：LRCLIB',
   lyricsSourceNetease: '来源：网易云',
+  lyricsRefresh: '刷新歌词',
   showDuration: '显示时长',
   showRemainingTime: '显示剩余时间',
   scrobbleStatus: 'Scrobble 状态',

--- a/src/styles/components/help-page.css
+++ b/src/styles/components/help-page.css
@@ -257,6 +257,54 @@
 
 /* ── Lyrics Pane (sidebar) ────────────────────────────────────────────────── */
 
+/* Wrapper so the refresh action can sit above the scrolling text instead of
+   scrolling away with it. Takes over the flex role the pane itself used to
+   hold inside the queue panel. */
+.lyrics-pane-wrap {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Set off from the scrolling text with the same top edge the tab bar below it
+   uses, so the pane reads as text / actions / tabs instead of running together. */
+.lyrics-pane-footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 7px 12px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-hover);
+  flex-shrink: 0;
+}
+
+/* Matches `.lyrics-source` so the two footer items read as one row; only the
+   hover state marks this one as the interactive half. */
+.lyrics-refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.lyrics-refresh-btn:hover:not(:disabled) {
+  color: var(--accent);
+}
+
+.lyrics-refresh-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .lyrics-pane {
   flex: 1;
   min-height: 0;
@@ -369,12 +417,17 @@
   margin: 0;
 }
 
+/* Sits in the footer next to the refresh action, separated by a rule that only
+   exists while both halves are on screen. Same weight and colour as the button
+   so the row reads as one unit. */
 .lyrics-source {
   font-size: 11px;
   color: var(--text-muted);
   text-align: center;
-  margin: 8px 0 4px;
-  opacity: 0.6;
+  margin: 0;
+  line-height: 1.2;
+  padding-left: 12px;
+  border-left: 1px solid var(--border-subtle);
 }
 
 


### PR DESCRIPTION
Closes #1506

## Summary

- Lyrics edited on the server stayed hidden behind the local cache: the persistent layer answers for 90 days and no sync path invalidates it, so only wiping all app data brought the new version in. The lyrics pane now carries a refresh action that drops both cache levels for the current track and refetches through the normal source chain.
- The action sits in a pinned footer below the scrolling text, alongside the source label, so it stays reachable on long songs.
- `deleteCachedLyrics` is a per-key sibling of the existing `clearLyricsCache`; the refetch waits for that delete so the effect cannot re-read the entry it is replacing.
- New key `player.lyricsRefresh` in all 15 locales, wording aligned with each locale's existing term for lyrics.

## Test plan

- `npx tsc --noEmit`, `npm run lint`, `npm run dep:check`, `npx vitest run` — all green (621 files, 4762 tests).
- New `useLyrics.refresh.test.ts` covers a stale cached copy replaced by fresh server lyrics, and a not-found entry that picks up lyrics added later. Both fail when either cache level is left untouched, verified by mutation.
- Checked in the dev build that the action renders and sits correctly in the pane; the refresh behaviour itself is covered by the tests above, not by a manual server-side edit.

Runtime benchmark: not applicable - the change adds a user-triggered cache drop and one piece of local state to a hook that already runs on the same render path; no browse, startup, query or event-rate surface is touched.

Note for review: the new footer wrapper reindents the pane's JSX, so roughly ninety unchanged lines show up in the diff. `-w` hides them.

