### PR TITLE
ci: generate Flatpak release sources automatically

### DIFF
--- a/.github/workflows/flatpak-release.yml
+++ b/.github/workflows/flatpak-release.yml
@@ -47,9 +47,13 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - name: verify published release, channel and packaging pin
+      - name: set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: verify published release and channel
         id: release
-        working-directory: flatpak
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
@@ -97,10 +101,8 @@ jobs:
             fi
           fi
 
-          EXPECTED_SHA="$(git -C ../app rev-parse HEAD)"
-          MANIFEST_SHA="$(awk '$1 == "url:" && $2 == "https://github.com/Psysonic/psysonic.git" { source = 1; next } source && $1 == "commit:" { print $2; exit }' io.github.psysonic.psysonic.yaml)"
-          MAKEFILE_SHA="$(awk '$1 == "COMMIT_HASH" { print $3; exit }' Makefile)"
-          PACKAGE_VERSION="$(node -p 'require("../app/package.json").version')"
+          EXPECTED_SHA="$(git -C app rev-parse HEAD)"
+          PACKAGE_VERSION="$(node -p 'require("./app/package.json").version')"
 
           if [ "$IS_TEST" = true ] && [ "$TEST_SOURCE_SHA" != "$EXPECTED_SHA" ]; then
             echo "::error::Checked-out source $EXPECTED_SHA does not match test_source_sha $TEST_SOURCE_SHA"
@@ -110,28 +112,6 @@ jobs:
             echo "::error::Release tag $RELEASE_TAG does not match package version $PACKAGE_VERSION"
             exit 1
           fi
-          if [ "$MANIFEST_SHA" != "$EXPECTED_SHA" ]; then
-            echo "::error::Flatpak manifest pins $MANIFEST_SHA, release $RELEASE_TAG points to $EXPECTED_SHA"
-            exit 1
-          fi
-          if [ "$MAKEFILE_SHA" != "$EXPECTED_SHA" ]; then
-            echo "::error::Flatpak Makefile pins $MAKEFILE_SHA, release $RELEASE_TAG points to $EXPECTED_SHA"
-            exit 1
-          fi
-          cmp io.github.psysonic.psysonic.desktop ../app/src-tauri/flatpak/io.github.psysonic.psysonic.desktop
-          cmp io.github.psysonic.psysonic.metainfo.xml ../app/src-tauri/flatpak/io.github.psysonic.psysonic.metainfo.xml
-          if [ "$IS_TEST" = true ]; then
-            PSYSONIC_FLATPAK_METAINFO_PATH="$PWD/io.github.psysonic.psysonic.metainfo.xml" \
-              PSYSONIC_FLATPAK_VERSION="$PACKAGE_VERSION" \
-              PSYSONIC_FLATPAK_ALLOW_DEVELOPMENT=true \
-              PSYSONIC_FLATPAK_DETAILS_URL="https://github.com/$GITHUB_REPOSITORY/commit/$EXPECTED_SHA" \
-              node ../app/scripts/sync-flatpak-metainfo-release.mjs
-          fi
-          if ! grep -Fq "<release version=\"$PACKAGE_VERSION\"" io.github.psysonic.psysonic.metainfo.xml; then
-            echo "::error::Flatpak metainfo has no release entry for $PACKAGE_VERSION"
-            exit 1
-          fi
-
           {
             echo "channel=$CHANNEL"
             echo "is_test=$IS_TEST"
@@ -210,13 +190,47 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y appstream desktop-file-utils flatpak flatpak-builder gnupg jq
+          sudo apt-get install -y appstream desktop-file-utils flatpak flatpak-builder gnupg jq python3-venv
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
           flatpak install --user -y flathub \
             org.gnome.Platform//50 \
             org.gnome.Sdk//50 \
             org.freedesktop.Sdk.Extension.node26//25.08 \
             org.freedesktop.Sdk.Extension.rust-stable//25.08
+
+      - name: prepare Flatpak packaging for selected source
+        env:
+          IS_TEST: ${{ steps.release.outputs.is_test }}
+          PACKAGE_VERSION: ${{ steps.release.outputs.package_version }}
+          SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          node app/scripts/prepare-flatpak-packaging.mjs \
+            --packaging-dir flatpak \
+            --source-dir app \
+            --source-sha "$SOURCE_SHA"
+
+          if [ "$IS_TEST" = true ]; then
+            PSYSONIC_FLATPAK_METAINFO_PATH="$PWD/flatpak/io.github.psysonic.psysonic.metainfo.xml" \
+              PSYSONIC_FLATPAK_VERSION="$PACKAGE_VERSION" \
+              PSYSONIC_FLATPAK_ALLOW_DEVELOPMENT=true \
+              PSYSONIC_FLATPAK_DETAILS_URL="https://github.com/$GITHUB_REPOSITORY/commit/$SOURCE_SHA" \
+              node app/scripts/sync-flatpak-metainfo-release.mjs
+          fi
+          if ! grep -Fq "<release version=\"$PACKAGE_VERSION\"" flatpak/io.github.psysonic.psysonic.metainfo.xml; then
+            echo "::error::Flatpak metainfo has no release entry for $PACKAGE_VERSION"
+            exit 1
+          fi
+
+          GENERATOR_VENV="$RUNNER_TEMP/flatpak-generators"
+          python3 -m venv "$GENERATOR_VENV"
+          "$GENERATOR_VENV/bin/pip" install --disable-pip-version-check \
+            flatpak-node-generator==0.1.1 \
+            flatpak-cargo-generator==0.1.4
+          "$GENERATOR_VENV/bin/flatpak-node-generator" npm app/package-lock.json \
+            -o flatpak/generated-sources.json
+          "$GENERATOR_VENV/bin/flatpak-cargo-generator" -t \
+            -o flatpak/cargo-sources.json app/src-tauri/Cargo.lock
 
       - name: validate desktop metadata
         working-directory: flatpak

--- a/.github/workflows/flatpak-release.yml
+++ b/.github/workflows/flatpak-release.yml
@@ -31,6 +31,13 @@ jobs:
     if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'app-v') }}
     runs-on: ubuntu-24.04
     steps:
