### PR TITLE
fix(library): draw a pivot per row for the random track sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,8 +229,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1532](https://github.com/Psysonic/psysonic/pull/1532)**
 
-* The rail often showed a run of consecutive tracks from one album instead of a spread across your collection. It now picks each track independently: on a library of roughly 154,000 tracks, thirteen cards came from thirteen different albums in every test run, against fewer than two albums before.
-* Still a quick query rather than a full shuffle of the catalog, so the home screen is no slower for it.
+* The rail often showed a run of consecutive tracks from one album instead of a spread across your collection. It now picks each track independently, whether one music folder is selected or several: on a library of roughly 154,000 tracks, thirteen cards came from thirteen different albums in every test run, against fewer than two albums before.
+* Measured on the same library, the rail takes as long to fill as it did before.
 
 ## [1.52.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Pausing for more than a minute and then resuming could occasionally move Now Playing to a later track while the audio kept playing the current one.
 * Root cause: a pause that long releases the audio output stream, and rebuilding it on resume briefly reports a position near the start. That looked like the next track beginning, so the queue moved on. A track that has not even reached its halfway mark is no longer treated that way.
 
+### Discover Songs draws from the whole library again
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), PR [#1532](https://github.com/Psysonic/psysonic/pull/1532)**
+
+* The rail often showed a run of consecutive tracks from one album instead of a spread across your collection. It now picks each track independently: on a library of roughly 154,000 tracks, thirteen cards came from thirteen different albums in every test run, against fewer than two albums before.
+* Still a quick query rather than a full shuffle of the catalog, so the home screen is no slower for it.
+
 ## [1.52.0]
 
 ## Added

--- a/src-tauri/crates/psysonic-library/src/advanced_search/sql.rs
+++ b/src-tauri/crates/psysonic-library/src/advanced_search/sql.rs
@@ -283,6 +283,41 @@ where
             taken.push(rowid);
             rows.push(row);
         }
+
+        // Repeated draws eat the budget, so a page can still be short while
+        // enough untaken rows exist — likeliest when the eligible set is close
+        // to the page size, or when rowid gaps map many pivots onto the same
+        // successor. The previous shape always returned `min(limit, matching)`,
+        // and a rail that quietly shows nine cards instead of thirteen is worse
+        // than a top-up that is only as mixed as a small set allows.
+        if rows.len() < limit as usize {
+            let missing = limit as usize - rows.len();
+            let placeholders = std::iter::repeat_n("?", taken.len())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let exclude = if taken.is_empty() {
+                String::new()
+            } else {
+                format!("AND t.rowid NOT IN ({placeholders}) ")
+            };
+            let fill_sql = format!(
+                "SELECT {select_cols}, t.rowid AS {PIVOT_ROWID_ALIAS} FROM track t \
+                 WHERE {where_sql} {exclude}ORDER BY t.rowid LIMIT ?"
+            );
+            let mut params: Vec<SqlValue> = w.params.clone();
+            params.extend(taken.iter().map(|rowid| SqlValue::Integer(*rowid)));
+            params.push(SqlValue::Integer(missing as i64));
+            let mut fill_stmt = conn.prepare(&fill_sql)?;
+            let filled = fill_stmt
+                .query_map(rusqlite::params_from_iter(params.iter()), |row| {
+                    Ok((row.get::<_, i64>(PIVOT_ROWID_ALIAS)?, map(row)?))
+                })?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            for (rowid, row) in filled {
+                taken.push(rowid);
+                rows.push(row);
+            }
+        }
         Ok((rows, 0))
     })
 }

--- a/src-tauri/crates/psysonic-library/src/advanced_search/sql.rs
+++ b/src-tauri/crates/psysonic-library/src/advanced_search/sql.rs
@@ -152,6 +152,15 @@ where
     })
 }
 
