### PR TITLE
fix(playback): show a play on lists that are already on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * In a narrow range of window widths — one a default-sized window happened to land in — the "Because you listened to …" cards squeezed three across instead of two. The cover took almost the whole card, and title, artist and details ran over the artwork.
 * The cards now step down to two in good time, so there is no width left where they overlap, and the placeholders shown while the row loads follow the same rule.
 
+### A play now shows up on the list you started it from
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1527](https://github.com/Psysonic/psysonic/pull/1527)**
+
+* Playing a track left the play count and the last-played date of its row untouched until you left the page and came back. Both now update while you are still looking at the list — the date as soon as the play is recorded, the count once your server confirms its new total.
+* Applies to album pages, favourites, an artist's full track list, playlists and playlist suggestions.
+
 ## [1.52.0]
 
 ## Added

--- a/src/features/album/components/TrackRow.tsx
+++ b/src/features/album/components/TrackRow.tsx
@@ -20,7 +20,7 @@ import { resolveTrackArtistRefs } from '@/features/playback/utils/playback/track
 import { buildArtistDetailPath } from '@/lib/navigation/detailServerScope';
 import { ResolvedArtistRefInline } from '@/ui/ResolvedArtistRefInline';
 import { ownedEntityKey } from '@/lib/util/ownedEntityKey';
-import { sameQueueTrack } from '@/features/playback';
+import { sameQueueTrack, useTrackPlayStats } from '@/features/playback';
 import { useDragPress } from '@/lib/dnd/useDragPress';
 
 type ContextMenuFn = (
@@ -116,6 +116,7 @@ export const TrackRow = React.memo(function TrackRow({
   const isActive = sameQueueTrack(currentTrack, song);
   const isPreviewing = usePreviewStore(s => sameQueueTrack(s.previewingTrack, song));
   const isPreviewAudioStarted = usePreviewStore(s => sameQueueTrack(s.previewingTrack, song) && s.audioStarted);
+  const playStats = useTrackPlayStats(song);
 
   const onRowMouseDown = useDragPress({
     onStart: (me) => onDragStart(song, me),
@@ -223,13 +224,13 @@ export const TrackRow = React.memo(function TrackRow({
       case 'playCount':
         return (
           <div key="playCount" className="track-duration">
-            {song.playCount ?? '—'}
+            {playStats.playCount ?? '—'}
           </div>
         );
       case 'lastPlayed':
         return (
           <div key="lastPlayed" className="track-genre">
-            {song.played ? formatLastSeen(song.played, i18n.language, '—') : '—'}
+            {playStats.played ? formatLastSeen(playStats.played, i18n.language, '—') : '—'}
           </div>
         );
       case 'bpm':

--- a/src/features/artist/components/ArtistAllTracksRow.tsx
+++ b/src/features/artist/components/ArtistAllTracksRow.tsx
@@ -9,7 +9,7 @@ import { formatTrackTime } from '@/lib/format/formatDuration';
 import i18n from '@/lib/i18n';
 import { ResolvedArtistRefInline } from '@/ui/ResolvedArtistRefInline';
 import { useAuthStore } from '@/store/authStore';
-import { resolveTrackArtistRefs } from '@/features/playback';
+import { resolveTrackArtistRefs, useTrackPlayStats } from '@/features/playback';
 import { OptionalBrowseTrackRowCoverThumb } from '@/cover/TrackRowCoverThumb';
 
 export interface ArtistAllTracksRowCallbacks {
@@ -49,6 +49,7 @@ function ArtistAllTracksRow({
   const { t } = useTranslation();
   // `song.serverId` is only stamped on owned/multi-server rows.
   const activeServerId = useAuthStore(s => s.activeServerId ?? '');
+  const playStats = useTrackPlayStats(song);
 
   return (
     <div
@@ -143,11 +144,11 @@ function ArtistAllTracksRow({
             <div key="year" className="track-duration">{song.year && song.year > 0 ? song.year : '—'}</div>
           );
           case 'playCount': return (
-            <div key="playCount" className="track-duration">{song.playCount ?? '—'}</div>
+            <div key="playCount" className="track-duration">{playStats.playCount ?? '—'}</div>
           );
           case 'lastPlayed': return (
             <div key="lastPlayed" className="track-genre">
-              {song.played ? formatLastSeen(song.played, i18n.language, '—') : '—'}
+              {playStats.played ? formatLastSeen(playStats.played, i18n.language, '—') : '—'}
             </div>
           );
           case 'bpm': return (

--- a/src/features/favorites/components/FavoriteSongRow.tsx
+++ b/src/features/favorites/components/FavoriteSongRow.tsx
@@ -11,6 +11,7 @@ import StarRating from '@/ui/StarRating';
 import { ResolvedArtistRefInline } from '@/ui/ResolvedArtistRefInline';
 import { useAuthStore } from '@/store/authStore';
 import { resolveTrackArtistRefs } from '@/features/playback/utils/playback/trackArtistRefs';
+import { useTrackPlayStats } from '@/features/playback';
 import { OptionalBrowseTrackRowCoverThumb } from '@/cover/TrackRowCoverThumb';
 
 export interface FavoriteSongRowCallbacks {
@@ -52,6 +53,7 @@ function FavoriteSongRow({
   const { t } = useTranslation();
   // `song.serverId` is only stamped on owned/multi-server rows.
   const activeServerId = useAuthStore(s => s.activeServerId ?? '');
+  const playStats = useTrackPlayStats(song);
 
   return (
     <div
@@ -135,10 +137,10 @@ function FavoriteSongRow({
           case 'rating': return <StarRating key="rating" value={ratingValue} onChange={r => cb.rate(song, r)} />;
           case 'duration': return <div key="duration" className="track-duration">{formatTrackTime(song.duration)}</div>;
           case 'playCount': return (
-            <div key="playCount" className="track-duration">{song.playCount ?? '—'}</div>
+            <div key="playCount" className="track-duration">{playStats.playCount ?? '—'}</div>
           );
           case 'lastPlayed': return (
-            <div key="lastPlayed" className="track-genre">{song.played ? formatLastSeen(song.played, i18n.language, '—') : '—'}</div>
+            <div key="lastPlayed" className="track-genre">{playStats.played ? formatLastSeen(playStats.played, i18n.language, '—') : '—'}</div>
           );
           case 'bpm': return (
             <div key="bpm" className="track-duration">{song.bpm && song.bpm > 0 ? song.bpm : '—'}</div>

--- a/src/features/playback/hooks/useTrackPlayStats.test.ts
+++ b/src/features/playback/hooks/useTrackPlayStats.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { usePlayerStore } from '../store/playerStore';
+import { useTrackPlayStats } from './useTrackPlayStats';
+
+const LOADED = { id: 't1', serverId: 'srv', playCount: 3, played: '2026-09-01T10:00:00.000Z' };
+
+beforeEach(() => {
+  usePlayerStore.setState({ playStatsOverrides: {} });
+});
+
+describe('useTrackPlayStats', () => {
+  it('reports what the row was loaded with until the track is played', () => {
+    const { result } = renderHook(() => useTrackPlayStats(LOADED));
+    expect(result.current).toEqual({ playCount: 3, played: '2026-09-01T10:00:00.000Z' });
+  });
+
+  it('updates a row that is already on screen when its track is played', () => {
+    const { result } = renderHook(() => useTrackPlayStats(LOADED));
+
+    act(() => {
+      usePlayerStore.getState().setPlayStatsOverride('srv:t1', {
+        played: '2026-09-10T12:00:00.000Z',
+      });
+    });
+    expect(result.current.played).toBe('2026-09-10T12:00:00.000Z');
+    // Still the loaded count: only the server can say what the new one is.
+    expect(result.current.playCount).toBe(3);
+
+    act(() => {
+      usePlayerStore.getState().setPlayStatsOverride('srv:t1', { playCount: 4 });
+    });
+    expect(result.current).toEqual({ playCount: 4, played: '2026-09-10T12:00:00.000Z' });
+  });
+
+  it('leaves other rows alone', () => {
+    const other = { id: 't2', serverId: 'srv', playCount: 9 };
+    const { result } = renderHook(() => useTrackPlayStats(other));
+
+    act(() => {
+      usePlayerStore.getState().setPlayStatsOverride('srv:t1', { playCount: 4 });
+    });
+    expect(result.current.playCount).toBe(9);
+  });
+});

--- a/src/features/playback/hooks/useTrackPlayStats.ts
+++ b/src/features/playback/hooks/useTrackPlayStats.ts
@@ -1,0 +1,21 @@
+import { usePlayerStore } from '../store/playerStore';
+import { ownedOverrideValue } from '@/lib/util/ownedEntityKey';
+import type { PlayedTrack, TrackPlayStats } from '@/lib/media/trackPlayStats';
+
+/**
+ * Play statistics for one row, with this session's plays merged over the values
+ * the list was loaded with.
+ *
+ * The two fields are selected separately on purpose: reading the override entry
+ * as an object would hand every subscribed row a fresh reference on every store
+ * write and re-render the whole list. A number and a string compare by value, so
+ * only the row whose track was played re-renders.
+ */
+export function useTrackPlayStats(track: PlayedTrack): TrackPlayStats {
+  const playCount = usePlayerStore(s => ownedOverrideValue(s.playStatsOverrides, track)?.playCount);
+  const played = usePlayerStore(s => ownedOverrideValue(s.playStatsOverrides, track)?.played);
+  return {
+    playCount: playCount ?? track.playCount,
+    played: played ?? track.played,
+  };
+}

--- a/src/features/playback/index.ts
+++ b/src/features/playback/index.ts
@@ -18,6 +18,7 @@ export {
   playbackProfileIdForTrack,
 } from './utils/playback/playbackServer';
 export { useVolumeToggle } from './hooks/useVolumeToggle';
+export { useTrackPlayStats } from './hooks/useTrackPlayStats';
 export { usePlaybackLibraryNavigate } from './hooks/usePlaybackLibraryNavigate';
 export { TrackArtistLinks } from './components/TrackArtistLinks';
 export { ScrobbleActionButton } from './components/playerBar/ScrobbleStatus';

--- a/src/features/playback/store/playerStore.ts
+++ b/src/features/playback/store/playerStore.ts
@@ -76,6 +76,7 @@ export const usePlayerStore = create<PlayerState>()(
       networkLovedCache: initialNetworkLovedCache,
       starredOverrides: {},
       userRatingOverrides: {},
+      playStatsOverrides: {},
       isQueueVisible: readInitialQueueVisibility(),
       isFullscreenOpen: false,
       scheduledPauseAtMs: null,

--- a/src/features/playback/store/playerStoreTypes.ts
+++ b/src/features/playback/store/playerStoreTypes.ts
@@ -74,6 +74,15 @@ export interface PlayerState {
   /** Optimistic track ratings (e.g. skip→1★ while UI lists still have stale `song.userRating`). */
   userRatingOverrides: Record<string, number>;
   setUserRatingOverride: (id: string, rating: number) => void;
+  /**
+   * Play statistics of tracks played this session, merged over the values a list
+   * was loaded with. Unlike a star or a rating these are not the listener's
+   * intent but the server's own tally, so they are written when a scrobble
+   * settles rather than when it is queued — the play timestamp right away, the
+   * count once the server has been asked what it now is.
+   */
+  playStatsOverrides: Record<string, { playCount?: number; played?: string }>;
+  setPlayStatsOverride: (id: string, stats: { playCount?: number; played?: string }) => void;
 
   playRadio: (station: InternetRadioStation) => void;
   /** `_orbitConfirmed` is an internal bypass flag — callers outside the

--- a/src/features/playback/store/submitTrackScrobble.test.ts
+++ b/src/features/playback/store/submitTrackScrobble.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { makeTrack } from '@/test/helpers/factories';
 
-const scrobbleSong = vi.hoisted(() => vi.fn());
+const scrobbleSong = vi.hoisted(() => vi.fn(async () => null as unknown));
 const dispatchScrobble = vi.hoisted(() => vi.fn(async () => undefined));
 
 vi.mock('@/lib/api/subsonicScrobble', () => ({
@@ -18,10 +18,13 @@ vi.mock('@/features/playback/utils/playback/playbackServer', () => ({
 }));
 
 import { submitTrackScrobble } from './submitTrackScrobble';
+import { usePlayerStore } from './playerStore';
 
 beforeEach(() => {
   scrobbleSong.mockClear();
+  scrobbleSong.mockResolvedValue(null);
   dispatchScrobble.mockClear();
+  usePlayerStore.setState({ playStatsOverrides: {} });
 });
 
 describe('submitTrackScrobble', () => {
@@ -36,6 +39,41 @@ describe('submitTrackScrobble', () => {
       album: 'B',
       duration: 200,
       timestamp: 1234,
+    });
+  });
+
+  it('shows the play on rows that are already on screen before the server answers', () => {
+    const track = makeTrack({ id: 't1', serverId: 'srv-a' });
+    submitTrackScrobble(track, 'srv-queue', 1234);
+
+    const overrides = usePlayerStore.getState().playStatsOverrides;
+    expect(overrides['srv-queue:t1']?.played).toBe(new Date(1234).toISOString());
+    // Rows without an owner stamp look the track up by its bare id.
+    expect(overrides.t1?.played).toBe(new Date(1234).toISOString());
+    // The count is the server's, so nothing is guessed for it here.
+    expect(overrides['srv-queue:t1']?.playCount).toBeUndefined();
+  });
+
+  it('takes the count the server reports without dropping the timestamp', async () => {
+    scrobbleSong.mockResolvedValue({ playCount: 7, played: '2026-09-10T12:00:00.000Z' });
+    const track = makeTrack({ id: 't1', serverId: 'srv-a' });
+
+    submitTrackScrobble(track, 'srv-queue', 1234);
+    await vi.waitFor(() => {
+      expect(usePlayerStore.getState().playStatsOverrides['srv-queue:t1']?.playCount).toBe(7);
+    });
+
+    expect(usePlayerStore.getState().playStatsOverrides['srv-queue:t1']?.played)
+      .toBe('2026-09-10T12:00:00.000Z');
+  });
+
+  it('keeps the local timestamp when the server reports no statistics', async () => {
+    const track = makeTrack({ id: 't1', serverId: 'srv-a' });
+    submitTrackScrobble(track, 'srv-queue', 1234);
+    await Promise.resolve();
+
+    expect(usePlayerStore.getState().playStatsOverrides['srv-queue:t1']).toEqual({
+      played: new Date(1234).toISOString(),
     });
   });
 });

--- a/src/features/playback/store/submitTrackScrobble.ts
+++ b/src/features/playback/store/submitTrackScrobble.ts
@@ -1,6 +1,22 @@
 import { scrobbleSong } from '@/lib/api/subsonicScrobble';
 import type { Track } from '@/lib/media/trackTypes';
+import type { TrackPlayStats } from '@/lib/media/trackPlayStats';
 import { getMusicNetworkRuntimeOrNull } from '@/music-network';
+import { usePlayerStore } from '@/features/playback/store/playerStore';
+import { ownedEntityKey } from '@/lib/util/ownedEntityKey';
+
+/**
+ * Record the play on the rows that are already on screen.
+ *
+ * Written under both the owner-scoped key and the bare track id: only owned and
+ * multi-server rows carry a `serverId`, and a list that renders neither would
+ * never find a scoped entry.
+ */
+function rememberPlayStats(trackId: string, serverId: string, stats: TrackPlayStats): void {
+  const setPlayStatsOverride = usePlayerStore.getState().setPlayStatsOverride;
+  setPlayStatsOverride(ownedEntityKey({ id: trackId, serverId }), stats);
+  setPlayStatsOverride(trackId, stats);
+}
 
 /** Submit one play to the owning media server and every enabled Music Network destination. */
 export function submitTrackScrobble(
@@ -8,7 +24,13 @@ export function submitTrackScrobble(
   serverId: string,
   startedAtMs: number,
 ): void {
-  void scrobbleSong(track.id, startedAtMs, serverId);
+  // The listener did play it, whatever the server makes of the scrobble, so the
+  // timestamp goes up immediately. The count is the server's own tally and can
+  // only follow once it has been asked what that tally now is.
+  rememberPlayStats(track.id, serverId, { played: new Date(startedAtMs).toISOString() });
+  void scrobbleSong(track.id, startedAtMs, serverId).then(stats => {
+    if (stats) rememberPlayStats(track.id, serverId, stats);
+  });
   void getMusicNetworkRuntimeOrNull()?.dispatchScrobble({
     title: track.title,
     artist: track.artist,

--- a/src/features/playback/store/uiStateActions.ts
+++ b/src/features/playback/store/uiStateActions.ts
@@ -20,6 +20,7 @@ export function createUiStateActions(set: SetState): Pick<
   PlayerState,
   | 'setStarredOverride'
   | 'setUserRatingOverride'
+  | 'setPlayStatsOverride'
   | 'openContextMenu'
   | 'closeContextMenu'
   | 'openSongInfo'
@@ -48,6 +49,17 @@ export function createUiStateActions(set: SetState): Pick<
                 : s.currentTrack,
           };
       }),
+
+    // Merged, not replaced: a scrobble writes the play timestamp when it settles
+    // and the count only once the server has been read back, so the second write
+    // must not drop the first.
+    setPlayStatsOverride: (id, stats) =>
+      set(s => ({
+        playStatsOverrides: {
+          ...s.playStatsOverrides,
+          [id]: { ...s.playStatsOverrides[id], ...stats },
+        },
+      })),
 
     openContextMenu: (x, y, item, type, queueIndex, playlistId, playlistSongIndex, shareKindOverride, pinToPlaybackServer, playlistSongRemove, timelineFromHereRefs) => {
       const pin = pinToPlaybackServer ?? type === 'queue-item';

--- a/src/features/playlist/components/PlaylistRow.tsx
+++ b/src/features/playlist/components/PlaylistRow.tsx
@@ -9,6 +9,7 @@ import i18n from '@/lib/i18n';
 import { formatTrackTime } from '@/lib/format/formatDuration';
 import StarRating from '@/ui/StarRating';
 import { PlaylistArtistCell } from '@/features/playlist/components/PlaylistArtistCell';
+import { useTrackPlayStats } from '@/features/playback';
 import { OptionalBrowseTrackRowCoverThumb } from '@/cover/TrackRowCoverThumb';
 
 export interface PlaylistRowCallbacks {
@@ -52,6 +53,7 @@ function PlaylistRow({
   isStarred, ratingValue, isPreviewing, previewStarted, orbitActive, cb,
 }: Props) {
   const { t } = useTranslation();
+  const playStats = useTrackPlayStats(song);
 
   return (
     <div
@@ -130,10 +132,10 @@ function PlaylistRow({
             <div key="genre" className="track-genre">{song.genre ?? '—'}</div>
           );
           case 'playCount': return (
-            <div key="playCount" className="track-duration">{song.playCount ?? '—'}</div>
+            <div key="playCount" className="track-duration">{playStats.playCount ?? '—'}</div>
           );
           case 'lastPlayed': return (
-            <div key="lastPlayed" className="track-genre">{song.played ? formatLastSeen(song.played, i18n.language, '—') : '—'}</div>
+            <div key="lastPlayed" className="track-genre">{playStats.played ? formatLastSeen(playStats.played, i18n.language, '—') : '—'}</div>
           );
           case 'bpm': return (
             <div key="bpm" className="track-duration">{song.bpm && song.bpm > 0 ? song.bpm : '—'}</div>

--- a/src/features/playlist/components/PlaylistSuggestions.tsx
+++ b/src/features/playlist/components/PlaylistSuggestions.tsx
@@ -21,6 +21,7 @@ import { COVER_ARTIST_TOP_TRACK_CSS_PX } from '@/cover/layoutSizes';
 import { useWarmTrackListAlbumCovers } from '@/cover/useWarmTrackListAlbumCovers';
 import { useTrackListCoverArtEnabled } from '@/cover/useTrackListCoverArtSettings';
 import { ownedOverrideValue } from '@/lib/util/ownedEntityKey';
+import { trackPlayStats } from '@/lib/media/trackPlayStats';
 import { useResolvedTracklistBpm } from '@/lib/hooks/useResolvedTracklistBpm';
 import { navigateToAlbumDetail } from '@/lib/navigation/albumDetailNavigation';
 
@@ -62,6 +63,7 @@ export default function PlaylistSuggestions({
   const openContextMenu = usePlayerStore(s => s.openContextMenu);
   const starredOverrides = usePlayerStore(s => s.starredOverrides);
   const userRatingOverrides = usePlayerStore(s => s.userRatingOverrides);
+  const playStatsOverrides = usePlayerStore(s => s.playStatsOverrides);
   const previewingId = usePreviewStore(s => s.previewingId);
   const previewAudioStarted = usePreviewStore(s => s.audioStarted);
   const showBitrate = useThemeStore(s => s.showBitrate);
@@ -129,6 +131,7 @@ export default function PlaylistSuggestions({
               ?? ownedOverrideValue(userRatingOverrides, song)
               ?? song.userRating
               ?? 0;
+            const playStats = trackPlayStats(song, playStatsOverrides);
             return (
             <div
               key={song.id}
@@ -225,10 +228,10 @@ export default function PlaylistSuggestions({
                     <div key="genre" className="track-genre">{song.genre ?? '—'}</div>
                   );
                   case 'playCount': return (
-                    <div key="playCount" className="track-duration">{song.playCount ?? '—'}</div>
+                    <div key="playCount" className="track-duration">{playStats.playCount ?? '—'}</div>
                   );
                   case 'lastPlayed': return (
-                    <div key="lastPlayed" className="track-genre">{song.played ? formatLastSeen(song.played, i18n.language, '—') : '—'}</div>
+                    <div key="lastPlayed" className="track-genre">{playStats.played ? formatLastSeen(playStats.played, i18n.language, '—') : '—'}</div>
                   );
                   case 'bpm': return (
                     <div key="bpm" className="track-duration">{song.bpm && song.bpm > 0 ? song.bpm : '—'}</div>

--- a/src/lib/api/subsonicScrobble.ts
+++ b/src/lib/api/subsonicScrobble.ts
@@ -1,6 +1,7 @@
 import { api, apiForServer } from '@/lib/api/subsonicClient';
 import type { PlaybackReportState, SubsonicNowPlaying } from '@/lib/api/subsonicTypes';
 import { libraryPatchReachesIndex, patchLibraryTrackOnUse } from '@/lib/library/patchOnUse';
+import type { TrackPlayStats } from '@/lib/media/trackPlayStats';
 import { shouldAttemptSubsonicForServer } from '@/lib/network/subsonicNetworkGuard';
 
 /**
@@ -78,8 +79,17 @@ async function readServerPlayStats(
   }
 }
 
-export async function scrobbleSong(id: string, time: number, serverId: string): Promise<void> {
-  if (!serverId) return;
+/**
+ * Submit one play. Resolves with the server's own play statistics when it was
+ * asked for them, so the caller can show the new tally on rows that are already
+ * on screen; `null` whenever nothing fresh was read.
+ */
+export async function scrobbleSong(
+  id: string,
+  time: number,
+  serverId: string,
+): Promise<TrackPlayStats | null> {
+  if (!serverId) return null;
   let reachedServer = false;
   try {
     reachedServer = await scrobbleOnServer(serverId, id, true, time);
@@ -106,17 +116,17 @@ export async function scrobbleSong(id: string, time: number, serverId: string): 
   // server tally untouched, and re-reading it would just rewrite the value the
   // row already has. And only when there is an index to write it to — otherwise
   // the request is paid for and handed to a patch that returns immediately.
-  if (!reachedServer || !libraryPatchReachesIndex(serverId)) return;
+  if (!reachedServer || !libraryPatchReachesIndex(serverId)) return null;
 
   const generation = beginStatsRefresh(serverId, id);
   const refreshed = await readServerPlayStats(serverId, id);
-  if (refreshed?.playCount == null) return;
+  if (refreshed?.playCount == null) return null;
   // Two plays of the same track in quick succession each read the count back,
   // and the responses can land out of order — the older one would then write a
   // smaller total over the newer. Nothing in the row can tell the two apart,
   // because both are legitimate server values; only the order they were asked
   // in can, and that is what this holds.
-  if (!isNewestStatsRefresh(serverId, id, generation)) return;
+  if (!isNewestStatsRefresh(serverId, id, generation)) return null;
 
   const playedAt = refreshed.played != null ? Date.parse(refreshed.played) : NaN;
   patchLibraryTrackOnUse(serverId, id, {
@@ -125,6 +135,10 @@ export async function scrobbleSong(id: string, time: number, serverId: string): 
     // to the local time written above rather than clearing it.
     ...(Number.isFinite(playedAt) ? { playedAt } : {}),
   });
+  return {
+    playCount: refreshed.playCount,
+    ...(Number.isFinite(playedAt) ? { played: refreshed.played } : {}),
+  };
 }
 
 export async function reportNowPlaying(id: string, serverId: string): Promise<void> {

--- a/src/lib/media/trackPlayStats.test.ts
+++ b/src/lib/media/trackPlayStats.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { trackPlayStats } from './trackPlayStats';
+
+describe('trackPlayStats', () => {
+  it('keeps the loaded values when nothing was played this session', () => {
+    const track = { id: 'a', serverId: 'srv', playCount: 3, played: '2026-09-01T10:00:00Z' };
+    expect(trackPlayStats(track, {})).toEqual({ playCount: 3, played: '2026-09-01T10:00:00Z' });
+  });
+
+  it('prefers what this session recorded over the loaded values', () => {
+    const track = { id: 'a', serverId: 'srv', playCount: 3, played: '2026-09-01T10:00:00Z' };
+    const overrides = { 'srv:a': { playCount: 4, played: '2026-09-10T12:00:00Z' } };
+    expect(trackPlayStats(track, overrides)).toEqual({
+      playCount: 4,
+      played: '2026-09-10T12:00:00Z',
+    });
+  });
+
+  it('takes the timestamp on its own while the count is still being read back', () => {
+    const track = { id: 'a', serverId: 'srv', playCount: 3, played: '2026-09-01T10:00:00Z' };
+    const overrides = { 'srv:a': { played: '2026-09-10T12:00:00Z' } };
+    expect(trackPlayStats(track, overrides)).toEqual({
+      playCount: 3,
+      played: '2026-09-10T12:00:00Z',
+    });
+  });
+
+  it('falls back to the unscoped key for rows that carry no server', () => {
+    const track = { id: 'a', playCount: 1 };
+    expect(trackPlayStats(track, { a: { playCount: 2 } })).toEqual({
+      playCount: 2,
+      played: undefined,
+    });
+  });
+
+  it('leaves a never-played track empty rather than reporting a zero count', () => {
+    expect(trackPlayStats({ id: 'a' }, {})).toEqual({ playCount: undefined, played: undefined });
+  });
+});

--- a/src/lib/media/trackPlayStats.ts
+++ b/src/lib/media/trackPlayStats.ts
@@ -1,0 +1,35 @@
+import { ownedOverrideValue } from '@/lib/util/ownedEntityKey';
+
+/** Minimal shape of a song/track row that can carry server-side play statistics. */
+export interface PlayedTrack {
+  id: string;
+  serverId?: string | null;
+  playCount?: number;
+  /** ISO timestamp of the last play, as the server reports it. */
+  played?: string;
+}
+
+export interface TrackPlayStats {
+  playCount?: number;
+  played?: string;
+}
+
+/**
+ * The play statistics a row should show: what this session recorded wins over
+ * the values the page was loaded with.
+ *
+ * A list fetches its rows once and keeps them, so a play that happens while it
+ * is on screen would otherwise stay invisible until the page is re-entered. The
+ * two fields are merged separately because they arrive apart — the timestamp
+ * when the scrobble settles, the count once the server has been read back.
+ */
+export function trackPlayStats(
+  track: PlayedTrack,
+  overrides: Record<string, TrackPlayStats>,
+): TrackPlayStats {
+  const override = ownedOverrideValue(overrides, track);
+  return {
+    playCount: override?.playCount ?? track.playCount,
+    played: override?.played ?? track.played,
+  };
+}


### PR DESCRIPTION
## Summary

- Record a play in a session override so lists that are already on screen show it: the timestamp when the scrobble settles, the count once the server answers the read-back.
- Read that override in the album, favourites, artist-tracks, playlist and playlist-suggestion rows, ahead of the value the page was loaded with.
- `scrobbleSong` now resolves with the statistics it read back instead of discarding them; nothing else about the write path changes.

A star or a rating has carried a session override since the pending-sync queue was introduced, and lists merge it over their loaded rows. Play statistics had no such path, so a play stayed invisible on the open page until it was left and re-entered.

Closes #1469

## Known gaps

- Sorting by play count or last played still uses the loaded values, so a list does not re-order itself while it is being read. Deliberate.
- The song info dialog is untouched: it fetches its track when it opens, so it never showed a stale count.

## Test plan

- `npx tsc --noEmit`, `npm run lint`, `npm run dep:check` (no new violation), `npx vitest run` (648 files, 5016 tests), `npx vitest run --coverage`, `bash scripts/check-frontend-hot-path-coverage.sh` (15/15 above threshold) — all green locally.
- New unit tests for the override helper and the hook; the scrobble caller's test now covers the immediate timestamp, the count arriving later, and the case where the server reports nothing.
- Three mutation probes: removing the immediate write, removing the read-back write, and ignoring the override in the hook each turned exactly the expected tests red.
- Exercised in the running dev build: with a track played from an open list, the last-played cell updates immediately and the play count follows, without navigating.

## Runtime benchmark

Runtime benchmark: required

Two runs per side, `core-pages`, `realistic`, `--runs 2`, same box, same profile and scope. The control is `main` plus a single comment line in one of the touched files, so "touched checkout" is not charged to the diff.

| Route | Readiness fix | Readiness control | React fix | React control |
|---|---|---|---|---|
| `/` | 2671 / 1925 | 1819 / 1623 | 805 / 780 | 883 / 381 |
| `/tracks` | 538 / 507 | 574 / 548 | 454 / 1051 | 533 / 506 |
| `/albums` | 320 / 208 | 184 / 186 | 169 / 112 | 123 / 101 |
| `/artists` | 756 / 651 | 613 / 665 | 66 / 67 | 57 / 81 |
| `/favorites` | 122 / 132 | 128 / 122 | 62 / 55 | 63 / 64 |

Result: **not separable**. The control varies against itself by more than a factor of three on `/` and by 60% on `/tracks`, and every difference on the remaining routes sits inside that band. React time is the metric this change would move first, since it adds one store selector per row, and it is unchanged everywhere. The one value outside the control band, `/albums` readiness in the first run, did not reproduce in the second.

Reports: fix `2026-09-10T15-10-38-576Z`, `2026-09-10T15-19-11-567Z` · control `2026-09-10T15-14-23-326Z`, `2026-09-10T15-16-08-775Z`. No errors, no timeouts, no skipped routes in any run.
