### PR TITLE
Fix test Flatpak AppStream version metadata

### DIFF
--- a/.github/workflows/flatpak-release.yml
+++ b/.github/workflows/flatpak-release.yml
@@ -117,7 +117,14 @@ jobs:
           fi
           cmp io.github.psysonic.psysonic.desktop ../app/src-tauri/flatpak/io.github.psysonic.psysonic.desktop
           cmp io.github.psysonic.psysonic.metainfo.xml ../app/src-tauri/flatpak/io.github.psysonic.psysonic.metainfo.xml
-          if [ "$IS_TEST" = false ] && ! grep -Fq "<release version=\"$PACKAGE_VERSION\"" io.github.psysonic.psysonic.metainfo.xml; then
+          if [ "$IS_TEST" = true ]; then
+            PSYSONIC_FLATPAK_METAINFO_PATH="$PWD/io.github.psysonic.psysonic.metainfo.xml" \
+              PSYSONIC_FLATPAK_VERSION="$PACKAGE_VERSION" \
+              PSYSONIC_FLATPAK_ALLOW_DEVELOPMENT=true \
+              PSYSONIC_FLATPAK_DETAILS_URL="https://github.com/$GITHUB_REPOSITORY/commit/$EXPECTED_SHA" \
+              node ../app/scripts/sync-flatpak-metainfo-release.mjs
+          fi
+          if ! grep -Fq "<release version=\"$PACKAGE_VERSION\"" io.github.psysonic.psysonic.metainfo.xml; then
             echo "::error::Flatpak metainfo has no release entry for $PACKAGE_VERSION"
             exit 1
           fi

