### PR TITLE
fix(album): stop the detail page from blanking on every library sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Lyrics were kept locally for 90 days once fetched, and nothing refreshed them — editing them on the server, rescanning and even a full library sync all left the old version on screen. The lyrics pane now has a "Refresh lyrics" action below the text that discards the stored copy for that track and fetches it again.
 * Useful for switching a track to word-synced lyrics, fixing a typo, or picking up lyrics added after Psysonic already looked and found none.
 
+### Album pages stop rebuilding themselves while you read them
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1520](https://github.com/Psysonic/psysonic/pull/1520)**
+
+* An album page cleared itself and loaded again at irregular intervals, as if you had just opened it. Every completed library sync did this — including syncs of a different server than the album belongs to. The page now keeps what it shows and updates it quietly in the background.
+
 ## [1.52.0]
 
 ## Added

--- a/src/features/album/hooks/useAlbumDetailData.syncRefresh.test.ts
+++ b/src/features/album/hooks/useAlbumDetailData.syncRefresh.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SubsonicAlbum } from '@/lib/api/subsonicTypes';
+
+const mocks = vi.hoisted(() => ({
+  resolveAlbum: vi.fn(),
+  resolveArtist: vi.fn(),
+  libraryIsReady: vi.fn(),
+}));
+
+vi.mock('@/features/offline', () => ({
+  resolveAlbum: mocks.resolveAlbum,
+  resolveArtist: mocks.resolveArtist,
+  loadAlbumFromLibraryIndex: vi.fn(async () => null),
+  loadArtistFromLibraryIndex: vi.fn(async () => null),
+  loadArtistFromLocalPlayback: vi.fn(async () => null),
+  offlineLocalBrowseEnabled: () => false,
+  useOfflineBrowseContext: () => ({ active: false }),
+}));
+vi.mock('@/lib/library/libraryReady', () => ({ libraryIsReady: mocks.libraryIsReady }));
+vi.mock('@/lib/library/libraryBrowseScope', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/library/libraryBrowseScope')>()),
+  getLibraryBrowseScope: () => ({ serverIds: ['srv-1'], pairs: [] }),
+  hasConfiguredLibraryBrowseScope: () => false,
+}));
+vi.mock('@/lib/navigation/detailServerScope', () => ({ readDetailServerId: () => 'srv-1' }));
+vi.mock('@/lib/network/subsonicNetworkGuard', () => ({
+  shouldAttemptSubsonicForServer: () => true,
+  shouldAttemptSubsonicForActiveServer: () => true,
+}));
+vi.mock('react-router', () => ({ useSearchParams: () => [new URLSearchParams(), vi.fn()] }));
+
+import { useAlbumDetailData } from '@/features/album/hooks/useAlbumDetailData';
+import {
+  bumpOfflineLocalLibrarySyncRevisionForTests,
+  resetOfflineLocalLibrarySyncRevisionForTests,
+} from '@/store/offlineLocalLibrarySyncRevision';
+
+function album(name: string): { album: SubsonicAlbum; songs: [] } {
+  return {
+    album: { id: 'alb-1', name, artist: 'Artist', artistId: 'art-1', serverId: 'srv-1' } as SubsonicAlbum,
+    songs: [],
+  };
+}
+
+beforeEach(() => {
+  resetOfflineLocalLibrarySyncRevisionForTests();
+  mocks.resolveAlbum.mockReset().mockResolvedValue(album('First load'));
+  mocks.resolveArtist.mockReset().mockResolvedValue(null);
+  mocks.libraryIsReady.mockReset().mockResolvedValue(true);
+});
+
+describe('useAlbumDetailData on a library sync tick', () => {
+  it('keeps the album on screen instead of blanking the page', async () => {
+    const { result } = renderHook(() => useAlbumDetailData('alb-1'));
+    await waitFor(() => expect(result.current.album?.album.name).toBe('First load'));
+    expect(result.current.loading).toBe(false);
+
+    // A background sync completing is not a navigation: the page must not fall
+    // back to its empty loading state (the visible "reload" in issue terms).
+    mocks.resolveAlbum.mockResolvedValue(album('Refreshed'));
+    act(() => bumpOfflineLocalLibrarySyncRevisionForTests('srv-1'));
+
+    expect(result.current.album).not.toBeNull();
+    expect(result.current.loading).toBe(false);
+
+    // …and the refreshed payload still lands once it resolves.
+    await waitFor(() => expect(result.current.album?.album.name).toBe('Refreshed'));
+  });
+
+  it('still clears the view when the album actually changes', async () => {
+    const { result, rerender } = renderHook(({ id }) => useAlbumDetailData(id), {
+      initialProps: { id: 'alb-1' },
+    });
+    await waitFor(() => expect(result.current.album?.album.name).toBe('First load'));
+
+    let resolveSecond!: (value: unknown) => void;
+    mocks.resolveAlbum.mockReturnValue(new Promise(resolve => { resolveSecond = resolve; }));
+    rerender({ id: 'alb-2' });
+
+    // Navigating away must not leave the previous album's tracks on screen.
+    expect(result.current.album).toBeNull();
+    expect(result.current.loading).toBe(true);
+
+    resolveSecond(album('Second album'));
+    await waitFor(() => expect(result.current.album?.album.name).toBe('Second album'));
+  });
+});