+      - name: check out publication tooling
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.repository.default_branch }}
+          path: tooling
+          persist-credentials: false
+
       - name: check out release source
         uses: actions/checkout@v5
         with:
@@ -205,7 +212,7 @@ jobs:
           SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
         run: |
           set -euo pipefail
-          node app/scripts/prepare-flatpak-packaging.mjs \
+          node tooling/scripts/prepare-flatpak-packaging.mjs \
             --packaging-dir flatpak \
             --source-dir app \
             --source-sha "$SOURCE_SHA"
@@ -215,7 +222,7 @@ jobs:
               PSYSONIC_FLATPAK_VERSION="$PACKAGE_VERSION" \
               PSYSONIC_FLATPAK_ALLOW_DEVELOPMENT=true \
               PSYSONIC_FLATPAK_DETAILS_URL="https://github.com/$GITHUB_REPOSITORY/commit/$SOURCE_SHA" \
-              node app/scripts/sync-flatpak-metainfo-release.mjs
+              node tooling/scripts/sync-flatpak-metainfo-release.mjs
           fi
           if ! grep -Fq "<release version=\"$PACKAGE_VERSION\"" flatpak/io.github.psysonic.psysonic.metainfo.xml; then
             echo "::error::Flatpak metainfo has no release entry for $PACKAGE_VERSION"

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -92,33 +92,25 @@ CI builds the Windows installer as an unsigned compile check. The installer that
 
 Step 2 is required for every stable release. The in-app updater reads `releases/latest`, which never resolves to a pre-release, so for an RC it is only needed when testing the updater against that RC directly.
 
-### Flatpak repository publication (automatic after packaging preparation)
+### Flatpak repository publication (automatic)
 
