### PR TITLE
fix(home): stop the recommendation cards collapsing in a narrow band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Rating a track through its context menu showed the stars for a moment and then dropped them again, and only re-entering the page brought the rating back. The rating now stays where you set it, the same way a favourite already did.
 
+### Recommendation cards no longer collapse at certain window widths
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1524](https://github.com/Psysonic/psysonic/pull/1524)**
+
+* In a narrow range of window widths — one a default-sized window happened to land in — the "Because you listened to …" cards squeezed three across instead of two. The cover took almost the whole card, and title, artist and details ran over the artwork.
+* The cards now step down to two in good time, so there is no width left where they overlap, and the placeholders shown while the row loads follow the same rule.
+
 ## [1.52.0]
 
 ## Added

--- a/src/features/home/components/BecauseYouLikeRail.test.tsx
+++ b/src/features/home/components/BecauseYouLikeRail.test.tsx
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import type { SubsonicAlbum } from '@/lib/api/subsonicTypes';
 import { renderWithProviders } from '@/test/helpers/renderWithProviders';
+import { latestResizeObserver } from '@/test/mocks/browser';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 const { artistInfoMock, artistMock, readCacheMock, writeCacheMock, primeMock } = vi.hoisted(() => ({
   artistInfoMock: vi.fn(),
@@ -156,5 +159,71 @@ describe('BecauseYouLikeRail diagnostics', () => {
       'similar',
       { libraryIds: ['lib-a'] },
     ));
+  });
+});
+
+describe('BecauseYouLikeRail narrow swap', () => {
+  beforeEach(() => {
+    artistInfoMock.mockReset();
+    artistMock.mockReset();
+    readCacheMock.mockReset();
+    writeCacheMock.mockReset();
+    primeMock.mockReset();
+    readCacheMock.mockReturnValue(null);
+    primeMock.mockResolvedValue(undefined);
+    // Keep the rail in its loading state for the whole test.
+    artistInfoMock.mockReturnValue(new Promise(() => {}));
+  });
+
+  function renderRail() {
+    return renderWithProviders(
+      <BecauseYouLikeRail
+        mostPlayed={[album('srv-a', 'seed', 'Seed')]}
+        scopeKey="scope-narrow"
+        scopeVersion={9}
+        scopes={[{ serverId: 'srv-a', libraryId: 'lib-a' }]}
+      />,
+    );
+  }
+
+  /** Drive the observer the rail installs on its own wrapper. */
+  function reportWidth(width: number) {
+    const observer = latestResizeObserver();
+    if (!observer) throw new Error('rail did not observe its container');
+    act(() => {
+      observer.callback(
+        [{ contentRect: { width } } as unknown as ResizeObserverEntry],
+        observer as unknown as ResizeObserver,
+      );
+    });
+  }
+
+  it('keeps the wide-card skeleton out of a narrow container', () => {
+    // jsdom reports a zero-width box, which is below the swap width.
+    const { container } = renderRail();
+    expect(container.querySelectorAll('.because-card').length).toBe(0);
+  });
+
+  it('shows the skeleton again once the container is wide enough', () => {
+    const { container } = renderRail();
+    reportWidth(900);
+    expect(container.querySelectorAll('.because-card').length).toBeGreaterThan(0);
+  });
+});
+
+describe('because-card container queries', () => {
+  const css = readFileSync(
+    join(process.cwd(), 'src/styles/components/orbit-session-top-strip.css'),
+    'utf8',
+  );
+
+  it('drops the third card with no lower container bound', () => {
+    // A lower bound leaves a band where the container is already too narrow for
+    // two cards while the JS swap to the compact row has not kicked in yet, and
+    // three cards then squeeze around their fixed-width cover.
+    const rules = [...css.matchAll(/@container \(([^)]*)\)([^{]*)\{/g)].map(m => m[0]);
+    const cardRules = rules.filter(rule => rule.includes('1051'));
+    expect(cardRules.length).toBeGreaterThan(0);
+    for (const rule of cardRules) expect(rule).not.toContain('min-width');
   });
 });

--- a/src/features/home/components/BecauseYouLikeRail.tsx
+++ b/src/features/home/components/BecauseYouLikeRail.tsx
@@ -640,9 +640,14 @@ export default function BecauseYouLikeRail({
     if (!refreshing && (!anchor || recs.length === 0)) {
       return <div ref={containerRef} />;
     }
+    // The skeleton is the same wide-card row as the loaded state, so it has to
+    // follow the same narrow swap. Rendering it below the swap width squeezed
+    // the cards around their fixed 160px cover with no room left for text.
     return (
       <div ref={containerRef}>
-        <BecauseYouLikeSkeleton title={t('home.becauseYouLike')} slotCount={skeletonSlots} />
+        {narrow ? null : (
+          <BecauseYouLikeSkeleton title={t('home.becauseYouLike')} slotCount={skeletonSlots} />
+        )}
       </div>
     );
   }

--- a/src/styles/components/orbit-session-top-strip.css
+++ b/src/styles/components/orbit-session-top-strip.css
@@ -1677,17 +1677,21 @@
 .because-card-grid--stagger > .because-card--skeleton-lead {
   flex: 1.35 1 0;
 }
-@container (min-width: 696px) and (max-width: 1051px) {
+@container (max-width: 1051px) {
   .because-card-grid--stagger > .because-card:nth-child(n + 3) {
     display: none;
   }
 }
-/* Hide the 3rd card only inside the 2-column range, so:
-     >= 1052px (3 cols)  -> 3 cards in one row
-     696-1051px (2 cols) -> 2 cards in one row, orphan dropped
-   Below 696px the rail switches to a standard AlbumRow in JS — no layout here.
-   Math: 3*340 + 2*16 = 1052 (3-col cutoff), 2*340 + 1*16 = 696 (2-col cutoff). */
-@container (min-width: 696px) and (max-width: 1051px) {
+/* Drop the 3rd card below the 3-column cutoff, so:
+     >= 1052px -> 3 cards in one row
+     <  1052px -> 2 cards in one row, orphan dropped
+   Math: 3*340 + 2*16 = 1052 (3-col cutoff), 2*340 + 1*16 = 696 (2-col cutoff).
+   The rule deliberately has NO lower bound. The rail swaps itself for a
+   standard AlbumRow in JS below 680px, and a lower bound of 696px left a
+   16px-wide band where the container was already too narrow for two cards but
+   the JS swap had not kicked in yet — three cards squeezed to ~210px each,
+   which leaves ~70px for the text column beside a fixed 160px cover. */
+@container (max-width: 1051px) {
   .because-card-grid > :nth-child(n+3) {
     display: none;
   }


### PR DESCRIPTION
The recommendation cards on the mainstage collapsed inside a narrow band of widths: three cards squeezed side by side, the text column crushed beside the fixed-width cover, title and artist running over the artwork. The band sits right above the switch to the compact layout, and a default-sized window lands in it.

- Two thresholds had drifted apart: the container query that drops the third card was bounded on both sides (696px–1051px), while the swap to the compact album row fires in JS below 680px. In between, neither applied and the flex row shared the space three ways.
- The container query lost its lower bound, so the third card is dropped for every width below the three-column cutoff.
- The loading skeleton is the same wide-card row and ignored the swap entirely, so it was too tight below the swap width regardless of the band. It now follows the same condition as the loaded state.
- Only one component renders these cards and it has a single call site, so this covers every recommendation row that uses them. The other mainstage rows use the ordinary album row and were never affected.

Measured headless against the shipped stylesheet, container width to card geometry:

| Container | Cards | Card width | Text column |
|---|---|---|---|
| 680–695, before | 3 | 216–221 px | 70 px |
| from 696, before | 2 | from 340 px | from 126 px |
| 660–1051, after | 2 | 322–518 px | 108–192 px |

### Test plan

- `npx tsc --noEmit`, `npm run lint`, `npm run dep:check` and `npx vitest run` are green on Windows.
- Two new tests: the skeleton stays out of a container below the swap width, and the container queries carry no lower bound. Both were run against the unchanged code first and fail there.
- Geometry verified in a headless browser across the whole range, from three cards through two cards down to the compact row.

### Runtime benchmark

- Applicability: smoke
- Status: captured after the merge, `core-pages`, `realistic`, `--runs 3` per side, same box and scope. Reports `2026-09-10T15-58-59-928Z` (parent `4c1c6f0b`) and `2026-09-10T16-01-06-157Z` (this commit). No error, no timeout, no skipped route on either side.
- Result: the harness cannot exercise this change. It runs a 2560px-wide window, and the breakpoint corrected here only applies inside a narrow band well below that, so the changed branch never becomes active. The home page DOM node count is the deterministic evidence: 2031 / 2032 / 2660 before against 2031 / 2659 / 2659 after, i.e. the spread within one side exceeds the difference between them. Home readiness is likewise unchanged, and the uninvolved tracks route moved further than the involved home route.
