### PR TITLE
fix(playlists): move the ownership filter into the header as a dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * An album page cleared itself and loaded again at irregular intervals, as if you had just opened it. Every completed library sync did this — including syncs of a different server than the album belongs to. The page now keeps what it shows and updates it quietly in the background.
 
+### The playlists header fits on one row again
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1521](https://github.com/Psysonic/psysonic/pull/1521)**
+
+* Filtering playlists by owner took four buttons on a row of their own, and they looked exactly like the actions above them even though only one can be active. It is now a single dropdown next to the sort control, showing the bucket you are in.
+
 ## [1.52.0]
 
 ## Added

--- a/src/features/playlist/components/PlaylistsHeader.test.tsx
+++ b/src/features/playlist/components/PlaylistsHeader.test.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PlaylistsHeader from '@/features/playlist/components/PlaylistsHeader';
@@ -112,7 +113,7 @@ describe('PlaylistsHeader', () => {
       <HeaderHarness ownershipCounts={{ personal: 4, sharedByMe: 0, sharedWithMe: 0 }} />,
     );
 
-    expect(view.queryByRole('group', { name: 'Playlists by owner' })).not.toBeInTheDocument();
+    expect(view.queryByRole('button', { name: 'Playlists by owner' })).not.toBeInTheDocument();
   });
 
   it('keeps the filter reachable when the last shared playlist disappears', () => {
@@ -124,34 +125,39 @@ describe('PlaylistsHeader', () => {
       <HeaderHarness ownershipCounts={{ personal: 4, sharedByMe: 0, sharedWithMe: 0 }} />,
     );
 
-    expect(view.getByRole('group', { name: 'Playlists by owner' })).toBeInTheDocument();
-    expect(view.getByRole('button', { name: 'All' })).toBeInTheDocument();
+    expect(view.getByRole('button', { name: 'Playlists by owner' })).toBeInTheDocument();
   });
 
-  it('shows the ownership filter once something is shared', () => {
+  it('shows the ownership filter once something is shared', async () => {
+    const user = userEvent.setup();
     const view = renderWithProviders(
       <HeaderHarness ownershipCounts={{ personal: 4, sharedByMe: 0, sharedWithMe: 1 }} />,
     );
 
-    const group = view.getByRole('group', { name: 'Playlists by owner' });
-    expect(group).toBeInTheDocument();
+    // One trigger in the toolbar, labelled with the active bucket; the buckets
+    // themselves only appear once it is opened.
+    const trigger = view.getByRole('button', { name: 'Playlists by owner' });
+    expect(trigger).toHaveTextContent('All');
+    await user.click(trigger);
+
     for (const name of ['All', 'Personal', 'Shared by me', 'Shared with me']) {
-      expect(view.getByRole('button', { name })).toBeInTheDocument();
+      expect(await screen.findByRole('option', { name })).toBeInTheDocument();
     }
-    // `all` is the default, and the pressed state is what a screen reader reads out.
-    expect(view.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'true');
-    expect(view.getByRole('button', { name: 'Personal' })).toHaveAttribute('aria-pressed', 'false');
+    // `all` is the default, and the selected state is what a screen reader reads out.
+    expect(screen.getByRole('option', { name: 'All' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('option', { name: 'Personal' })).toHaveAttribute('aria-selected', 'false');
   });
 
-  it('moves the pressed state to the bucket the user picks', async () => {
+  it('moves the selection to the bucket the user picks', async () => {
     const user = userEvent.setup();
     const view = renderWithProviders(
       <HeaderHarness ownershipCounts={{ personal: 2, sharedByMe: 1, sharedWithMe: 3 }} />,
     );
 
-    await user.click(view.getByRole('button', { name: 'Shared with me' }));
+    await user.click(view.getByRole('button', { name: 'Playlists by owner' }));
+    await user.click(await screen.findByRole('option', { name: 'Shared with me' }));
 
-    expect(view.getByRole('button', { name: 'Shared with me' })).toHaveAttribute('aria-pressed', 'true');
-    expect(view.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'false');
+    expect(usePlaylistLayoutStore.getState().ownershipFilter).toBe('sharedWithMe');
+    expect(view.getByRole('button', { name: 'Playlists by owner' })).toHaveTextContent('Shared with me');
   });
 });

--- a/src/features/playlist/components/PlaylistsHeader.tsx
+++ b/src/features/playlist/components/PlaylistsHeader.tsx
@@ -105,6 +105,9 @@ export default function PlaylistsHeader({
               tooltip={t('playlists.listSort.label')}
             />
           )}
+          {!(selectionMode && selectedIds.size > 0) && (
+            <PlaylistsOwnershipFilter counts={ownershipCounts} />
+          )}
           {foldersEnabled && !(selectionMode && selectedIds.size > 0) && <PlaylistsFolderViewToggle />}
           {foldersEnabled && !(selectionMode && selectedIds.size > 0) && <PlaylistsNewFolderButton />}
           {selectionMode && selectedIds.size > 0 && (() => {
@@ -138,9 +141,6 @@ export default function PlaylistsHeader({
           </button>
         </div>
       </div>
-      {!(selectionMode && selectedIds.size > 0) && (
-        <PlaylistsOwnershipFilter counts={ownershipCounts} />
-      )}
       {creating && (
         <form
           className="playlist-create-panel"

--- a/src/features/playlist/components/PlaylistsOwnershipFilter.tsx
+++ b/src/features/playlist/components/PlaylistsOwnershipFilter.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { LibraryBig, Share2, User, Users } from 'lucide-react';
+import SortDropdown from '@/ui/SortDropdown';
 import { usePlaylistLayoutStore } from '@/features/playlist/store/playlistLayoutStore';
 import {
   hasSharedPlaylists,
@@ -45,27 +46,19 @@ export default function PlaylistsOwnershipFilter({ counts }: Props) {
 
   if (!hasSharedPlaylists(counts) && ownershipFilter === 'all') return null;
 
+  // One dropdown rather than four buttons: the header row already carries real
+  // actions, and four more of them read as actions too while being a single
+  // choice. Same control the list sort uses, so the toolbar stays one row.
+  const ActiveIcon = (OPTIONS.find(o => o.value === ownershipFilter) ?? OPTIONS[0]).Icon;
+
   return (
-    <div
-      className="playlists-ownership-filter"
-      role="group"
-      aria-label={t('playlists.ownership.groupLabel')}
-    >
-      {OPTIONS.map(({ value, labelKey, Icon }) => {
-        const active = ownershipFilter === value;
-        return (
-          <button
-            key={value}
-            type="button"
-            className={`btn btn-surface${active ? ' btn-sort-active' : ''}`}
-            onClick={() => setOwnershipFilter(value)}
-            aria-pressed={active}
-            style={active ? { background: 'var(--accent)', color: 'var(--text-on-accent)' } : {}}
-          >
-            <Icon size={15} /> {t(labelKey)}
-          </button>
-        );
-      })}
-    </div>
+    <SortDropdown
+      value={ownershipFilter}
+      options={OPTIONS.map(({ value, labelKey }) => ({ value, label: t(labelKey) }))}
+      onChange={setOwnershipFilter}
+      ariaLabel={t('playlists.ownership.groupLabel')}
+      tooltip={t('playlists.ownership.groupLabel')}
+      icon={<ActiveIcon size={14} />}
+    />
   );
 }

--- a/src/styles/components/playlists-overview-header.css
+++ b/src/styles/components/playlists-overview-header.css
@@ -79,20 +79,5 @@
   }
 }
 
-/* ─ Ownership filter (personal / shared by me / shared with me) ─ */
-.playlists-ownership-filter {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  margin-top: var(--space-3);
-}
-
-/*
- * Content width, never an equal share. These labels differ a lot in length once
- * translated ("All" against "Shared with me"), and an equal-share flex basis
- * combined with the button's own nowrap clips the longer ones at both ends —
- * a failure that only shows up in some locales.
- */
-.playlists-ownership-filter > .btn {
-  flex: 0 0 auto;
-}
+/* The ownership filter is a dropdown in the header's action bar now, styled by
+   the shared sort control — it needs no rules of its own. */

--- a/src/ui/SortDropdown.tsx
+++ b/src/ui/SortDropdown.tsx
@@ -27,9 +27,15 @@ interface Props<V extends string> {
    * it sorts. The popover itself is unchanged, so the selection stays readable.
    */
   iconOnly?: boolean;
+  /**
+   * Trigger glyph, defaulting to the sort arrows. Other single-choice pickers
+   * in the same toolbar reuse this control so they read as one kind of thing;
+   * they pass their own icon rather than pretending to be a sort.
+   */
+  icon?: React.ReactNode;
 }
 
-export default function SortDropdown<V extends string>({ value, options, onChange, ariaLabel, tooltip, align = 'left', iconOnly = false }: Props<V>) {
+export default function SortDropdown<V extends string>({ value, options, onChange, ariaLabel, tooltip, align = 'left', iconOnly = false, icon }: Props<V>) {
   const [open, setOpen] = useState(false);
   const [popStyle, setPopStyle] = useState<React.CSSProperties>({});
 
@@ -110,7 +116,7 @@ export default function SortDropdown<V extends string>({ value, options, onChang
         {...(tooltip ? tooltipAttrs(tooltip, { pos: 'bottom' }) : {})}
         style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}
       >
-        <ArrowDownUp size={14} />
+        {icon ?? <ArrowDownUp size={14} />}
         {!iconOnly && <span className="toolbar-btn-label">{current?.label ?? value}</span>}
       </button>
 


### PR DESCRIPTION
## Summary

- The playlists header carried the ownership filter as four buttons on a row of their own, styled exactly like the real actions above them — same button class, same accent fill for the active one as the Select toggle. Four more buttons that look like actions but are a single choice.
- It is now one dropdown in the header's action bar, next to the list sort. Trigger shows the active bucket and its icon, the buckets live in the menu. The header goes from seven controls to four, and the second row disappears.
- Reuses `SortDropdown` rather than adding a second popover: it was already generic apart from a hardcoded trigger glyph, which is now an optional prop. Default is unchanged for the existing call sites.
- Behaviour is unchanged: the control still hides while every playlist is personal, and still stays reachable when a bucket is selected but the shared playlists are gone.

## Test plan

- `npx tsc --noEmit`, `npm run lint`, `npm run dep:check`, `npx vitest run` — all green (641 files, 4971 tests).
- The four header tests that asserted pressed state now drive the menu: trigger present and labelled with the active bucket, options only after opening, selection lands in the store and in the trigger label. The hide/reachable pair is unchanged in intent.
- Removing the hide condition fails `hides the ownership filter while every playlist is personal`, verified by mutation — that test asserts absence and would otherwise pass silently.

Runtime benchmark: not applicable - the change removes DOM from the playlists header and adds no query, request or subscription; the menu mounts only while open.