-**Next Channel** and **Release Channel** create draft GitHub Releases. Prepare
-the Flatpak packaging while the Release is still a draft, after all channel
-artifacts are attached. Publishing the prepared Release triggers **Flatpak
-Publish** automatically. The workflow rejects draft or otherwise unpublished
-Releases before it reads or changes a Flatpak channel. The promotion commit
-already contains the matching AppStream release entry; do not add it after the
-tag or rewrite the tag.
+**Next Channel** and **Release Channel** create draft GitHub Releases. Publishing
+the Release triggers **Flatpak Publish** automatically. The workflow checks out
+the exact tag, prepares a temporary packaging checkout, copies canonical desktop
+metadata, and regenerates npm/Cargo offline sources before building. No separate
+packaging commit or manual source pin is required. The workflow rejects draft or
+otherwise unpublished Releases before it reads or changes a Flatpak channel.
+The promotion commit already contains the matching AppStream release entry; do
+not add it after the tag or rewrite the tag.
 
-1. Record the draft tag commit: `git rev-list -n 1 app-vX.Y.Z[-rc.N]`.
-2. In `Psysonic/flatpak-psysonic`, update both the manifest source commit and
-   `COMMIT_HASH` to that exact SHA.
-3. Copy the canonical desktop and AppStream metadata from the tagged app tree
-   into the packaging repository. The files must remain byte-identical.
-4. Regenerate `generated-sources.json` and `cargo-sources.json` for the pinned
-   commit, then run the packaging validation commands documented in that repo.
-5. Merge the packaging update to its `main` branch. `Flatpak Publish` always
-   checks out packaging from `main` and rejects stale pins or metadata.
-6. Confirm the application repository has all six `OSTREE_SSH_*` deployment
+1. Confirm the application repository has all six `OSTREE_SSH_*` deployment
    secrets and the GPG signing secret, plus the public
    `OSTREE_GPG_FINGERPRINT` repository variable. Run **Flatpak SSH Diagnostics**
    after changing the host, key, known-host entry, account, port, or path.
-7. Publish the draft GitHub Release. Its `release.published` event starts
+2. Publish the draft GitHub Release. Its `release.published` event starts
    **Flatpak Publish** with the exact tag. Use `workflow_dispatch` with
    `release_tag` only to retry or recover a failed automatic run.
-8. Verify the bundle assets on the GitHub release and the signed channel under
+3. Verify the bundle assets on the GitHub release and the signed channel under
    `https://flatpak.psysonic.de/<stable|rc>/` before announcing availability.
 
 The supported installation path is per-user. Release instructions and the
@@ -132,12 +124,11 @@ verification path before the first RC/stable publication. Leave `release_tag`
 empty. The input must be an exact 40-character application commit SHA.
 For safety, it must also equal the current `main` head when the workflow starts.
 
-The packaging repository `main` branch must pin that same SHA and contain
-byte-identical desktop/AppStream metadata plus regenerated npm/Cargo offline
-sources. The workflow publishes only `https://flatpak.psysonic.de/test/`, does
-not read or update `stable` or `rc`, and uploads its bundle as a workflow
-artifact instead of modifying a GitHub Release. Remove the test channel from the
-server after validation if it is no longer needed.
+The workflow prepares the packaging checkout and offline sources from that SHA
+automatically. It publishes only `https://flatpak.psysonic.de/test/`, does not
+read or update `stable` or `rc`, and uploads its bundle as a workflow artifact
+instead of modifying a GitHub Release. Remove the test channel from the server
+after validation if it is no longer needed.
 
 ### Step E: Move `main` forward
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dep:check:barrels": "node scripts/check-feature-barrel-ui.mjs",
     "check:boot-chunks": "node scripts/check-boot-chunk-lucide.mjs",
     "build:verify": "npm run build && npm run check:boot-chunks",
