### PR TITLE
Fix Flatpak publish runtime installation

### DIFF
--- a/.github/workflows/flatpak-release.yml
+++ b/.github/workflows/flatpak-release.yml
@@ -203,6 +203,7 @@ jobs:
           sudo apt-get install -y appstream desktop-file-utils flatpak flatpak-builder gnupg jq
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
           flatpak install --user -y flathub \
+            org.gnome.Platform//50 \
             org.gnome.Sdk//50 \
             org.freedesktop.Sdk.Extension.node26//25.08 \
             org.freedesktop.Sdk.Extension.rust-stable//25.08

--- a/scripts/sync-flatpak-metainfo-release.test.mjs
+++ b/scripts/sync-flatpak-metainfo-release.test.mjs
@@ -60,6 +60,15 @@ describe('Flatpak signing continuity wiring', () => {
   });
 });
 
+describe('Flatpak build dependencies', () => {
+  it('installs both the application runtime and build SDK', () => {
+    const source = readFileSync(new URL('../.github/workflows/flatpak-release.yml', import.meta.url), 'utf8');
+
+    assert.match(source, /org\.gnome\.Platform\/\/50/);
+    assert.match(source, /org\.gnome\.Sdk\/\/50/);
+  });
+});
+
 describe('Flatpak GitHub Release publication gate', () => {
   it('rejects draft or unpublished releases before deployment planning', () => {
     const source = readFileSync(new URL('../.github/workflows/flatpak-release.yml', import.meta.url), 'utf8');


### PR DESCRIPTION
## Summary
- install `org.gnome.Platform//50` before invoking `flatpak-builder`
- add a workflow regression test requiring both the GNOME runtime and SDK

## Root cause
The first test-channel publication run installed `org.gnome.Sdk//50` and the SDK extensions, but omitted the application runtime declared by the manifest. `flatpak-builder` therefore stopped with `org.gnome.Platform/x86_64/50 not installed` before build, signing export, or deployment.

Failed run: https://github.com/Psysonic/psysonic/actions/runs/34521198805

## Verification
- `nix develop -c node --test scripts/sync-flatpak-metainfo-release.test.mjs`
- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/flatpak-release.yml`
- `npm run lint`
- `npm run dep:check`
- `npm test` (5,030 Vitest tests and 44 Node tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh` (15/15)

The first coverage invocation ran concurrently with the full test suite and hit two unrelated Login test timeouts. The isolated coverage rerun passed.

## Runtime benchmark
Not applicable: this changes only GitHub Actions dependency installation and a static workflow test.

## Tauri boundary
Not touched.

After human merge, rerun `Flatpak Publish` with `test_source_sha` set to the resulting current `main` SHA. No production channel was changed by the failed run.