--- a/src/features/album/hooks/useAlbumDetailData.ts
+++ b/src/features/album/hooks/useAlbumDetailData.ts
@@ -54,6 +54,10 @@ export function useAlbumDetailData(id: string | undefined): UseAlbumDetailDataRe
   const [loading, setLoading] = useState(true);
   const [starredSongs, setStarredSongs] = useState<Set<string>>(new Set());
   const loadGenerationRef = useRef(0);
+  // Identity of what is on screen. The effect also re-runs on every successful
+  // library sync, and those runs must refresh in place instead of blanking the
+  // page — a background sync tick is not a navigation.
+  const viewIdentityRef = useRef<string | null>(null);
   const favoritesOfflineEnabled = useAuthStore(s => s.favoritesOfflineEnabled);
   const activeServerId = useAuthStore(s => s.activeServerId);
   const libraryBrowseScopeVersion = useAuthStore(s => s.libraryBrowseScopeVersion);
@@ -67,14 +71,30 @@ export function useAlbumDetailData(id: string | undefined): UseAlbumDetailDataRe
     if (!id) return;
     const generation = ++loadGenerationRef.current;
     const isCurrent = () => loadGenerationRef.current === generation;
-    // React Compiler set-state-in-effect rule: state set from an async result resolved in this effect.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setLoading(true);
-    setAlbum(null);
-    setRelatedAlbums([]);
-    setStarredSongs(new Set());
+
+    const viewIdentity = [
+      id,
+      detailServerId ?? '',
+      String(libraryBrowseScopeVersion),
+      String(offlineBrowseActive),
+      String(favoritesOfflineEnabled),
+      String(invalidExplicitServer),
+    ].join('|');
+    // Same album, same server, same scope: the re-run came from a sync tick, so
+    // keep showing what is there and swap it once the reload resolves.
+    const isBackgroundRefresh = viewIdentityRef.current === viewIdentity;
+    viewIdentityRef.current = viewIdentity;
+
+    if (!isBackgroundRefresh) {
+      setLoading(true);
+      setAlbum(null);
+      setRelatedAlbums([]);
+      setStarredSongs(new Set());
+    }
 
     if (invalidExplicitServer) {
+      // React Compiler set-state-in-effect rule: state set from an async result resolved in this effect.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setLoading(false);
       return () => {
         if (loadGenerationRef.current === generation) loadGenerationRef.current += 1;


### PR DESCRIPTION
## Summary

- The album detail page rebuilt itself at irregular intervals while sitting still. Its load effect re-runs on every successful library sync — that part is intended, the index may have changed — but its first step cleared album, tracks and starred state, so a background tick looked like a full page reload.
- The effect now records the identity of what is on screen (album id, detail server, browse scope version, offline and favourites flags). It only clears when that identity changes, which is navigation. A sync-driven re-run refreshes in place and swaps the payload once it resolves.
- The revision it reacts to aggregates every server in the browse scope, so a sync on one server blanked detail pages of another. Confirmed on a library where a second server ticked roughly once a minute.
- Failed syncs were never the trigger: they report as failures and bump nothing.

## Test plan

- `npx tsc --noEmit`, `npm run lint`, `npm run dep:check`, `npx vitest run` — all green (622 files, 4764 tests).
- New `useAlbumDetailData.syncRefresh.test.ts` covers both directions: a sync tick leaves the album on screen and still applies the refreshed payload, while switching to another album clears the view as before. Making the clear unconditional fails the first with `expected null not to be null`, verified by mutation.
- Verified in the dev build against a live library: the page had been rebuilding roughly once a minute and stopped doing so with this change.

Runtime benchmark: not applicable - the route's first load is unchanged (the identity never matches on a fresh mount, so the clearing path runs exactly as before); the change only removes work from background re-runs, which the route harness does not sample.

Known gap: the sync that made this visible here runs far more often than the normal cadence because a post-sync tagging pass never completes. That is in the library engine and is not touched by this PR.
