### PR TITLE
Remember the Artists page view mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The info tab in the right sidebar offers tour dates as an optional feature, but the prompt could not be turned down. It now has a close button that hides it for good, and a short message points to **Settings → Integrations** in case you want the feature later.
 
+### Artists remember the selected view
+
+**By [@cucadmuh](https://github.com/cucadmuh), reported by [@MrSunshine1988](https://github.com/MrSunshine1988), PR [#1523](https://github.com/Psysonic/psysonic/pull/1523)**
+
+* Switching Artists between the grid and list now keeps that choice when you leave the page or restart Psysonic, instead of returning to the grid every time.
+
 ## Fixed
 
 ### Shared Top Albums pictures show their covers again

--- a/src/features/artist/hooks/useArtistsBrowseFilters.ts
+++ b/src/features/artist/hooks/useArtistsBrowseFilters.ts
@@ -4,10 +4,10 @@ import { useAuthStore } from '@/store/authStore';
 import {
   DEFAULT_ARTIST_BROWSE_RETURN_STATE,
   type ArtistBrowseReturnState,
-  type ArtistBrowseViewMode,
   isArtistsBrowsePath,
   useArtistBrowseSessionStore,
 } from '@/features/artist/store/artistBrowseSessionStore';
+import { useArtistViewModeStore } from '@/features/artist/store/artistViewModeStore';
 import type { ArtistCreditMode } from '@/lib/api/library';
 import { isArtistDetailPath } from '@/features/album';
 import { ALL_SENTINEL } from '@/features/artist/utils/artistsHelpers';
@@ -42,6 +42,8 @@ export function useArtistsBrowseFilters(
   const setShowArtistImages = useAuthStore(s => s.setShowArtistImages);
   const creditMode = useAuthStore(s => s.artistBrowseCreditMode);
   const setArtistBrowseCreditMode = useAuthStore(s => s.setArtistBrowseCreditMode);
+  const viewMode = useArtistViewModeStore(s => s.viewMode);
+  const setViewMode = useArtistViewModeStore(s => s.setViewMode);
 
   const [letterFilter, setLetterFilter] = useState(
     () => returnStateForNavigation(serverId, navigationType, location.state).letterFilter,
@@ -49,10 +51,6 @@ export function useArtistsBrowseFilters(
   const [starredOnly, setStarredOnlyRaw] = useState(
     () => returnStateForNavigation(serverId, navigationType, location.state).starredOnly,
   );
-  const [viewMode, setViewMode] = useState<ArtistBrowseViewMode>(
-    () => returnStateForNavigation(serverId, navigationType, location.state).viewMode,
-  );
-
   const browseStateRef = useRef<ArtistBrowseReturnState>(DEFAULT_ARTIST_BROWSE_RETURN_STATE);
   const restoredFromStashRef = useRef(false);
   const showArtistImages = useAuthStore(s => s.showArtistImages);
@@ -108,8 +106,14 @@ export function useArtistsBrowseFilters(
     useLiveSearchScopeStore.getState().setQuery('');
     setLetterFilter(DEFAULT_ARTIST_BROWSE_RETURN_STATE.letterFilter);
     setStarredOnlyRaw(false);
-    setViewMode('grid');
-  }, [serverId, navigationType, location.state, setShowArtistImages, setArtistBrowseCreditMode]);
+  }, [
+    serverId,
+    navigationType,
+    location.state,
+    setShowArtistImages,
+    setArtistBrowseCreditMode,
+    setViewMode,
+  ]);
 
   useEffect(() => {
     return () => {

--- a/src/features/artist/store/artistBrowseSessionStore.ts
+++ b/src/features/artist/store/artistBrowseSessionStore.ts
@@ -1,8 +1,7 @@
 import { create } from 'zustand';
 import { ALL_SENTINEL } from '@/features/artist/utils/artistsHelpers';
+import type { ArtistBrowseViewMode } from '@/features/artist/store/artistViewModeStore';
 import type { ArtistCreditMode } from '@/lib/api/library';
-
-export type ArtistBrowseViewMode = 'grid' | 'list';
 
 /** Browse state restored when returning to Artists via back from artist detail. */
 export interface ArtistBrowseReturnState {

--- a/src/features/artist/store/artistViewModeStore.test.ts
+++ b/src/features/artist/store/artistViewModeStore.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_ARTIST_VIEW_MODE,
+  useArtistViewModeStore,
+} from './artistViewModeStore';
+
+const STORAGE_KEY = 'psysonic_artist_view_mode';
+
+function seedPersisted(viewMode: unknown): void {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ state: { viewMode }, version: 1 }),
+  );
+}
+
+describe('useArtistViewModeStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useArtistViewModeStore.setState({ viewMode: DEFAULT_ARTIST_VIEW_MODE });
+  });
+
+  it('persists the selected view mode', () => {
+    useArtistViewModeStore.getState().setViewMode('list');
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as {
+      state?: { viewMode?: unknown };
+    };
+    expect(persisted.state?.viewMode).toBe('list');
+  });
+
+  it('rehydrates the stored view mode', async () => {
+    seedPersisted('list');
+    await useArtistViewModeStore.persist.rehydrate();
+
+    expect(useArtistViewModeStore.getState().viewMode).toBe('list');
+  });
+
+  it('falls back to grid for a damaged persisted mode', async () => {
+    seedPersisted('table');
+
+    await useArtistViewModeStore.persist.rehydrate();
+
+    expect(useArtistViewModeStore.getState().viewMode).toBe('grid');
+    expect(typeof useArtistViewModeStore.getState().setViewMode).toBe('function');
+  });
+});

