### PR TITLE
docs: prepare 1.53.0 highlights

### DIFF
--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -8,74 +8,86 @@ Within each section, order by **user impact** (most noticeable first) — not PR
 `CHANGELOG.md` keeps strict PR order inside Added / Changed / Fixed.
 
 
-## [1.52.0]
+## [1.53.0]
 
 ## Highlights
 
-### Offline downloads — resume safely on slow connections
+### Native smart playlists — build dynamic playlists in Psysonic
 
-- Original-quality downloads no longer fail merely because a slow server needs more than two minutes. Transfers can continue for as long as data keeps arriving.
-- An interrupted download resumes from a verified partial file instead of starting over. Changed or unsafe responses discard the partial cleanly, while cancellation, disk-space reservations, and concurrent attempts remain protected.
-- Album, artist, playlist, and favourites pins keep every server owner, survive restarts and server-address migrations, and stay cancelled when you remove them.
+- Navidrome smart playlists now appear with a sparkle marker and keep their server-evaluated tracks read-only.
+- Create and edit native rules in Basic, Advanced, or lossless JSON mode, preview matching tracks, and refresh the results from the Playlists page.
+- Availability follows the connected Navidrome version, with a warning when the server cannot keep part of a rule.
 
-### Album catalogue — switch between cards and a detailed table
+### Reliable scrobbling — plays wait until services recover
 
-- **All Albums, New Releases**, and **Lossless** can switch independently between the familiar card grid and a table. Each page remembers its own choice.
-- The table shows cover, title, artist, song count, year, duration, and date added, removes columns gracefully on narrower windows, and sorts from the title and year headers.
-- Song counts, durations, and added dates now remain available across filtered album views. Albums added in the last two days also carry the new-release ribbon on the **All Albums** grid.
+- Plays that cannot reach a Music Network service are kept for up to 14 days and sent automatically when the connection or login recovers.
+- Pending plays survive restarts, and each destination under **Settings → Integrations** shows how many are still waiting.
 
-### Playlists — know what is yours and sort it everywhere
+### Safer desktop updates — install the right build with confidence
 
-- When a server mixes your playlists with everyone else's public lists, the **Playlists** page and sidebar can separate your own, the ones you share, and the ones shared with you. The filter appears only when shared playlists exist.
-- Sidebar playlists show their cover and song count, while playlists without artwork keep the simple list icon.
-- Order the page and sidebar together by name, creation date, or song count. The choice is remembered and still works with folders and search.
+- **Windows:** the update dialog now downloads, verifies, and installs signed updates inside the app, then restarts Psysonic automatically.
+- Supported Flatpak installs now use signed Psysonic repositories with separate stable and release-candidate channels.
+- The Flatpak update dialog follows the installed channel and shows the exact update command.
 
-### Artist pages — every track they perform on
+### Psysonic Rewind — turn your year into a story
 
-- Artist pages now pair the familiar **Popular tracks** ranking with an **All tracks** tab containing every song that artist performs on, including compilations and guest appearances.
-- The complete list is ordered by album, disc, and track number, supports sorting from every column, and lets you choose which metadata columns to show. It loads from the local index only when you open the tab, so the page remains quick to enter.
+- Open **Statistics → Psysonic Rewind** to explore your year in music and export overview, artist, album, or nerd-stats posters.
+- Choose story or square layouts in a dedicated dark poster style with a live preview.
+- Everything is generated locally from your own play history; your listening data stays on your device.
 
-### Scrobbling — choose the threshold or send it now
+### Device Sync — reuse tracks across playlists
 
-- **Settings → Integrations → Music Network** now lets you choose a **25–90%** scrobble threshold; the default remains 50%.
-- Advanced settings can add **Force scrobble** to the player bar and fullscreen player. It shows listening progress and can submit the current track immediately to the media server and every enabled Music Network destination.
+- Albums and playlists on a portable device now share one physical copy of each song instead of duplicating it inside every playlist folder.
+- Existing layouts migrate on the next sync, with recovery support if the device is disconnected before the migration finishes.
 
-### Full Ukrainian interface
+### Album artwork — choose where missing covers come from
 
-- Ukrainian (**Українська**) is available from the language picker on the Login and Settings screens, with the full interface translated.
-- Counts use the correct one, few, and many forms, and Ukrainian Cyrillic is folded consistently when matching the same release across several servers.
+- **Settings → Integrations → Album artwork** lets you enable and reorder the server, Apple Music, and Last.fm as fallback sources.
+- The first enabled source that finds a cover wins.
 
-### Navidrome upgrades — keep local data intact
+### Follow the desktop theme on Linux
 
