### PR TITLE
chore: harden release automation and toolchain

### DIFF
--- a/.github/workflows/flatpak-release.yml
+++ b/.github/workflows/flatpak-release.yml
@@ -1,6 +1,8 @@
 name: Flatpak Publish
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       release_tag:
@@ -26,12 +28,13 @@ env:
 
 jobs:
   build-and-publish:
+    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'app-v') }}
     runs-on: ubuntu-24.04
     steps:
       - name: check out release source
         uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.test_source_sha || inputs.release_tag || github.sha }}
+          ref: ${{ inputs.test_source_sha || inputs.release_tag || github.event.release.tag_name || github.sha }}
           path: app
           persist-credentials: false
 
@@ -49,7 +52,7 @@ jobs:
         working-directory: flatpak
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
           TEST_SOURCE_SHA: ${{ inputs.test_source_sha }}
         run: |
           set -euo pipefail
@@ -277,7 +280,7 @@ jobs:
           GPG_PUBLIC_KEY: ${{ steps.signing.outputs.public_key }}
           PACKAGE_VERSION: ${{ steps.release.outputs.package_version }}
           PRIMARY_CHANNEL: ${{ steps.release.outputs.channel }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
           SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
           IS_TEST: ${{ steps.release.outputs.is_test }}
         run: |
@@ -388,7 +391,7 @@ jobs:
         env:
           CHANNEL: ${{ steps.release.outputs.channel }}
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
         run: |
           gh release upload "$RELEASE_TAG" \
             Psysonic.flatpak \
@@ -399,7 +402,7 @@ jobs:
 
       - name: upload test bundle artifact
         if: steps.release.outputs.is_test == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: psysonic-flatpak-test-${{ github.run_id }}
           path: |

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -79,7 +79,7 @@ jobs:
         run: npx vitest run --coverage
       - name: hot-path file coverage gate
         run: bash scripts/check-frontend-hot-path-coverage.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: frontend-coverage-lcov
           path: coverage/lcov.info

--- a/.github/workflows/linux-bundle-test.yml
+++ b/.github/workflows/linux-bundle-test.yml
@@ -101,7 +101,7 @@ jobs:
           cd src-tauri/target/release/bundle
           find . \( -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" \) -print0 \
             | tar czf "${GITHUB_WORKSPACE}/psysonic-linux-bundles.tar.gz" --null -T -
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: psysonic-linux-bundles
           path: psysonic-linux-bundles.tar.gz

--- a/.github/workflows/macos-bundle-test.yml
+++ b/.github/workflows/macos-bundle-test.yml
@@ -113,7 +113,7 @@ jobs:
           set -euo pipefail
           tar czf "${GITHUB_WORKSPACE}/Psysonic-${TARGET}.app.tar.gz" \
             -C "src-tauri/target/${TARGET}/release/bundle/macos" Psysonic.app
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: psysonic-macos-${{ inputs.target }}
           path: Psysonic-${{ inputs.target }}.app.tar.gz

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -120,7 +120,7 @@ jobs:
           cargo llvm-cov --workspace --json --output-path target/llvm-cov/cov.json
       - name: hot-path file coverage gate
         run: bash scripts/check-hot-path-coverage.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: rust-coverage-lcov
           path: src-tauri/lcov.info

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -92,33 +92,33 @@ CI builds the Windows installer as an unsigned compile check. The installer that
 
 Step 2 is required for every stable release. The in-app updater reads `releases/latest`, which never resolves to a pre-release, so for an RC it is only needed when testing the updater against that RC directly.
 
-### Flatpak repository publication (manual for RC and stable)
+### Flatpak repository publication (automatic after packaging preparation)
 
-Run this only after **Next Channel** or **Release Channel** has attached all
-artifacts and the exact `app-vX.Y.Z-rc.N` or `app-vX.Y.Z` GitHub Release has
-been published publicly. `Flatpak Publish` rejects draft or otherwise
-unpublished Releases before it reads or changes any Flatpak channel. The
-promotion commit already contains the matching AppStream release entry; do not
-add it after the tag or rewrite the tag.
+**Next Channel** and **Release Channel** create draft GitHub Releases. Prepare
+the Flatpak packaging while the Release is still a draft, after all channel
+artifacts are attached. Publishing the prepared Release triggers **Flatpak
+Publish** automatically. The workflow rejects draft or otherwise unpublished
+Releases before it reads or changes a Flatpak channel. The promotion commit
+already contains the matching AppStream release entry; do not add it after the
+tag or rewrite the tag.
 
-1. Confirm the Release is public:
-   `gh release view app-vX.Y.Z[-rc.N] --json isDraft,publishedAt` must show
-   `isDraft: false` and a non-empty `publishedAt`.
-2. Record the tag commit: `git rev-list -n 1 app-vX.Y.Z[-rc.N]`.
-3. In `Psysonic/flatpak-psysonic`, update both the manifest source commit and
+1. Record the draft tag commit: `git rev-list -n 1 app-vX.Y.Z[-rc.N]`.
+2. In `Psysonic/flatpak-psysonic`, update both the manifest source commit and
    `COMMIT_HASH` to that exact SHA.
-4. Copy the canonical desktop and AppStream metadata from the tagged app tree
+3. Copy the canonical desktop and AppStream metadata from the tagged app tree
    into the packaging repository. The files must remain byte-identical.
-5. Regenerate `generated-sources.json` and `cargo-sources.json` for the pinned
+4. Regenerate `generated-sources.json` and `cargo-sources.json` for the pinned
    commit, then run the packaging validation commands documented in that repo.
-6. Merge the packaging update to its `main` branch. `Flatpak Publish` always
+5. Merge the packaging update to its `main` branch. `Flatpak Publish` always
    checks out packaging from `main` and rejects stale pins or metadata.
-7. Confirm the application repository has all six `OSTREE_SSH_*` deployment
+6. Confirm the application repository has all six `OSTREE_SSH_*` deployment
    secrets and the GPG signing secret, plus the public
    `OSTREE_GPG_FINGERPRINT` repository variable. Run **Flatpak SSH Diagnostics**
    after changing the host, key, known-host entry, account, port, or path.
-8. Run **Flatpak Publish** with the exact published app Release tag.
-9. Verify the bundle assets on the GitHub release and the signed channel under
+7. Publish the draft GitHub Release. Its `release.published` event starts
+   **Flatpak Publish** with the exact tag. Use `workflow_dispatch` with
+   `release_tag` only to retry or recover a failed automatic run.
+8. Verify the bundle assets on the GitHub release and the signed channel under
    `https://flatpak.psysonic.de/<stable|rc>/` before announcing availability.
 
 The supported installation path is per-user. Release instructions and the

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
         in
         pkgs.mkShell {
           packages = with pkgs; [
-            nodejs_22
+            nodejs_24
             rustc
             cargo
             clippy

--- a/nix/upstream-sources.json
+++ b/nix/upstream-sources.json
@@ -1,3 +1,3 @@
 {
-  "npmDepsHash": "sha256-yL8FxAgIVcHWuK4QhTy8eIC+9zk33d5m1ScAov7pCMU="
+  "npmDepsHash": "sha256-QxRkceuzCF6GC+h3F7/NCMsDaNgRVV251/yP2FbeJvA="
 }

--- a/nixos-install.md
+++ b/nixos-install.md
@@ -176,7 +176,7 @@ home.packages = [
 
 From a **flake-enabled** clone of the repo:
 
-- **`nix develop`** — enters the upstream `devShell` (Rust, Node 22, WebKitGTK, GStreamer plugins for the webview, env hooks aligned with `package.json` / Tauri dev).
+- **`nix develop`** — enters the upstream `devShell` (Rust, Node 24, WebKitGTK, GStreamer plugins for the webview, env hooks aligned with `package.json` / Tauri dev).
 - **`nix shell .#devShells.default`** — same packages and hooks without `nix develop`’s subshell semantics.
 
 The flake **`devShell`** uses the same **`nixpkgs`** input as **`packages.psysonic`** (see **`flake.nix`**).

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
-        "@vitest/coverage-v8": "^4.1.8",
+        "@vitest/coverage-v8": "^4.1.11",
         "dependency-cruiser": "^18.0.0",
         "esbuild": "^0.28.1",
         "eslint": "^10.5.0",
@@ -67,10 +67,10 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.0",
         "vite": "^8.0.14",
-        "vitest": "^4.1.8"
+        "vitest": "^4.1.11"
       },
       "engines": {
-        "node": ">=22.22.0"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2539,14 +2539,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
-      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.11",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -2560,8 +2560,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.8",
-        "vitest": "4.1.8"
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -2570,16 +2570,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2588,13 +2588,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2615,9 +2615,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2628,13 +2628,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2642,14 +2642,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2658,9 +2658,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2668,13 +2668,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -3332,9 +3332,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3626,9 +3626,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4795,9 +4795,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
-      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.2.1.tgz",
+      "integrity": "sha512-XrsrhT5sybtKI6wakr2SPOlGZWWYbUXZ7a0jT8/QOeAPau+1X/bSegNe5YR75oJmEZQbKningirmGOEJCIk61Q==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -5296,9 +5296,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5380,9 +5380,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5407,9 +5407,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5711,19 +5711,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -5751,12 +5751,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.53.0-dev",
   "private": true,
   "engines": {
-    "node": ">=22.22.0"
+    "node": ">=24.0.0"
+  },
+  "allowScripts": {
+    "esbuild@0.28.1": true
   },
   "scripts": {
     "check:css-imports": "node scripts/check-css-import-graph.mjs",
@@ -74,7 +77,7 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
-    "@vitest/coverage-v8": "^4.1.8",
+    "@vitest/coverage-v8": "^4.1.11",
     "dependency-cruiser": "^18.0.0",
     "esbuild": "^0.28.1",
     "eslint": "^10.5.0",
@@ -85,7 +88,7 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.0",
     "vite": "^8.0.14",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.11"
   },
   "overrides": {
     "undici": "^7.29.0"

--- a/scripts/sync-flatpak-metainfo-release.test.mjs
+++ b/scripts/sync-flatpak-metainfo-release.test.mjs
@@ -92,6 +92,14 @@ describe('Flatpak build dependencies', () => {
 });
 
 describe('Flatpak GitHub Release publication gate', () => {
+  it('starts automatically when a prepared GitHub Release is published', () => {
+    const source = readFileSync(new URL('../.github/workflows/flatpak-release.yml', import.meta.url), 'utf8');
+
+    assert.match(source, /release:\s*\n\s*types: \[published\]/);
+    assert.match(source, /inputs\.release_tag \|\| github\.event\.release\.tag_name/);
+    assert.match(source, /workflow_dispatch:/);
+  });
+
   it('rejects draft or unpublished releases before deployment planning', () => {
     const source = readFileSync(new URL('../.github/workflows/flatpak-release.yml', import.meta.url), 'utf8');
     const releaseGate = source.indexOf('must be publicly published before its Flatpak channel can update');
@@ -127,4 +135,21 @@ describe('Flatpak GitHub Release publication gate', () => {
     assert.match(source, /commit\/\$EXPECTED_SHA/);
     assert.doesNotMatch(source, /\[ "\$IS_TEST" = false \] && ! grep/);
   });
+});
+
+describe('GitHub artifact action runtime', () => {
+  for (const workflow of [
+    'flatpak-release.yml',
+    'frontend-tests.yml',
+    'linux-bundle-test.yml',
+    'macos-bundle-test.yml',
+    'rust-tests.yml',
+  ]) {
+    it(`${workflow} uses the Node 24 artifact action`, () => {
+      const source = readFileSync(new URL(`../.github/workflows/${workflow}`, import.meta.url), 'utf8');
+
+      assert.match(source, /actions\/upload-artifact@v7/);
+      assert.doesNotMatch(source, /actions\/upload-artifact@v4/);
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- trigger signed Flatpak publication automatically when a prepared GitHub Release is published, while retaining manual recovery dispatch
- move artifact uploads and the Nix development shell to Node 24-compatible tooling
- explicitly approve the pinned esbuild install script and update Vitest to the patched 4.1.11 release
- document the draft-release packaging order and keep the Nix npm dependency hash synchronized

## Verification
- `npx npm@12.0.0 ci --no-audit --no-fund`
- `npm audit --audit-level=moderate`
- `npm run lint`
- `npm run dep:check`
- `npm test`
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`
- `npm run build`
- `actionlint` on all changed workflows
- `nix flake check --no-build`
- recomputed and verified `nix/upstream-sources.json`

## Release notes
- User-visible behavior: none
- Tauri boundary: not touched
- Runtime benchmark: not applicable - CI, release automation, development toolchain, and test dependency changes only