-    "test": "npm run prebuild:release-notes && vitest run && node --test scripts/extract-release-section.test.mjs scripts/wix-bundle-version.test.mjs scripts/sync-version-pipeline.test.mjs scripts/sync-flatpak-metainfo-release.test.mjs scripts/deploy-flatpak-ssh.test.mjs scripts/sign-windows-updater.test.mjs && npm run check:css-imports && npm run dep:check:barrels",
+    "test": "npm run prebuild:release-notes && vitest run && node --test scripts/extract-release-section.test.mjs scripts/wix-bundle-version.test.mjs scripts/sync-version-pipeline.test.mjs scripts/sync-flatpak-metainfo-release.test.mjs scripts/prepare-flatpak-packaging.test.mjs scripts/deploy-flatpak-ssh.test.mjs scripts/sign-windows-updater.test.mjs && npm run check:css-imports && npm run dep:check:barrels",
     "test:watch": "vitest",
     "test:coverage": "npm run prebuild:release-notes && vitest run --coverage && npm run check:css-imports"
   },

--- a/scripts/prepare-flatpak-packaging.mjs
+++ b/scripts/prepare-flatpak-packaging.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import { copyFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const manifestName = 'io.github.psysonic.psysonic.yaml';
+const desktopName = 'io.github.psysonic.psysonic.desktop';
+const metainfoName = 'io.github.psysonic.psysonic.metainfo.xml';
+
+function replaceRequired(source, pattern, replacement, description) {
+  if (!pattern.test(source)) {
+    throw new Error(`Flatpak packaging has no ${description} insertion point`);
+  }
+  return source.replace(pattern, replacement);
+}
+
+export function prepareFlatpakPackaging({ packagingDir, sourceDir, sourceSha }) {
+  if (!/^[0-9a-f]{40}$/i.test(sourceSha)) {
+    throw new Error(`Flatpak source SHA must be an exact 40-character commit SHA, got ${sourceSha}`);
+  }
+
+  const manifestPath = resolve(packagingDir, manifestName);
+  const makefilePath = resolve(packagingDir, 'Makefile');
+  const manifest = replaceRequired(
+    readFileSync(manifestPath, 'utf8'),
+    /(^\s*url:\s+https:\/\/github\.com\/Psysonic\/psysonic\.git[ \t]*$\n^\s*commit:\s*)[0-9a-f]{40}[ \t]*$/m,
+    `$1${sourceSha}`,
+    'Psysonic manifest source',
+  );
+  const makefile = replaceRequired(
+    readFileSync(makefilePath, 'utf8'),
+    /^(COMMIT_HASH\s*(?::|\?|\+)?=\s*)[0-9a-f]{40}[ \t]*$/m,
+    `$1${sourceSha}`,
+    'COMMIT_HASH',
+  );
+
+  writeFileSync(manifestPath, manifest);
+  writeFileSync(makefilePath, makefile);
+  copyFileSync(resolve(sourceDir, 'src-tauri/flatpak', desktopName), resolve(packagingDir, desktopName));
+  copyFileSync(resolve(sourceDir, 'src-tauri/flatpak', metainfoName), resolve(packagingDir, metainfoName));
+}
+
+function argumentValue(name) {
+  const index = process.argv.indexOf(name);
+  if (index < 0 || !process.argv[index + 1]) {
+    throw new Error(`Missing required argument ${name}`);
+  }
+  return process.argv[index + 1];
+}
+
+function main() {
+  const packagingDir = resolve(argumentValue('--packaging-dir'));
+  const sourceDir = resolve(argumentValue('--source-dir'));
+  const sourceSha = argumentValue('--source-sha');
+  prepareFlatpakPackaging({ packagingDir, sourceDir, sourceSha });
+  console.log(`Flatpak packaging prepared for ${sourceSha}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main();
+}

--- a/scripts/prepare-flatpak-packaging.test.mjs
+++ b/scripts/prepare-flatpak-packaging.test.mjs
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { prepareFlatpakPackaging } from './prepare-flatpak-packaging.mjs';
+
+describe('prepareFlatpakPackaging', () => {
+  it('pins the selected source and copies canonical desktop metadata', () => {
+    const root = mkdtempSync(join(tmpdir(), 'psysonic-flatpak-'));
+    const packagingDir = join(root, 'flatpak');
+    const sourceDir = join(root, 'app');
+    const metadataDir = join(sourceDir, 'src-tauri', 'flatpak');
+    const sourceSha = '1234567890abcdef1234567890abcdef12345678';
+
+    try {
+      mkdirSync(packagingDir, { recursive: true });
+      mkdirSync(metadataDir, { recursive: true });
+      writeFileSync(
+        join(packagingDir, 'io.github.psysonic.psysonic.yaml'),
+        'sources:\n  - type: git\n    url: https://github.com/Psysonic/psysonic.git\n    commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n',
+      );
+      writeFileSync(join(packagingDir, 'Makefile'), `COMMIT_HASH = ${'a'.repeat(40)}\n`);
+      writeFileSync(join(metadataDir, 'io.github.psysonic.psysonic.desktop'), '[Desktop Entry]\n');
+      writeFileSync(join(metadataDir, 'io.github.psysonic.psysonic.metainfo.xml'), '<component/>\n');
+
+      prepareFlatpakPackaging({ packagingDir, sourceDir, sourceSha });
+
+      assert.match(
+        readFileSync(join(packagingDir, 'io.github.psysonic.psysonic.yaml'), 'utf8'),
+        new RegExp(`commit: ${sourceSha}`),
+      );
+      assert.equal(readFileSync(join(packagingDir, 'Makefile'), 'utf8'), `COMMIT_HASH = ${sourceSha}\n`);
+      assert.equal(
+        readFileSync(join(packagingDir, 'io.github.psysonic.psysonic.desktop'), 'utf8'),
+        '[Desktop Entry]\n',
+      );
+      assert.equal(
+        readFileSync(join(packagingDir, 'io.github.psysonic.psysonic.metainfo.xml'), 'utf8'),
+        '<component/>\n',
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an invalid source SHA before editing files', () => {
+    assert.throws(
+      () => prepareFlatpakPackaging({ packagingDir: '.', sourceDir: '.', sourceSha: 'main' }),
+      /exact 40-character commit SHA/,
+    );
+  });
+});

--- a/scripts/sync-flatpak-metainfo-release.test.mjs
+++ b/scripts/sync-flatpak-metainfo-release.test.mjs
@@ -100,6 +100,23 @@ describe('Flatpak GitHub Release publication gate', () => {
     assert.match(source, /workflow_dispatch:/);
   });
 
+  it('prepares pins, metadata and offline sources from the selected application checkout', () => {
+    const source = readFileSync(new URL('../.github/workflows/flatpak-release.yml', import.meta.url), 'utf8');
+    const preparation = source.indexOf('prepare Flatpak packaging for selected source');
+    const nodeSources = source.indexOf('flatpak-node-generator" npm app/package-lock.json');
+    const cargoSources = source.indexOf('flatpak-cargo-generator" -t');
+    const build = source.indexOf('make build');
+
+    assert.match(source, /prepare-flatpak-packaging\.mjs/);
+    assert.match(source, /flatpak-node-generator==0\.1\.1/);
+    assert.match(source, /flatpak-cargo-generator==0\.1\.4/);
+    assert.doesNotMatch(source, /Flatpak manifest pins/);
+    assert.ok(preparation >= 0, 'workflow must prepare the packaging checkout');
+    assert.ok(preparation < nodeSources, 'workflow must pin the selected source before npm generation');
+    assert.ok(nodeSources < build, 'npm sources must be generated before the Flatpak build');
+    assert.ok(cargoSources < build, 'Cargo sources must be generated before the Flatpak build');
+  });
+
   it('rejects draft or unpublished releases before deployment planning', () => {
     const source = readFileSync(new URL('../.github/workflows/flatpak-release.yml', import.meta.url), 'utf8');
     const releaseGate = source.indexOf('must be publicly published before its Flatpak channel can update');
@@ -124,15 +141,17 @@ describe('Flatpak GitHub Release publication gate', () => {
 
   it('generates test AppStream metadata from the checked-out package version', () => {
     const source = readFileSync(new URL('../.github/workflows/flatpak-release.yml', import.meta.url), 'utf8');
+    const preparation = source.indexOf('prepare-flatpak-packaging.mjs');
     const generation = source.indexOf('PSYSONIC_FLATPAK_ALLOW_DEVELOPMENT=true');
     const validation = source.indexOf('appstreamcli validate --pedantic');
     const build = source.indexOf('make build');
 
-    assert.ok(generation >= 0, 'test publication must generate development AppStream metadata');
+    assert.ok(preparation >= 0, 'test publication must copy canonical AppStream metadata');
+    assert.ok(preparation < generation, 'test metadata generation must run after canonical metadata is copied');
     assert.ok(generation < validation, 'AppStream metadata must be generated before validation');
     assert.ok(generation < build, 'AppStream metadata must be generated before the Flatpak build');
     assert.match(source, /PSYSONIC_FLATPAK_VERSION="\$PACKAGE_VERSION"/);
-    assert.match(source, /commit\/\$EXPECTED_SHA/);
+    assert.match(source, /commit\/\$SOURCE_SHA/);
     assert.doesNotMatch(source, /\[ "\$IS_TEST" = false \] && ! grep/);
   });
 });

--- a/scripts/sync-flatpak-metainfo-release.test.mjs
+++ b/scripts/sync-flatpak-metainfo-release.test.mjs
@@ -107,7 +107,9 @@ describe('Flatpak GitHub Release publication gate', () => {
     const cargoSources = source.indexOf('flatpak-cargo-generator" -t');
     const build = source.indexOf('make build');
 
-    assert.match(source, /prepare-flatpak-packaging\.mjs/);
+    assert.match(source, /check out publication tooling/);
+    assert.match(source, /path: tooling/);
+    assert.match(source, /node tooling\/scripts\/prepare-flatpak-packaging\.mjs/);
     assert.match(source, /flatpak-node-generator==0\.1\.1/);
     assert.match(source, /flatpak-cargo-generator==0\.1\.4/);
     assert.doesNotMatch(source, /Flatpak manifest pins/);
@@ -141,7 +143,7 @@ describe('Flatpak GitHub Release publication gate', () => {
 
   it('generates test AppStream metadata from the checked-out package version', () => {
     const source = readFileSync(new URL('../.github/workflows/flatpak-release.yml', import.meta.url), 'utf8');
-    const preparation = source.indexOf('prepare-flatpak-packaging.mjs');
+    const preparation = source.indexOf('tooling/scripts/prepare-flatpak-packaging.mjs');
     const generation = source.indexOf('PSYSONIC_FLATPAK_ALLOW_DEVELOPMENT=true');
     const validation = source.indexOf('appstreamcli validate --pedantic');
     const build = source.indexOf('make build');


### PR DESCRIPTION
## Summary
- prepare the temporary Flatpak packaging checkout from the exact release tag or test SHA
- copy canonical desktop metadata and regenerate npm/Cargo offline sources with pinned generators before the build
- keep workflow tooling separate from the selected application source so release tags and manual test SHAs remain reproducible
- remove the manual packaging pin/update gate from the release process
- add direct transformation tests and workflow-order regression coverage

## Verification
- `npm run lint`
- `npm run dep:check`
- `npm test`
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`
- `actionlint .github/workflows/flatpak-release.yml`
- `nix flake check --no-build`
- generated both offline source manifests from the current lockfiles with `flatpak-node-generator==0.1.1` and `flatpak-cargo-generator==0.1.4`
- full test-channel build/sign/smoke/deploy succeeded: https://github.com/Psysonic/psysonic/actions/runs/34539954485
- public test metadata confirms source `60dcf84f8353dccedeafa6147e339bd5b1d5fa58`

Runtime benchmark: not applicable - CI and release tooling only. Tauri boundary: not changed.