--- a/scripts/sync-flatpak-metainfo-release.mjs
+++ b/scripts/sync-flatpak-metainfo-release.mjs
@@ -5,13 +5,16 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const metainfoPath = resolve(
+const defaultMetainfoPath = resolve(
   root,
   'src-tauri/flatpak/io.github.psysonic.psysonic.metainfo.xml',
 );
 
-function assertReleaseVersion(version) {
-  if (!/^\d+\.\d+\.\d+(?:-rc\.\d+)?$/.test(version)) {
+function assertReleaseVersion(version, allowDevelopment) {
+  const pattern = allowDevelopment
+    ? /^\d+\.\d+\.\d+(?:-rc\.\d+|-dev)?$/
+    : /^\d+\.\d+\.\d+(?:-rc\.\d+)?$/;
+  if (!pattern.test(version)) {
     throw new Error(`Flatpak AppStream release requires X.Y.Z or X.Y.Z-rc.N, got ${version}`);
   }
 }
@@ -22,9 +25,14 @@ function assertReleaseDate(date) {
   }
 }
 
-export function syncFlatpakMetainfoRelease(xml, version, date) {
-  assertReleaseVersion(version);
+export function syncFlatpakMetainfoRelease(xml, version, date, options = {}) {
+  const { allowDevelopment = false, detailsUrl } = options;
+  assertReleaseVersion(version, allowDevelopment);
   assertReleaseDate(date);
+
+  if (version.endsWith('-dev') && !detailsUrl) {
+    throw new Error('Flatpak development release requires an explicit details URL');
+  }
 
   if (xml.includes(`<release version="${version}"`)) {
     return { xml, changed: false };
@@ -32,7 +40,7 @@ export function syncFlatpakMetainfoRelease(xml, version, date) {
 
   const release = [
     `    <release version="${version}" date="${date}">`,
-    `      <url type="details">https://github.com/Psysonic/psysonic/releases/tag/app-v${version}</url>`,
+    `      <url type="details">${detailsUrl ?? `https://github.com/Psysonic/psysonic/releases/tag/app-v${version}`}</url>`,
     '    </release>',
   ].join('\n');
   const marker = '  <releases>\n';
@@ -47,10 +55,18 @@ export function syncFlatpakMetainfoRelease(xml, version, date) {
 }
 
 function main() {
-  const { version } = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+  const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+  const version = process.env.PSYSONIC_FLATPAK_VERSION ?? packageJson.version;
   const date = process.env.PSYSONIC_RELEASE_DATE ?? new Date().toISOString().slice(0, 10);
+  const metainfoPath = resolve(
+    root,
+    process.env.PSYSONIC_FLATPAK_METAINFO_PATH ?? defaultMetainfoPath,
+  );
   const original = readFileSync(metainfoPath, 'utf8');
-  const result = syncFlatpakMetainfoRelease(original, version, date);
+  const result = syncFlatpakMetainfoRelease(original, version, date, {
+    allowDevelopment: process.env.PSYSONIC_FLATPAK_ALLOW_DEVELOPMENT === 'true',
+    detailsUrl: process.env.PSYSONIC_FLATPAK_DETAILS_URL,
+  });
   if (!result.changed) {
     console.log(`Flatpak metainfo already contains ${version}`);
     return;

--- a/scripts/sync-flatpak-metainfo-release.test.mjs
+++ b/scripts/sync-flatpak-metainfo-release.test.mjs
@@ -34,6 +34,28 @@ describe('syncFlatpakMetainfoRelease', () => {
       /requires X\.Y\.Z or X\.Y\.Z-rc\.N/,
     );
   });
+
+  it('generates development metadata only with an explicit commit URL', () => {
+    const detailsUrl = 'https://github.com/Psysonic/psysonic/commit/0123456789abcdef';
+    const result = syncFlatpakMetainfoRelease(base, '1.54.0-dev', '2026-09-10', {
+      allowDevelopment: true,
+      detailsUrl,
+    });
+
+    assert.equal(result.changed, true);
+    assert.match(result.xml, /<release version="1\.54\.0-dev" date="2026-09-10">/);
+    assert.ok(result.xml.includes(`<url type="details">${detailsUrl}</url>`));
+    assert.ok(result.xml.indexOf('1.54.0-dev') < result.xml.indexOf('1.52.0'));
+  });
+
+  it('rejects development metadata without a details URL', () => {
+    assert.throws(
+      () => syncFlatpakMetainfoRelease(base, '1.54.0-dev', '2026-09-10', {
+        allowDevelopment: true,
+      }),
+      /requires an explicit details URL/,
+    );
+  });
 });
 
 describe('Flatpak release promotion wiring', () => {
@@ -90,5 +112,19 @@ describe('Flatpak GitHub Release publication gate', () => {
     assert.match(source, /if \[ "\$PRIMARY_CHANNEL" = test \]/);
     assert.match(source, /if: steps\.release\.outputs\.is_test != 'true'/);
     assert.match(source, /publish\/test\/psysonic\.flatpakref/);
+  });
+
+  it('generates test AppStream metadata from the checked-out package version', () => {
+    const source = readFileSync(new URL('../.github/workflows/flatpak-release.yml', import.meta.url), 'utf8');
+    const generation = source.indexOf('PSYSONIC_FLATPAK_ALLOW_DEVELOPMENT=true');
+    const validation = source.indexOf('appstreamcli validate --pedantic');
+    const build = source.indexOf('make build');
+
+    assert.ok(generation >= 0, 'test publication must generate development AppStream metadata');
+    assert.ok(generation < validation, 'AppStream metadata must be generated before validation');
+    assert.ok(generation < build, 'AppStream metadata must be generated before the Flatpak build');
+    assert.match(source, /PSYSONIC_FLATPAK_VERSION="\$PACKAGE_VERSION"/);
+    assert.match(source, /commit\/\$EXPECTED_SHA/);
+    assert.doesNotMatch(source, /\[ "\$IS_TEST" = false \] && ! grep/);
   });
 });


### PR DESCRIPTION
## Summary
- generate an ephemeral AppStream release entry from `package.json` for test-channel builds
- link development metadata to the exact source commit instead of a nonexistent release tag
- require the generated package version before validation and build

## Verification
- `nix develop -c bash -lc 'node --test scripts/sync-flatpak-metainfo-release.test.mjs'` (12/12)\n- `nix run nixpkgs#actionlint -- .github/workflows/flatpak-release.yml`\n- generated `1.53.0-dev` metadata: `appstreamcli validate --pedantic` passed\n- `git diff --check`\n\n## Scope\n- Tauri commands/events: unchanged\n- Runtime benchmark: not applicable - publishing metadata and workflow tests only\n- Stable/RC metadata generation remains release-only; `-dev` requires an explicit opt-in and commit URL