+/// Column alias the sampler reads back so it can tell two picks apart. Appended
+/// to the caller's select list, so their own column indices stay valid.
+const PIVOT_ROWID_ALIAS: &str = "psy_pivot_rowid";
+
+/// How many picks the sampler may attempt per requested row before giving up.
+/// A pivot can land on a row already taken — likelier the smaller the catalog —
+/// and without a ceiling a set smaller than the limit would spin.
+const PIVOT_ATTEMPTS_PER_ROW: u32 = 4;
+
 pub(super) fn query_random_track_rows<T, F>(
     store: &LibraryStore,
     select_cols: &str,
@@ -162,8 +171,69 @@ pub(super) fn query_random_track_rows<T, F>(
 where
     F: Fn(&rusqlite::Row<'_>) -> rusqlite::Result<T> + Copy,
 {
+    query_random_track_rows_with(store, select_cols, w, limit, map, clock_pivot_source())
+}
+
+/// Successive pivots for one sample.
+///
+/// The first draw is the clock-based one this path has always used; the rest
+/// are derived from it. Calling the clock directly for each draw does not work:
+/// the picks happen microseconds apart, and modulo a small rowid span they
+/// collapse onto the same value, which would return one row instead of a sample.
+fn clock_pivot_source() -> impl FnMut(i64, i64) -> i64 {
+    let mut state: Option<u64> = None;
+    move |min_rowid, max_rowid| {
+        if min_rowid >= max_rowid {
+            return min_rowid;
+        }
+        let span = (max_rowid - min_rowid) as u128 + 1;
+        match state {
+            None => {
+                let first = random_rowid_pivot(min_rowid, max_rowid);
+                state = Some((first as u64) ^ 0x9E37_79B9_7F4A_7C15);
+                first
+            }
+            Some(previous) => {
+                // splitmix64: one multiply-xor chain per draw, no dependencies.
+                let mut z = previous.wrapping_add(0x9E37_79B9_7F4A_7C15);
+                state = Some(z);
+                z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+                z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+                z ^= z >> 31;
+                min_rowid + (u128::from(z) % span) as i64
+            }
+        }
+    }
+}
+
+/// Bounded random track sample: one pivot per row, not one pivot for the page.
+///
+/// The earlier shape drew a single pivot and read `limit` consecutive rowids
+/// from it. Ingest writes a catalog album by album, so a run of rowids is an
+/// album in track order — the sample was never mixed, it was a slice (#1446).
+/// Drawing a pivot per row keeps the bounded-sample intent, and the expensive
+/// part stays a single query: the `MIN/MAX(rowid)` scan runs once, the picks
+/// ride the rowid index.
+///
+/// `pivot_for` is a parameter so tests can pin the draws — an assertion about
+/// mixing is otherwise statistical, and a test that can only flake is no test.
+pub(super) fn query_random_track_rows_with<T, F, P>(
+    store: &LibraryStore,
+    select_cols: &str,
+    w: &WhereBuilder,
+    limit: u32,
+    map: F,
+    mut pivot_for: P,
+) -> Result<(Vec<T>, u32), String>
+where
+    F: Fn(&rusqlite::Row<'_>) -> rusqlite::Result<T> + Copy,
+    P: FnMut(i64, i64) -> i64,
+{
     let where_sql = w.where_sql();
     store.with_read_conn(|conn| {
+        if limit == 0 {
+            return Ok((Vec::new(), 0));
+        }
         let bounds_sql =
             format!("SELECT MIN(t.rowid), MAX(t.rowid) FROM track t WHERE {where_sql}");
         let (min_rowid, max_rowid): (Option<i64>, Option<i64>) = conn.query_row(
@@ -174,29 +244,44 @@ where
         let (Some(min_rowid), Some(max_rowid)) = (min_rowid, max_rowid) else {
             return Ok((Vec::new(), 0));
         };
-        let pivot = random_rowid_pivot(min_rowid, max_rowid);
 
-        let collect = |comparison: &str, pivot: i64, page_limit: u32| -> rusqlite::Result<Vec<T>> {
-            let page_sql = format!(
-                "SELECT {select_cols} FROM track t WHERE {where_sql} \
-                 AND t.rowid {comparison} ? ORDER BY t.rowid LIMIT ?"
-            );
-            let mut page_params: Vec<SqlValue> = w.params.clone();
-            page_params.push(SqlValue::Integer(pivot));
-            page_params.push(SqlValue::Integer(i64::from(page_limit)));
-            let mut stmt = conn.prepare(&page_sql)?;
-            let rows = stmt
-                .query_map(rusqlite::params_from_iter(page_params.iter()), |row| {
-                    map(row)
-                })?
-                .collect::<rusqlite::Result<Vec<T>>>()?;
-            Ok(rows)
+        // A pivot may fall into a gap, so the pick takes the first row at or
+        // above it and wraps to the start of the range when it points past the
+        // last one. Both are single index seeks.
+        let pick_sql = format!(
+            "SELECT {select_cols}, t.rowid AS {PIVOT_ROWID_ALIAS} FROM track t \
+             WHERE {where_sql} AND t.rowid >= ? ORDER BY t.rowid LIMIT 1"
+        );
+        let mut stmt = conn.prepare(&pick_sql)?;
+        let mut pick = |from_rowid: i64| -> rusqlite::Result<Option<(i64, T)>> {
+            let mut params: Vec<SqlValue> = w.params.clone();
+            params.push(SqlValue::Integer(from_rowid));
+            let mut found = stmt.query_map(rusqlite::params_from_iter(params.iter()), |row| {
+                Ok((row.get::<_, i64>(PIVOT_ROWID_ALIAS)?, map(row)?))
+            })?;
+            found.next().transpose()
         };
 
-        let mut rows = collect(">=", pivot, limit)?;
-        if rows.len() < limit as usize {
-            let remaining = limit.saturating_sub(rows.len() as u32);
-            rows.extend(collect("<", pivot, remaining)?);
+        let mut rows: Vec<T> = Vec::with_capacity(limit as usize);
+        let mut taken: Vec<i64> = Vec::with_capacity(limit as usize);
+        let attempts = limit.saturating_mul(PIVOT_ATTEMPTS_PER_ROW);
+        for _ in 0..attempts {
+            if rows.len() >= limit as usize {
+                break;
+            }
+            let pivot = pivot_for(min_rowid, max_rowid).clamp(min_rowid, max_rowid);
+            let picked = match pick(pivot)? {
+                Some(hit) => Some(hit),
+                None => pick(min_rowid)?,
+            };
+            let Some((rowid, row)) = picked else {
+                break;
+            };
+            if taken.contains(&rowid) {
+                continue;
+            }
+            taken.push(rowid);
+            rows.push(row);
         }
         Ok((rows, 0))
     })

--- a/src-tauri/crates/psysonic-library/src/advanced_search/tests/random.rs
+++ b/src-tauri/crates/psysonic-library/src/advanced_search/tests/random.rs
@@ -9,6 +9,7 @@ use crate::advanced_search::sql::{
 use crate::dto::{LibraryScopePair, LibrarySortClause, SortDir};
 use crate::filter::EntityKind;
 use crate::repos::TrackRepository;
+use crate::scope_merge::random_sample_order_sql;
 use crate::store::LibraryStore;
 
 #[test]
@@ -131,6 +132,31 @@ fn random_sample_skips_a_repeated_pivot_instead_of_returning_it_twice() {
 }
 
 #[test]
+fn random_sample_still_fills_the_page_when_every_draw_collides() {
+    let store = LibraryStore::open_in_memory();
+    seed_three_albums(&store);
+
+    // Every draw lands on the same row, so the attempt budget runs out with one
+    // row taken. Thirty rows are eligible, so a short page would be a regress
+    // against the shape this replaced.
+    let (ids, _) = query_random_track_rows_with(
+        &store,
+        "t.id",
+        &scoped_where(),
+        4,
+        |row| row.get::<_, String>(0),
+        |min, _max| min,
+    )
+    .unwrap();
+
+    let mut distinct = ids.clone();
+    distinct.sort();
+    distinct.dedup();
+    assert_eq!(ids.len(), 4, "page must be filled, got {ids:?}");
+    assert_eq!(distinct.len(), 4, "and hold four different tracks");
+}
+
+#[test]
 fn random_sample_stops_when_the_catalog_is_smaller_than_the_limit() {
     let store = LibraryStore::open_in_memory();
     TrackRepository::new(&store)
@@ -183,4 +209,63 @@ fn scoped_random_track_request_uses_bounded_sample_path() {
     let response = run_advanced_search(&store, &r).unwrap();
     assert_eq!(response.tracks.len(), 4);
     assert_eq!(response.totals.tracks, 0);
+}
+
+/// Two selected folders never reach the per-row sampler — that path queries
+/// `track` directly, and repeating the scope CTE per draw was measured at twelve
+/// seconds against a real library, against roughly one for shuffling it once.
+/// So that path shuffles, and this pins the clause rather than the output: with
+/// no `ORDER BY` at all SQLite promises no order, so an "is it shuffled" check
+/// on returned rows passes even when the clause is gone.
+#[test]
+fn multi_folder_random_sample_shuffles_instead_of_taking_a_window() {
+    assert_eq!(
+        random_sample_order_sql(true, "ORDER BY t.title COLLATE NOCASE ASC"),
+        "ORDER BY RANDOM()",
+        "the unfiltered random sample must shuffle, not drop ordering for a window"
+    );
+    assert_eq!(
+        random_sample_order_sql(false, "ORDER BY t.title COLLATE NOCASE ASC"),
+        "ORDER BY t.title COLLATE NOCASE ASC",
+        "every other request keeps its own ordering"
+    );
+}
+
+/// The same request still comes back complete across two folders.
+#[test]
+fn multi_folder_random_request_returns_a_full_page() {
+    let store = LibraryStore::open_in_memory();
+    let tracks = (0..30)
+        .map(|index| {
+            scoped_track(
+                "s1",
+                &format!("t-{index:02}"),
+                &format!("Song {index}"),
+                "Artist",
+                &format!("Album {}", index / 10),
+                "album",
+                if index < 15 { "lib-a" } else { "lib-b" },
+                None,
+                None,
+                None,
+            )
+        })
+        .collect::<Vec<_>>();
+    TrackRepository::new(&store).upsert_batch(&tracks).unwrap();
+
+    let mut r = req("s1", &[EntityKind::Track]);
+    r.library_scopes = Some(vec![scope_pair("s1", "lib-a"), scope_pair("s1", "lib-b")]);
+    r.sort = vec![LibrarySortClause {
+        field: "random".into(),
+        dir: SortDir::Asc,
+    }];
+    r.limit = 8;
+    r.skip_totals = true;
+
+    let response = run_advanced_search(&store, &r).unwrap();
+    assert_eq!(response.tracks.len(), 8);
+    let mut ids: Vec<&str> = response.tracks.iter().map(|t| t.id.as_str()).collect();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), 8, "no track may appear twice in one sample");
 }

--- a/src-tauri/crates/psysonic-library/src/advanced_search/tests/random.rs
+++ b/src-tauri/crates/psysonic-library/src/advanced_search/tests/random.rs
@@ -1,6 +1,11 @@
+use rusqlite::types::Value as SqlValue;
+
 use super::support::{req, scope_pair, scoped_track, track};
+use crate::advanced_search::filters::WhereBuilder;
 use crate::advanced_search::run_advanced_search;
-use crate::advanced_search::sql::{is_fast_random_track_sample, random_rowid_pivot};
+use crate::advanced_search::sql::{
+    is_fast_random_track_sample, query_random_track_rows_with, random_rowid_pivot,
+};
 use crate::dto::{LibraryScopePair, LibrarySortClause, SortDir};
 use crate::filter::EntityKind;
 use crate::repos::TrackRepository;
@@ -47,6 +52,102 @@ fn unfiltered_random_track_request_uses_bounded_sample_path() {
 fn random_rowid_pivot_stays_inside_bounds() {
     assert_eq!(random_rowid_pivot(7, 7), 7);
     assert!((10..=25).contains(&random_rowid_pivot(10, 25)));
+}
+
+/// Seed three albums the way ingest writes a catalog: one after another, so a
+/// run of rowids is one album in track order.
+fn seed_three_albums(store: &LibraryStore) {
+    let mut tracks = Vec::new();
+    for album in 0..3 {
+        for index in 0..10 {
+            tracks.push(track(
+                "s1",
+                &format!("t-{album}-{index:02}"),
+                &format!("Song {index}"),
+                "Artist",
+                &format!("Album {album}"),
+            ));
+        }
+    }
+    TrackRepository::new(store).upsert_batch(&tracks).unwrap();
+}
+
+fn scoped_where() -> WhereBuilder {
+    let mut w = WhereBuilder::new();
+    w.push_param("t.server_id = ?", SqlValue::Text("s1".into()));
+    w.push_raw("t.deleted = 0");
+    w
+}
+
+#[test]
+fn random_sample_draws_one_pivot_per_row_rather_than_a_run() {
+    let store = LibraryStore::open_in_memory();
+    seed_three_albums(&store);
+
+    // Pinned draws, one per requested row, each landing in a different album.
+    // Reading a page from a single pivot would return three tracks of one.
+    let mut pivots = [21_i64, 11, 1].into_iter();
+    let (albums, _) = query_random_track_rows_with(
+        &store,
+        "t.album",
+        &scoped_where(),
+        3,
+        |row| row.get::<_, String>(0),
+        |_min, _max| pivots.next().unwrap_or(1),
+    )
+    .unwrap();
+
+    let mut distinct = albums.clone();
+    distinct.sort();
+    distinct.dedup();
+    assert_eq!(albums.len(), 3);
+    assert_eq!(
+        distinct.len(),
+        3,
+        "each pinned pivot must land in its own album, got {albums:?}"
+    );
+}
+
+#[test]
+fn random_sample_skips_a_repeated_pivot_instead_of_returning_it_twice() {
+    let store = LibraryStore::open_in_memory();
+    seed_three_albums(&store);
+
+    // The same draw twice, then a different one: the duplicate is dropped and
+    // the sample still fills, because the budget allows further attempts.
+    let mut pivots = [5_i64, 5, 25].into_iter();
+    let (ids, _) = query_random_track_rows_with(
+        &store,
+        "t.id",
+        &scoped_where(),
+        2,
+        |row| row.get::<_, String>(0),
+        |_min, _max| pivots.next().unwrap_or(25),
+    )
+    .unwrap();
+
+    assert_eq!(ids.len(), 2);
+    assert_ne!(ids[0], ids[1]);
+}
+
+#[test]
+fn random_sample_stops_when_the_catalog_is_smaller_than_the_limit() {
+    let store = LibraryStore::open_in_memory();
+    TrackRepository::new(&store)
+        .upsert_batch(&[track("s1", "only", "Song", "Artist", "Album")])
+        .unwrap();
+
+    let (ids, _) = query_random_track_rows_with(
+        &store,
+        "t.id",
+        &scoped_where(),
+        5,
+        |row| row.get::<_, String>(0),
+        |min, _max| min,
+    )
+    .unwrap();
+
+    assert_eq!(ids, vec!["only".to_string()]);
 }
 
 #[test]

--- a/src-tauri/crates/psysonic-library/src/perf_probe.rs
+++ b/src-tauri/crates/psysonic-library/src/perf_probe.rs
@@ -76,6 +76,25 @@ fn largest_scope_index(store: &LibraryStore, scopes: &[LibraryScopePair]) -> usi
     best.0
 }
 
+/// The predicate and binds a single-scope track request builds, mirroring
+/// `advanced_search::track::build_track`: deleted, server, and the library when
+/// the scope names a folder. Reference queries take it verbatim so they weigh
+/// the same rows as the request they are compared against.
+fn scope_predicate(scope: &LibraryScopePair) -> (String, Vec<rusqlite::types::Value>) {
+    let mut sql = "t.deleted = 0 AND t.server_id = ?".to_string();
+    let mut binds = vec![rusqlite::types::Value::Text(scope.server_id.clone())];
+    if let Some(library) = scope
+        .library_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        sql.push_str(" AND t.library_id = ?");
+        binds.push(rusqlite::types::Value::Text(library.to_string()));
+    }
+    (sql, binds)
+}
+
 fn row_counts(store: &LibraryStore) -> (i64, i64, i64) {
     store
         .with_read_conn(|conn| {
@@ -544,50 +563,212 @@ fn discover_songs_sample_spread_on_a_real_library() {
         distinct_counts.iter().map(|(r, _)| *r).collect::<Vec<_>>(),
     );
 
-    // Reference points measured on the same copy: the shape this replaced, and
-    // the fully shuffled query it was introduced to avoid.
+    // Reference points on the same copy: the shape this replaced, and the fully
+    // shuffled query it was introduced to avoid. Both take the scope predicate,
+    // the binds and the projection from the request above, so all three read the
+    // same population and carry the same rows back — a reference that filtered
+    // by server alone would measure a different, larger set on any server with
+    // more than one music folder.
+    let (scope_sql, scope_binds) = scope_predicate(&scope);
+    let cols = crate::search::aliased_track_columns("t");
     store
         .with_read_conn(|conn| {
-            let scope_sql = "t.server_id = ? AND t.deleted = 0";
-            let bounds: (i64, i64) = conn.query_row(
-                &format!("SELECT MIN(t.rowid), MAX(t.rowid) FROM track t WHERE {scope_sql}"),
-                rusqlite::params![scope.server_id],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )?;
-            let mut old_spans = Vec::new();
+            let album_of = |row: &rusqlite::Row<'_>| row.get::<_, Option<String>>("album_id");
+            let bounds_sql =
+                format!("SELECT MIN(t.rowid), MAX(t.rowid) FROM track t WHERE {scope_sql}");
+            let page_sql = format!(
+                "SELECT {cols} FROM track t WHERE {scope_sql} AND t.rowid {{cmp}} ? \
+                 ORDER BY t.rowid LIMIT ?"
+            );
+            let forward_sql = page_sql.replace("{cmp}", ">=");
+            let wrap_sql = page_sql.replace("{cmp}", "<");
+
+            let (mut old_spans, mut old_ms) = (Vec::new(), Vec::new());
             for step in 0..RUNS {
+                let started = Instant::now();
+                // The replaced shape, whole: bounds, one pivot for the page, then
+                // a wrap to the front when the tail is short.
+                let bounds: (i64, i64) = conn.query_row(
+                    &bounds_sql,
+                    rusqlite::params_from_iter(scope_binds.iter()),
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )?;
                 let span = (bounds.1 - bounds.0 + 1) as u128;
                 let pivot = bounds.0 + ((step as u128 * span / RUNS as u128) as i64);
-                let mut stmt = conn.prepare(&format!(
-                    "SELECT t.album_id FROM track t WHERE {scope_sql} AND t.rowid >= ? \
-                     ORDER BY t.rowid LIMIT ?"
-                ))?;
-                let mut ids = stmt
-                    .query_map(rusqlite::params![scope.server_id, pivot, LIMIT], |row| {
-                        row.get::<_, Option<String>>(0)
-                    })?
-                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                let page = |sql: &str, pivot: i64, take: u32| -> rusqlite::Result<Vec<_>> {
+                    let mut binds = scope_binds.clone();
+                    binds.push(rusqlite::types::Value::Integer(pivot));
+                    binds.push(rusqlite::types::Value::Integer(i64::from(take)));
+                    let mut stmt = conn.prepare(sql)?;
+                    let rows = stmt
+                        .query_map(rusqlite::params_from_iter(binds.iter()), |row| album_of(row))?
+                        .collect::<rusqlite::Result<Vec<_>>>();
+                    rows
+                };
+                let mut ids = page(&forward_sql, pivot, LIMIT)?;
+                if ids.len() < LIMIT as usize {
+                    let remaining = LIMIT.saturating_sub(ids.len() as u32);
+                    ids.extend(page(&wrap_sql, pivot, remaining)?);
+                }
+                old_ms.push(started.elapsed().as_millis());
                 ids.sort();
                 ids.dedup();
                 old_spans.push(ids.len());
             }
             let old_mean = old_spans.iter().sum::<usize>() as f64 / old_spans.len() as f64;
-            eprintln!("previous shape: distinct_albums={old_spans:?} mean={old_mean:.2}");
+            eprintln!(
+                "previous shape: distinct_albums={old_spans:?} mean={old_mean:.2} \
+                 elapsed_ms={old_ms:?}"
+            );
 
-            let started = Instant::now();
-            let mut stmt = conn.prepare(&format!(
-                "SELECT t.album_id FROM track t WHERE {scope_sql} ORDER BY RANDOM() LIMIT ?"
-            ))?;
-            let mut ids = stmt
-                .query_map(rusqlite::params![scope.server_id, LIMIT], |row| {
-                    row.get::<_, Option<String>>(0)
-                })?
-                .collect::<rusqlite::Result<Vec<_>>>()?;
-            let full_shuffle_ms = started.elapsed().as_millis();
-            ids.sort();
-            ids.dedup();
-            eprintln!("order by random(): distinct_albums={} elapsed_ms={full_shuffle_ms}", ids.len());
+            let shuffle_sql =
+                format!("SELECT {cols} FROM track t WHERE {scope_sql} ORDER BY RANDOM() LIMIT ?");
+            let (mut shuffle_spans, mut shuffle_ms) = (Vec::new(), Vec::new());
+            for _ in 0..RUNS {
+                let started = Instant::now();
+                let mut binds = scope_binds.clone();
+                binds.push(rusqlite::types::Value::Integer(i64::from(LIMIT)));
+                let mut stmt = conn.prepare(&shuffle_sql)?;
+                let mut ids = stmt
+                    .query_map(rusqlite::params_from_iter(binds.iter()), |row| album_of(row))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                shuffle_ms.push(started.elapsed().as_millis());
+                ids.sort();
+                ids.dedup();
+                shuffle_spans.push(ids.len());
+            }
+            let shuffle_mean =
+                shuffle_spans.iter().sum::<usize>() as f64 / shuffle_spans.len() as f64;
+            eprintln!(
+                "order by random(): distinct_albums={shuffle_spans:?} mean={shuffle_mean:.2} \
+                 elapsed_ms={shuffle_ms:?}"
+            );
             Ok(())
         })
         .expect("reference queries");
+}
+
+/// Multi-folder Discover Songs: the same rail when more than one music folder
+/// is selected. That request never reaches the per-row sampler, so this weighs
+/// the three shapes it could take before one is built (#1532 review).
+#[test]
+#[ignore = "needs PSYSONIC_PERF_DB pointing at a copy of a real library"]
+fn multi_folder_random_sample_shapes_on_a_real_library() {
+    let Some(db) = probe_db_path() else {
+        eprintln!("PSYSONIC_PERF_DB unset or missing — skipping");
+        return;
+    };
+    let store = LibraryStore::open_path_for_test(&db).expect("open probe db");
+    let scopes = scopes_from_db(&store);
+    let largest = largest_scope_index(&store, &scopes);
+    let server = scopes[largest].server_id.clone();
+    let multi: Vec<crate::dto::LibraryScopePair> = scopes
+        .iter()
+        .filter(|s| s.server_id == server)
+        .cloned()
+        .collect();
+    eprintln!("scope_index={largest} folders={}", multi.len());
+    if multi.len() < 2 {
+        eprintln!("server has a single folder — nothing to compare");
+        return;
+    }
+
+    const LIMIT: u32 = 13;
+    const RUNS: usize = 6;
+    let (cte, scope_binds) = crate::scope_merge::scope_cte_sql(&multi);
+    let base = "FROM scoped_track s CROSS JOIN track t ON t.rowid = s.rowid WHERE t.deleted = 0";
+
+    let summarise = |label: &str, spans: &[usize], times: &[u128]| {
+        let mean = spans.iter().sum::<usize>() as f64 / spans.len() as f64;
+        eprintln!("{label}: distinct_albums={spans:?} mean={mean:.2} elapsed_ms={times:?}");
+    };
+
+    store
+        .with_read_conn(|conn| {
+            // (a) per-row pivots, the shape the single-scope path now uses.
+            let bounds_sql = format!("{cte} SELECT MIN(t.rowid), MAX(t.rowid) {base}");
+            let (min_rowid, max_rowid): (i64, i64) = conn.query_row(
+                &bounds_sql,
+                rusqlite::params_from_iter(scope_binds.iter()),
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )?;
+            let pick_sql =
+                format!("{cte} SELECT t.album_id {base} AND t.rowid >= ? ORDER BY t.rowid LIMIT 1");
+            let (mut spans, mut times) = (Vec::new(), Vec::new());
+            for run in 0..RUNS {
+                let started = Instant::now();
+                let mut ids = Vec::new();
+                for step in 0..LIMIT as usize {
+                    let span = (max_rowid - min_rowid + 1) as u128;
+                    let seed = (run * 31 + step * 7919) as u128;
+                    let pivot = min_rowid + ((seed * 2_654_435_761 % span) as i64);
+                    let mut binds = scope_binds.clone();
+                    binds.push(rusqlite::types::Value::Integer(pivot));
+                    let mut stmt = conn.prepare(&pick_sql)?;
+                    let mut got = stmt
+                        .query_map(rusqlite::params_from_iter(binds.iter()), |row| {
+                            row.get::<_, Option<String>>(0)
+                        })?;
+                    if let Some(id) = got.next().transpose()? {
+                        ids.push(id);
+                    }
+                }
+                times.push(started.elapsed().as_millis());
+                ids.sort();
+                ids.dedup();
+                spans.push(ids.len());
+            }
+            summarise("(a) per-row pivots", &spans, &times);
+
+            // (b) one CTE, fully shuffled.
+            let shuffle_sql = format!("{cte} SELECT t.album_id {base} ORDER BY RANDOM() LIMIT ?");
+            let (mut spans, mut times) = (Vec::new(), Vec::new());
+            for _ in 0..RUNS {
+                let started = Instant::now();
+                let mut binds = scope_binds.clone();
+                binds.push(rusqlite::types::Value::Integer(i64::from(LIMIT)));
+                let mut stmt = conn.prepare(&shuffle_sql)?;
+                let mut ids = stmt
+                    .query_map(rusqlite::params_from_iter(binds.iter()), |row| {
+                        row.get::<_, Option<String>>(0)
+                    })?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                times.push(started.elapsed().as_millis());
+                ids.sort();
+                ids.dedup();
+                spans.push(ids.len());
+            }
+            summarise("(b) order by random()", &spans, &times);
+
+            // (c) what multi-folder does today: count, then one unordered page.
+            let count_sql = format!("{cte} SELECT COUNT(*) {base}");
+            let page_sql = format!("{cte} SELECT t.album_id {base} LIMIT ? OFFSET ?");
+            let (mut spans, mut times) = (Vec::new(), Vec::new());
+            for run in 0..RUNS {
+                let started = Instant::now();
+                let total: i64 = conn.query_row(
+                    &count_sql,
+                    rusqlite::params_from_iter(scope_binds.iter()),
+                    |row| row.get(0),
+                )?;
+                let window = (total as u32).saturating_sub(LIMIT).saturating_add(1);
+                let offset = ((run as u32 * 6151) % window.max(1)) as i64;
+                let mut binds = scope_binds.clone();
+                binds.push(rusqlite::types::Value::Integer(i64::from(LIMIT)));
+                binds.push(rusqlite::types::Value::Integer(offset));
+                let mut stmt = conn.prepare(&page_sql)?;
+                let mut ids = stmt
+                    .query_map(rusqlite::params_from_iter(binds.iter()), |row| {
+                        row.get::<_, Option<String>>(0)
+                    })?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                times.push(started.elapsed().as_millis());
+                ids.sort();
+                ids.dedup();
+                spans.push(ids.len());
+            }
+            summarise("(c) current window page", &spans, &times);
+            Ok(())
+        })
+        .expect("shape comparison");
 }

--- a/src-tauri/crates/psysonic-library/src/perf_probe.rs
+++ b/src-tauri/crates/psysonic-library/src/perf_probe.rs
@@ -478,3 +478,116 @@ fn artist_browse_phase_breakdown_on_a_real_library() {
         })
         .expect("plan");
 }
+
+/// What the Discover Songs rail asks for: an unfiltered random track sample of
+/// one page, single scope, no totals. Reports how many distinct albums the
+/// sample spans, which is the whole point of the rail (#1446), alongside the
+/// two alternatives it sits between.
+#[test]
+#[ignore = "needs PSYSONIC_PERF_DB pointing at a copy of a real library"]
+fn discover_songs_sample_spread_on_a_real_library() {
+    let Some(db) = probe_db_path() else {
+        eprintln!("PSYSONIC_PERF_DB unset or missing — skipping");
+        return;
+    };
+    let store = LibraryStore::open_path_for_test(&db).expect("open probe db");
+    let scopes = scopes_from_db(&store);
+    let largest = largest_scope_index(&store, &scopes);
+    let scope = scopes[largest].clone();
+    let (tracks, albums, _artists) = row_counts(&store);
+    eprintln!("catalog: tracks={tracks} albums={albums} scope_index={largest}");
+
+    const LIMIT: u32 = 13;
+    const RUNS: usize = 12;
+
+    let request = LibraryAdvancedSearchRequest {
+        server_id: scope.server_id.clone(),
+        library_scope: None,
+        library_scopes: Some(vec![scope.clone()]),
+        query: None,
+        entity_types: vec![EntityKind::Track],
+        filters: Vec::new(),
+        starred_only: None,
+        restrict_album_ids: None,
+        query_album_title_only: None,
+        sort: vec![LibrarySortClause {
+            field: "random".to_string(),
+            dir: SortDir::Asc,
+        }],
+        limit: LIMIT,
+        offset: 0,
+        skip_totals: true,
+        artist_credit_mode: None,
+        artist_letter_bucket: None,
+    };
+
+    let mut distinct_counts = Vec::with_capacity(RUNS);
+    let mut elapsed_ms = Vec::with_capacity(RUNS);
+    for _ in 0..RUNS {
+        let started = Instant::now();
+        let result = crate::advanced_search::run_advanced_search(&store, &request).expect("search");
+        elapsed_ms.push(started.elapsed().as_millis());
+        let mut album_ids: Vec<String> = result
+            .tracks
+            .iter()
+            .map(|t| t.album_id.clone().unwrap_or_else(|| t.album.clone()))
+            .collect();
+        album_ids.sort();
+        album_ids.dedup();
+        distinct_counts.push((result.tracks.len(), album_ids.len()));
+    }
+
+    let spans: Vec<usize> = distinct_counts.iter().map(|(_, d)| *d).collect();
+    let mean = spans.iter().sum::<usize>() as f64 / spans.len() as f64;
+    eprintln!(
+        "sampler: rows={:?} distinct_albums={spans:?} mean={mean:.2} elapsed_ms={elapsed_ms:?}",
+        distinct_counts.iter().map(|(r, _)| *r).collect::<Vec<_>>(),
+    );
+
+    // Reference points measured on the same copy: the shape this replaced, and
+    // the fully shuffled query it was introduced to avoid.
+    store
+        .with_read_conn(|conn| {
+            let scope_sql = "t.server_id = ? AND t.deleted = 0";
+            let bounds: (i64, i64) = conn.query_row(
+                &format!("SELECT MIN(t.rowid), MAX(t.rowid) FROM track t WHERE {scope_sql}"),
+                rusqlite::params![scope.server_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )?;
+            let mut old_spans = Vec::new();
+            for step in 0..RUNS {
+                let span = (bounds.1 - bounds.0 + 1) as u128;
+                let pivot = bounds.0 + ((step as u128 * span / RUNS as u128) as i64);
+                let mut stmt = conn.prepare(&format!(
+                    "SELECT t.album_id FROM track t WHERE {scope_sql} AND t.rowid >= ? \
+                     ORDER BY t.rowid LIMIT ?"
+                ))?;
+                let mut ids = stmt
+                    .query_map(rusqlite::params![scope.server_id, pivot, LIMIT], |row| {
+                        row.get::<_, Option<String>>(0)
+                    })?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                ids.sort();
+                ids.dedup();
+                old_spans.push(ids.len());
+            }
+            let old_mean = old_spans.iter().sum::<usize>() as f64 / old_spans.len() as f64;
+            eprintln!("previous shape: distinct_albums={old_spans:?} mean={old_mean:.2}");
+
+            let started = Instant::now();
+            let mut stmt = conn.prepare(&format!(
+                "SELECT t.album_id FROM track t WHERE {scope_sql} ORDER BY RANDOM() LIMIT ?"
+            ))?;
+            let mut ids = stmt
+                .query_map(rusqlite::params![scope.server_id, LIMIT], |row| {
+                    row.get::<_, Option<String>>(0)
+                })?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            let full_shuffle_ms = started.elapsed().as_millis();
+            ids.sort();
+            ids.dedup();
+            eprintln!("order by random(): distinct_albums={} elapsed_ms={full_shuffle_ms}", ids.len());
+            Ok(())
+        })
+        .expect("reference queries");
+}

--- a/src-tauri/crates/psysonic-library/src/perf_probe.rs
+++ b/src-tauri/crates/psysonic-library/src/perf_probe.rs
@@ -673,14 +673,23 @@ fn multi_folder_random_sample_shapes_on_a_real_library() {
         return;
     }
 
-    const LIMIT: u32 = 13;
+    // The Home rail asks for `HOME_DISCOVER_SONGS_SIZE` rows from one server and
+    // `homeFeedLoader` abandons the local read after `HOME_LOCAL_READ_TIMEOUT_MS`,
+    // so those are the numbers to measure against — not a smaller page.
+    const LIMIT: u32 = 18;
     const RUNS: usize = 6;
+    const HOME_LOCAL_READ_BUDGET_MS: u128 = 1000;
     let (cte, scope_binds) = crate::scope_merge::scope_cte_sql(&multi);
     let base = "FROM scoped_track s CROSS JOIN track t ON t.rowid = s.rowid WHERE t.deleted = 0";
+    // The request carries the whole track row through to `LibraryTrackDto`, and a
+    // full-set random sort has to move that projection, so a probe on one narrow
+    // column would understate it.
+    let cols = crate::search::aliased_track_columns("t");
 
     let summarise = |label: &str, spans: &[usize], times: &[u128]| {
         let mean = spans.iter().sum::<usize>() as f64 / spans.len() as f64;
-        eprintln!("{label}: distinct_albums={spans:?} mean={mean:.2} elapsed_ms={times:?}");
+        let worst = times.iter().copied().max().unwrap_or(0);
+        eprintln!("{label}: distinct_albums={spans:?} mean={mean:.2} elapsed_ms={times:?} worst={worst}ms");
     };
 
     store
@@ -718,31 +727,40 @@ fn multi_folder_random_sample_shapes_on_a_real_library() {
                 ids.dedup();
                 spans.push(ids.len());
             }
-            summarise("(a) per-row pivots", &spans, &times);
+            summarise(
+                "(a) per-row pivots, album id only (a lower bound — the real projection is wider)",
+                &spans,
+                &times,
+            );
 
-            // (b) one CTE, fully shuffled.
-            let shuffle_sql = format!("{cte} SELECT t.album_id {base} ORDER BY RANDOM() LIMIT ?");
+            // (b) one CTE, fully shuffled, carrying the projection the request
+            // returns. This is what the multi-folder path now runs.
+            let shuffle_sql = format!("{cte} SELECT {cols} {base} ORDER BY RANDOM() LIMIT ?");
             let (mut spans, mut times) = (Vec::new(), Vec::new());
             for _ in 0..RUNS {
                 let started = Instant::now();
                 let mut binds = scope_binds.clone();
                 binds.push(rusqlite::types::Value::Integer(i64::from(LIMIT)));
                 let mut stmt = conn.prepare(&shuffle_sql)?;
-                let mut ids = stmt
+                let rows = stmt
                     .query_map(rusqlite::params_from_iter(binds.iter()), |row| {
-                        row.get::<_, Option<String>>(0)
+                        crate::repos::row_to_track_row(row)
+                            .map(|tr| crate::dto::LibraryTrackDto::from_row(&tr))
                     })?
                     .collect::<rusqlite::Result<Vec<_>>>()?;
                 times.push(started.elapsed().as_millis());
+                let mut ids: Vec<_> = rows.iter().filter_map(|t| t.album_id.clone()).collect();
                 ids.sort();
                 ids.dedup();
                 spans.push(ids.len());
             }
-            summarise("(b) order by random()", &spans, &times);
+            summarise("(b) order by random(), full projection", &spans, &times);
 
-            // (c) what multi-folder does today: count, then one unordered page.
+            // (c) the shape this replaced: count the matching set, pick one
+            // offset into it, return an unordered page. Same projection as (b),
+            // so the two are comparable.
             let count_sql = format!("{cte} SELECT COUNT(*) {base}");
-            let page_sql = format!("{cte} SELECT t.album_id {base} LIMIT ? OFFSET ?");
+            let page_sql = format!("{cte} SELECT {cols} {base} LIMIT ? OFFSET ?");
             let (mut spans, mut times) = (Vec::new(), Vec::new());
             for run in 0..RUNS {
                 let started = Instant::now();
@@ -757,18 +775,71 @@ fn multi_folder_random_sample_shapes_on_a_real_library() {
                 binds.push(rusqlite::types::Value::Integer(i64::from(LIMIT)));
                 binds.push(rusqlite::types::Value::Integer(offset));
                 let mut stmt = conn.prepare(&page_sql)?;
-                let mut ids = stmt
+                let rows = stmt
                     .query_map(rusqlite::params_from_iter(binds.iter()), |row| {
-                        row.get::<_, Option<String>>(0)
+                        crate::repos::row_to_track_row(row)
+                            .map(|tr| crate::dto::LibraryTrackDto::from_row(&tr))
                     })?
                     .collect::<rusqlite::Result<Vec<_>>>()?;
                 times.push(started.elapsed().as_millis());
+                let mut ids: Vec<_> = rows.iter().filter_map(|t| t.album_id.clone()).collect();
                 ids.sort();
                 ids.dedup();
                 spans.push(ids.len());
             }
-            summarise("(c) current window page", &spans, &times);
+            summarise("(c) replaced window page, full projection", &spans, &times);
             Ok(())
         })
         .expect("shape comparison");
+    // (d) the production request itself: same scopes, same limit, same sort,
+    // through the planner that Discover Songs actually calls.
+    //
+    // It runs last on purpose. On a freshly copied database the first block pays
+    // the cold page cache, and that cost belongs to no strategy: measured first,
+    // this request reported a 1314 ms outlier followed by ~600 ms; measured last,
+    // the same code reports 375-457 ms while the first block carries the warm-up.
+    let request = LibraryAdvancedSearchRequest {
+        server_id: server.clone(),
+        library_scope: None,
+        library_scopes: Some(multi.clone()),
+        query: None,
+        entity_types: vec![EntityKind::Track],
+        filters: Vec::new(),
+        starred_only: None,
+        restrict_album_ids: None,
+        query_album_title_only: None,
+        sort: vec![LibrarySortClause {
+            field: "random".into(),
+            dir: SortDir::Asc,
+        }],
+        limit: LIMIT,
+        offset: 0,
+        skip_totals: true,
+        artist_credit_mode: None,
+        artist_letter_bucket: None,
+    };
+    let (mut spans, mut times) = (Vec::new(), Vec::new());
+    for _ in 0..RUNS {
+        let started = Instant::now();
+        let resp = crate::advanced_search::run_advanced_search(&store, &request)
+            .expect("production request");
+        times.push(started.elapsed().as_millis());
+        let mut ids: Vec<_> = resp
+            .tracks
+            .iter()
+            .filter_map(|t| t.album_id.clone())
+            .collect();
+        let rows = resp.tracks.len();
+        ids.sort();
+        ids.dedup();
+        spans.push(ids.len());
+        assert_eq!(rows, LIMIT as usize, "production request returned a short page");
+    }
+    let worst = times.iter().copied().max().unwrap_or(0);
+    summarise("(d) production request through run_advanced_search", &spans, &times);
+    eprintln!(
+        "    local-read budget={HOME_LOCAL_READ_BUDGET_MS}ms headroom_at_worst={}ms",
+        HOME_LOCAL_READ_BUDGET_MS as i128 - worst as i128,
+    );
+
 }

--- a/src-tauri/crates/psysonic-library/src/scope_merge.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge.rs
@@ -35,7 +35,7 @@ pub(crate) use artist_candidates::{album_artist_id_expr, AlbumSplitMeta};
 #[allow(unused_imports)]
 pub(crate) use common::{
     album_row_to_dto, ensure_cluster_keys_for_scopes, finish_scope_album_list, non_empty_scopes,
-    normalize_scope_pairs, random_window_offset, scope_cte_sql, AlbumListRow, ALBUM_DEDUP_KEY,
+    normalize_scope_pairs, scope_cte_sql, AlbumListRow, ALBUM_DEDUP_KEY,
     ALBUM_PICK_KEY, TRACK_CLUSTER_PARTITION_KEY, TRACK_DEDUP_KEY,
 };
 #[allow(unused_imports)]
@@ -45,6 +45,8 @@ pub(crate) use track_browse::{
     collect_scope_fts_rowids, list_albums_filtered, list_artists_filtered, list_tracks_filtered,
     list_tracks_layer1_filtered, search_tracks_filtered,
 };
+#[cfg(test)]
+pub(crate) use track_browse::random_sample_order_sql;
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/crates/psysonic-library/src/scope_merge/common.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge/common.rs
@@ -1,24 +1,12 @@
 use rusqlite::types::Value as SqlValue;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::album_compilation_filter::pick_album_group_artist;
 use crate::browse_support::{overlay_album_artist_links, overlay_album_starred_at_rows};
 use crate::dto::{LibraryAlbumDto, LibraryScopePair};
 use crate::search::PAGE_LIMIT_MAX;
 use crate::store::LibraryStore;
-
-pub(crate) fn random_window_offset(total: u32, limit: u32) -> u32 {
-    let window_count = total.saturating_sub(limit).saturating_add(1);
-    if window_count <= 1 {
-        return 0;
-    }
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_nanos());
-    (nanos % u128::from(window_count)) as u32
-}
 
 /// NULL `album_key` rows never merge — fall back to a per-server album id.
 pub(crate) const ALBUM_DEDUP_KEY: &str = "CASE WHEN ck.album_key IS NOT NULL THEN ck.album_key \

--- a/src-tauri/crates/psysonic-library/src/scope_merge/tests/support.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge/tests/support.rs
@@ -11,13 +11,6 @@ use crate::store::LibraryStore;
 use rusqlite::params_from_iter;
 use rusqlite::types::Value as SqlValue;
 
-#[test]
-fn random_window_offset_stays_within_a_full_page_range() {
-    assert_eq!(random_window_offset(0, 6), 0);
-    assert_eq!(random_window_offset(6, 6), 0);
-    assert!(random_window_offset(100, 6) <= 94);
-}
-
 fn scope_pair(server: &str, lib: &str) -> LibraryScopePair {
     LibraryScopePair {
         server_id: server.into(),

--- a/src-tauri/crates/psysonic-library/src/scope_merge/track_browse.rs
+++ b/src-tauri/crates/psysonic-library/src/scope_merge/track_browse.rs
@@ -5,7 +5,7 @@ use super::browse_lists::{artist_row_to_dto, map_artist_list_row};
 use super::common::{
     album_row_to_dto, append_extra_where, ensure_cluster_keys_for_all_scopes,
     finish_scope_album_list, map_album_list_row, merge_binds, non_empty_scopes,
-    plain_track_columns_sql, random_window_offset, scope_cte_sql, scoped_track_join,
+    plain_track_columns_sql, scope_cte_sql, scoped_track_join,
     scoped_track_join_layer1, ALBUM_DEDUP_KEY, ALBUM_PICK_KEY, ARTIST_DEDUP_KEY, ARTIST_PICK_KEY,
     TRACK_DEDUP_KEY, TRACK_FTS_BM25_RANK,
 };
@@ -13,6 +13,37 @@ use crate::dto::{LibraryAlbumDto, LibraryArtistDto, LibraryScopePair, LibraryTra
 use crate::repos::row_to_track_row;
 use crate::search::{aliased_track_columns, PAGE_LIMIT_MAX};
 use crate::store::LibraryStore;
+
+/// Ordering for the unfiltered random track sample across more than one scope.
+///
+/// The single-scope path samples by drawing a rowid pivot per row, which it can
+/// do because it queries `track` directly. Here the rows come out of the scope
+/// CTE, and that CTE is part of the statement: repeating it once per draw was
+/// measured at 9.2–10.1 s for thirteen rows across three folders of a 154k-track
+/// library, against 0.68–0.75 s for shuffling the CTE once (release build,
+/// `perf_probe::multi_folder_random_sample_shapes_on_a_real_library`). So this
+/// path shuffles.
+///
+/// What it replaces picked one offset into the matching set and returned an
+/// unordered page from it — a run of neighbouring rows, which is one album in
+/// track order once ingest has written the catalog album by album (#1446). That
+/// also needed a `COUNT(*)` to size the window; shuffling does not.
+const RANDOM_SAMPLE_ORDER_SQL: &str = "ORDER BY RANDOM()";
+
+/// Ordering for a track page: shuffled for the unfiltered random sample, the
+/// caller's clause otherwise.
+///
+/// Split out so the choice can be asserted directly. Asserting it through
+/// returned rows does not work — without an `ORDER BY`, SQLite guarantees no
+/// order at all, so an "is it shuffled" check on the output can pass while the
+/// clause is missing.
+pub(crate) fn random_sample_order_sql(random_window: bool, order_sql: &str) -> &str {
+    if random_window {
+        RANDOM_SAMPLE_ORDER_SQL
+    } else {
+        order_sql
+    }
+}
 
 /// Layer-1 scoped track browse — sargable join, no cross-library dedup window.
 #[allow(clippy::too_many_arguments)]
@@ -39,7 +70,7 @@ pub(crate) fn list_tracks_layer1_filtered(
         aliased_track_columns("t")
     };
 
-    let matching_total = if skip_totals && !random_window {
+    let matching_total = if skip_totals {
         0u32
     } else {
         let count_sql = format!("{cte} SELECT COUNT(*) {base_where}");
@@ -51,12 +82,8 @@ pub(crate) fn list_tracks_layer1_filtered(
     };
 
     let total = if skip_totals { 0 } else { matching_total };
-    let page_offset = if random_window {
-        random_window_offset(matching_total, limit)
-    } else {
-        offset
-    };
-    let page_order = if random_window { "" } else { order_sql };
+    let page_offset = if random_window { 0 } else { offset };
+    let page_order = random_sample_order_sql(random_window, order_sql);
 
     let sql = format!("{cte} SELECT {cols} {base_where} {page_order} LIMIT ? OFFSET ?");
     binds.push(SqlValue::Integer(i64::from(limit)));
@@ -247,7 +274,7 @@ pub(crate) fn list_tracks_filtered(
     };
     let plain_cols = plain_track_columns_sql();
 
-    let matching_total = if skip_totals && !random_window {
+    let matching_total = if skip_totals {
         0u32
     } else {
         let count_sql = format!(
@@ -263,12 +290,8 @@ pub(crate) fn list_tracks_filtered(
     };
 
     let total = if skip_totals { 0 } else { matching_total };
-    let page_offset = if random_window {
-        random_window_offset(matching_total, limit)
-    } else {
-        offset
-    };
-    let page_order = if random_window { "" } else { order_sql };
+    let page_offset = if random_window { 0 } else { offset };
+    let page_order = random_sample_order_sql(random_window, order_sql);
 
     let sql = format!(
         "{cte}, \

--- a/src/lib/library/browseTextSearch.ts
+++ b/src/lib/library/browseTextSearch.ts
@@ -439,7 +439,9 @@ import { runLocalAlbumBrowse, type AlbumBrowseQuery } from './albumBrowseLoad';
 import { GENRE_ALBUM_FETCH_LIMIT } from './albumBrowseTypes';
 
 /**
- * Random track sample from the local `track` table using the backend's bounded window path.
+ * Random track sample from the local `track` table. The backend samples one
+ * folder by drawing a rowid pivot per row and more than one by shuffling the
+ * scoped set, so every selected folder is passed along.
  * Returns null when the index is unavailable (caller falls back to the network).
  */
 export async function runLocalRandomSongs(


### PR DESCRIPTION
## Summary

- Draw one rowid pivot per row instead of one for the whole page, so the bounded random track sample actually mixes.
- Skip a repeated draw rather than returning the same track twice, top up the page when the attempt budget runs out, and stop when the catalog is smaller than the page instead of spinning.
- Shuffle the multi-folder path instead of returning a window into it, so Discover Songs mixes for a multi-folder home too.
- Pivot generation is injectable, which is what makes the spread assertable on pinned draws rather than statistically.

Ingest writes a catalog album by album, so a run of rowids is one album in track order. Reading `limit` consecutive rows from a single pivot was never a poorly shuffled sample — it was a slice that was never shuffled.

Closes #1446

## Measured on a real library

A `.backup` copy of a 153,982-track library, largest scope, the real request shape (`sort: random`, `skipTotals`, offset 0, no filters). Release build; the probes are committed as `#[ignore]` tests in `perf_probe.rs`.

One music folder — `discover_songs_sample_spread_on_a_real_library`, twelve runs. This probe compares SQL shapes at 13 rows on one column, below the production page size:

| shape | distinct albums per 13 songs | elapsed |
|---|---|---|
| this change | **13 of 13** in every run | 10–12 ms |
| previous | 1.92 mean, range 1–3 | 8–11 ms |
| `ORDER BY RANDOM()` | 13 of 13 | 359–454 ms |

The 1.92 matches the 1.84 measured in August on a different snapshot, so the shape of the problem was stable.

Two folders on the same server — `multi_folder_random_sample_shapes_on_a_real_library`, six runs each, at the size Home actually asks for: 18 rows, the full track projection, and the request driven through `run_advanced_search` rather than reproduced as SQL:

| shape | distinct albums per 18 songs | elapsed |
|---|---|---|
| this change, through the planner | **18 of 18** in every run | 375–457 ms |
| previous (count, then one window) | 2.0 mean, range 1–3 | 365–448 ms |
| per-row pivots, as used for one folder | 18 of 18 | 6,323–6,750 ms |

`homeFeedLoader` abandons the local read after 1000 ms, so the worst run leaves roughly 540 ms of headroom, and the shuffle is not slower than the window it replaces.

That last row is why the two paths do not share an implementation. The scope CTE is part of the statement, so a pivot per row repeats it once per draw; querying `track` directly, as the single-folder path does, has no such cost.

**The production request is measured last, deliberately.** On a freshly copied database the first block pays the cold page cache, and that cost belongs to no strategy: measured first, this request reported a 1314 ms outlier followed by ~600 ms runs; measured last, the same code stays in the range above while the pivot block carries the warm-up. Both orders were run to establish that.

## Review findings

From cucadmuh's review of `3f59d24` (round 1):

1. **Multi-folder Discover Songs still used the old window.** Correct, and the two-scope test asserted only row count. The multi-scope and Layer-1 track paths now shuffle; `random_window_offset` is gone with its test. The reviewer's suggestion was to share the per-row sampler — the table above is why that was not done. The new test pins the SQL clause rather than the returned rows: without an `ORDER BY`, SQLite promises no order at all, so an "is it shuffled" assertion on output stays green when the clause is deleted. Verified by mutation, twice.
2. **A short page despite enough eligible rows.** Correct. The sampler now tops up in rowid order when the attempt budget is exhausted, with a pinned test that drives every draw onto the same row and still expects a full page of distinct tracks.
3. **The probe was not a comparable measurement.** Correct. The single-folder probe now uses the same predicate, binds and projection as the request it is compared against, and times the previous shape including its wrap-around.

From the review of `b60fc4de` (round 2):

4. **The multi-folder probe did not model the Home request.** Correct: it shuffled 13 rows of one column while Home asks for 18 and the query carries the whole track row into the DTO. It now runs the production request through the planner at the production page size, with both reference shapes on the same projection. The numbers are in the second table, and they support the changelog line rather than contradicting it. Two stale descriptions went with it: the probe called the replaced window shape the current one, and the frontend comment still described every local random request as the bounded-window path.

## One correction found by an existing test

Calling the clock for each draw returns the same value thirteen times: the picks are microseconds apart and collapse modulo a small rowid span. The first draw still comes from the clock; the rest derive from it.

## Test plan

- `cargo test --workspace --all-targets --no-fail-fast` — the only failure is the known wall-clock ingest budget test, green in isolation. `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Nine tests on this path, six of them new: spread across albums on pinned draws, a repeated draw, an exhausted budget with enough rows left, a catalog smaller than the page, the multi-folder ordering clause, and a full multi-folder page without duplicates.
- Mutation probes: restoring the single-pivot page turns the spread test red with all three rows from one album; dropping the shuffle clause turns the multi-folder test red.

Runtime benchmark: required — captured as the query measurements above rather than through the route harness. The rail sits on home, and home varies by more than a factor of three between identical runs on this machine, so a single-digit millisecond difference cannot surface there; the sample spread it is about does not surface there at all.