-- When a newer Navidrome switches albums, artists, and tracks to canonical IDs, Psysonic safely migrates the local library, analysis results, offline downloads, cached covers, and saved app state before completing a full verification sync.
-- The migration resumes after interruption and prevents playback, sync, imports, or background work from seeing a half-converted library. Navidrome 0.63.2 and older servers, and other Subsonic servers, continue as before.
+- Psysonic can follow desktop colour files such as Omarchy's and update its theme within seconds when the desktop theme changes.
+- The generated theme appears under **Settings → Themes**, with a **Follow desktop theme** switch that stays off for existing installs until enabled.
+
+### Ratings and queue controls — act without leaving the list
+
+- Assign 1–5 stars to the current track with optional global shortcuts under **Settings → Input**.
+- Select several tracks in an album, Favourites, or a playlist to rate, favourite, queue, or add all of them at once.
+- Queue rows now include an optional heart for favouriting a track directly.
+
+### Windows mini player — choose a slimmer frame
+
+- **Settings → Appearance** can remove the Windows system title bar from the mini player and replace it with Psysonic's compact draggable bar.
+- The option is off by default, applies immediately, and leaves macOS and Linux behaviour unchanged.
 
 ## Improved
 
-- Hovering a shortened card title or artist now reveals the complete text across album, artist, playlist, radio, song, and offline cards. The tooltip appears only when text is actually truncated and can be disabled under **Settings → Appearance → Display**.
-- Album cards and the offline play button now use the selected language for screen-reader labels instead of always announcing a German word.
-- **Windows:** update notices now wait 12 hours for WinGet moderation instead of two days, making new releases visible roughly a day and a half sooner without pointing at a version WinGet cannot install yet.
-- Help now covers multi-server browsing, Timeline playback, per-address streaming quality, album tables, shared playlists, composers, the visualizer, themes, and background sources, while outdated answers and settings paths have been removed.
+- Subsonic servers that work normally but reject browser-style requests can now be added without failing with a network error.
+- The Artists page remembers whether you prefer grid or list view, including after restarting Psysonic.
+- The optional tour-dates prompt in the info tab can be dismissed permanently and restored later from **Settings → Integrations**.
 
 ## Fixed
 
 ### Playback and audio
 
-- Synced lyrics now follow playback continuously instead of lighting up inconsistently or nearly a second late. Every lyrics view uses the same position, including after seeking while paused.
-- Tracks played in Psysonic update their play count and last played date as soon as the server records the scrobble, including native Navidrome connections.
+- **Linux:** PipeWire playback no longer crackles, drops out, or floods the log with buffer underruns.
+- Resuming after a long pause no longer moves the Now Playing display ahead while the current track is still playing.
+- Unfocused visualizers pause in the background by default and resume when Psysonic regains focus.
 
 ### Browse and library
 
-- Albums, queue rows, playlists, favourites, search results, Random Mix, and Home song cards no longer start dragging after a held press loses or replaces its original row.
-- **Live Search** no longer shows the same artist, album, or song twice when the local index and server response use different forms of the same server identity.
-- Navidrome background sync preserves structured multi-artist credits instead of collapsing them into one comma-joined name.
-- The library selector can choose an individual music folder again after updating from Psysonic 1.50 to 1.51, with invalid saved scope repaired during startup.
-- Album, artist, favourites, and playlist tracklists now show and sort by locally analysed BPM when it is available.
-- Navidrome timestamps with negative UTC offsets populate **New Releases**, favourites, and last played dates again, with safe legacy values repaired gradually in the background.
-- Standard, deluxe, remastered, and other physical versions of an album stay separate, while matching copies of the same version can still merge across servers.
+- Navidrome libraries keep ISRC and MusicBrainz recording IDs again, and existing libraries receive them through a one-time background repair.
+- Library rebuilds remove albums and tracks that were deleted from Navidrome instead of leaving ghost entries.
+- Albums recover release years and dates from servers that report them differently, restoring recently-added and New Releases results.
+- Multi-disc album subtitles from OpenSubsonic appear on Album Detail again.
+- Album pages stay visible while library sync refreshes them in the background.
+- Long playlist pages return to the previous scroll position, and the owner filter now fits beside the sort control.
+- Play count and last played values update on the list where playback started instead of waiting for a page reload.
+- Ratings set from a context menu stay visible, and recommendation cards no longer collapse at narrow widths.
+- Lyrics edited or added on the server can be reloaded from the lyrics pane.
 
 ### Other
 
-- **Linux/KDE Plasma:** Space, F11, and other shortcuts work immediately after returning to Psysonic with Alt+Tab, without requiring an extra click inside the window.
-- Turning off **Show Tray Icon** also disables tray-dependent minimise settings, and unsafe saved combinations are repaired so closing Psysonic cannot leave it hidden with no way to reopen it.
-- Ukrainian settings descriptions include their full security, privacy, source, and playback warnings again.
+- Shared Top Albums and New Albums images show their cover art again.
+- Update dialog buttons wrap instead of running outside the dialog in languages with longer labels.


### PR DESCRIPTION
## Summary
- replace the previous release highlights with a complete `1.53.0` section
- lead with native smart playlists, reliable scrobbling, signed updates, Rewind, and Device Sync improvements
- group user-visible fixes by playback, browse/library, and other surfaces without PR or author metadata

## Verification
- `node scripts/extract-release-section.mjs WHATS_NEW.md 1.53.0`
- `node --test scripts/extract-release-section.test.mjs`
- `npm run prebuild:release-notes`
- `git diff --check`

## Release notes
- Runtime benchmark: not applicable - release-note copy only
- Tauri boundary: not touched