### PR TITLE
docs(readme): document the Homebrew cask as an install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Psysonic is built primarily for **Navidrome** and also works with **Gonic**, **A
 
 <a href="https://discord.gg/AMnDRErm4u"><img src="https://img.shields.io/badge/Discord-Community-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord Community"></a> <a href="https://t.me/+GLBx1_xeH28xYTJi"><img src="https://img.shields.io/badge/Telegram-Community-26A5E4?style=for-the-badge&logo=telegram&logoColor=white" alt="Telegram Community"></a> <a href="https://ko-fi.com/psychotoxic"><img src="https://img.shields.io/badge/Ko--fi-Support%20Psysonic-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white" alt="Support Psysonic on Ko-fi"></a>
 
-<a href="https://aur.archlinux.org/packages/psysonic"><img src="https://img.shields.io/badge/AUR-psysonic-1793d1?style=for-the-badge&logo=arch-linux&logoColor=white" alt="AUR psysonic"></a> <a href="https://aur.archlinux.org/packages/psysonic-bin"><img src="https://img.shields.io/badge/AUR-psysonic--bin-1793d1?style=for-the-badge&logo=arch-linux&logoColor=white" alt="AUR psysonic-bin"></a> <a href="https://psysonic.cachix.org"><img src="https://img.shields.io/badge/Cachix-psysonic.cachix.org-5277C3?style=for-the-badge&logo=nixos&logoColor=white" alt="Cachix"></a> <a href="https://github.com/microsoft/winget-pkgs/tree/master/manifests/p/Psychotoxical/Psysonic"><img src="https://img.shields.io/badge/WinGet-psysonic-blue?style=for-the-badge&logo=windows" alt="WinGet psysonic"></a> <a href="https://scoop.sh/#/apps?q=psysonic&p=1"><img src="https://img.shields.io/badge/Scoop-psysonic-4a9edc?style=for-the-badge&logo=windows&logoColor=white" alt="Scoop psysonic"></a>
+<a href="https://aur.archlinux.org/packages/psysonic"><img src="https://img.shields.io/badge/AUR-psysonic-1793d1?style=for-the-badge&logo=arch-linux&logoColor=white" alt="AUR psysonic"></a> <a href="https://aur.archlinux.org/packages/psysonic-bin"><img src="https://img.shields.io/badge/AUR-psysonic--bin-1793d1?style=for-the-badge&logo=arch-linux&logoColor=white" alt="AUR psysonic-bin"></a> <a href="https://psysonic.cachix.org"><img src="https://img.shields.io/badge/Cachix-psysonic.cachix.org-5277C3?style=for-the-badge&logo=nixos&logoColor=white" alt="Cachix"></a> <a href="https://github.com/microsoft/winget-pkgs/tree/master/manifests/p/Psychotoxical/Psysonic"><img src="https://img.shields.io/badge/WinGet-psysonic-blue?style=for-the-badge&logo=windows" alt="WinGet psysonic"></a> <a href="https://scoop.sh/#/apps?q=psysonic&p=1"><img src="https://img.shields.io/badge/Scoop-psysonic-4a9edc?style=for-the-badge&logo=windows&logoColor=white" alt="Scoop psysonic"></a> <a href="https://formulae.brew.sh/cask/psysonic"><img src="https://img.shields.io/badge/Homebrew-psysonic-FBB040?style=for-the-badge&logo=homebrew&logoColor=white" alt="Homebrew psysonic"></a>
 
 <br><br>
 
@@ -188,11 +188,11 @@ The things you simply expect from a serious music player — and Psysonic does t
 
 # Platforms
 
-| OS      | Support                                                         |
-| ------- | --------------------------------------------------------------- |
-| Windows | Native installer / WinGet / Scoop                               |
-| macOS   | Signed DMG                                                      |
-| Linux   | AppImage / DEB / RPM / AUR (`psysonic`, `psysonic-bin`) / NixOS |
+| OS      | Support                                                                    |
+| ------- | -------------------------------------------------------------------------- |
+| Windows | Native installer / WinGet / Scoop                                          |
+| macOS   | Signed DMG / Homebrew                                                      |
+| Linux   | AppImage / DEB / RPM / AUR (`psysonic`, `psysonic-bin`) / NixOS / Homebrew |
 
 ---
 
@@ -204,7 +204,11 @@ The things you simply expect from a serious music player — and Psysonic does t
 curl -fsSL https://raw.githubusercontent.com/Psysonic/psysonic/main/scripts/install.sh | sudo bash
 ```
 
-Linux builds are also available through GitHub Releases, AUR and Cachix/Nix.
+Linux builds are also available through GitHub Releases, AUR and Cachix/Nix, or via Homebrew on x86_64:
+
+```bash
+brew install --cask psysonic
+```
 
 > **AppImage runs under X11/XWayland** — it pins `GDK_BACKEND=x11` for a stable WebKitGTK stack. For a native-Wayland launch, use the `.deb`, `.rpm`, AUR, or Nix packages, which follow your session's display server.
 
@@ -228,6 +232,11 @@ You can also browse and install it on [winstall.app](https://winstall.app/apps/P
 ## macOS
 
 Download the signed DMG from the [GitHub Releases](https://github.com/Psysonic/psysonic/releases/latest).
+
+or, install via [Homebrew](https://formulae.brew.sh/cask/psysonic):
+```bash
+brew install --cask psysonic
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a Homebrew badge alongside the existing package-manager badges.
- Name Homebrew in the platform table for macOS and Linux.
- Add `brew install --cask psysonic` to both install sections, noting that the Linux branch is x86_64 only.

The cask was accepted into `Homebrew/homebrew-cask` and ships a macOS DMG branch alongside an x86_64 Linux AppImage branch, so it now covers two of the three platforms.

## Test plan

- Documentation only; no source paths touched, so the frontend and Rust gates do not apply.
- Badge URL and catalogue page were both resolved while writing the change.

Runtime benchmark: not applicable - documentation only