--- a/src/features/artist/store/artistViewModeStore.ts
+++ b/src/features/artist/store/artistViewModeStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type ArtistBrowseViewMode = 'grid' | 'list';
+
+export const DEFAULT_ARTIST_VIEW_MODE: ArtistBrowseViewMode = 'grid';
+
+function isArtistViewMode(value: unknown): value is ArtistBrowseViewMode {
+  return value === 'grid' || value === 'list';
+}
+
+interface ArtistViewModeStore {
+  viewMode: ArtistBrowseViewMode;
+  setViewMode: (viewMode: ArtistBrowseViewMode) => void;
+}
+
+export const useArtistViewModeStore = create<ArtistViewModeStore>()(
+  persist(
+    (set) => ({
+      viewMode: DEFAULT_ARTIST_VIEW_MODE,
+      setViewMode: (viewMode) => set({ viewMode }),
+    }),
+    {
+      name: 'psysonic_artist_view_mode',
+      version: 1,
+      merge: (persistedState, currentState) => {
+        const viewMode = (persistedState as { viewMode?: unknown } | undefined)?.viewMode;
+        return {
+          ...currentState,
+          viewMode: isArtistViewMode(viewMode) ? viewMode : DEFAULT_ARTIST_VIEW_MODE,
+        };
+      },
+    },
+  ),
+);


### PR DESCRIPTION
Closes #1518

## Summary
- persist the last selected Artists grid/list view mode across navigation and app restarts
- follow the existing persisted Zustand pattern used by album view modes
- keep the existing artist-detail return state and all other browse filters unchanged
- fall back safely to grid if persisted state is invalid

## Verification
- `npm run lint`
- `npm run dep:check`
- `npm test` (642 files, 4974 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`

## Runtime benchmark
- Applicability: final smoke required because Artists route behaviour changed
- Final: `055a9449` / report `2026-09-09T18-47-29-433Z`
- Command: `psysonic benchmark run --scenario all-pages --runs 2 --profile realistic --json`
- Environment: 1271x694 at 2x DPR, 3 selected servers, stable scope fingerprint
- Artists: actual route reached in both runs; persisted `list` mode restored; cold 4191 ms, warm 980 ms; 0 route/readiness/stability timeouts; 0 long tasks; all filter and pagination interactions completed
- Skips: unrelated label route skipped because no reachable owned album had label data
- Automatic comparison ignored: the previous matching report used Artists `grid`, while this smoke restored `list`, so the route samples are not like-for-like

## Tauri boundary
- Not touched.