### PR TITLE
fix(home): fill a rail that is wider than one page of albums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Pausing for more than a minute and then resuming could occasionally move Now Playing to a later track while the audio kept playing the current one.
 * Root cause: a pause that long releases the audio output stream, and rebuilding it on resume briefly reports a position near the start. That looked like the next track beginning, so the queue moved on. A track that has not even reached its halfway mark is no longer treated that way.
 
+### Mainstage rows no longer stop halfway across a wide window
+
+**By [@Psychotoxical](https://github.com/Psychotoxical), reported by zunoz on Discord, PR [#1536](https://github.com/Psysonic/psysonic/pull/1536)**
+
+* On a 4K or dual-screen window the album rows stopped after twelve entries, left the rest of the row empty, and both arrows stayed greyed out — with no way to reach the rest of the section.
+* Root cause: a row only loaded more entries while it was being scrolled, and a row wide enough to show a full page has nothing to scroll. Rows now keep pulling until they are actually full, and the arrows are re-checked when the row itself changes width, such as when the queue panel opens beside it.
+
 ## [1.52.0]
 
 ## Added

--- a/src/features/album/components/AlbumRow.tsx
+++ b/src/features/album/components/AlbumRow.tsx
@@ -6,6 +6,7 @@ import { NavLink, useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { usePerfProbeFlags } from '@/lib/perf/perfFlags';
 import { dedupeById } from '@/lib/util/dedupeById';
+import { useRailScroll } from '@/lib/hooks/useRailScroll';
 
 interface Props {
   title: string;
@@ -58,10 +59,7 @@ export default function AlbumRow({
   const artworkDisabled = perfFlags.disableMainstageRailArtwork || disableArtwork;
   const interactivityDisabled = perfFlags.disableMainstageRailInteractivity || disableInteractivity;
   const { t } = useTranslation();
-  const scrollRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
-  const [showLeft, setShowLeft] = useState(false);
-  const [showRight, setShowRight] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [artworkBudget, setArtworkBudget] = useState(initialArtworkBudget);
 
@@ -69,6 +67,14 @@ export default function AlbumRow({
   const scrollRestoreTargetRef = useRef(restoreScrollLeft);
   const scrollRestoreDoneRef = useRef(false);
   const uniqueAlbums = useMemo(() => dedupeById(albums), [albums]);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Reset when the row’s identity changes (new data / server), not when the list grows via
+  // “load more” — reusing albums.length would shrink the budget mid-scroll and flash placeholders.
+  const firstAlbum = uniqueAlbums[0];
+  const rowArtworkResetKey = firstAlbum
+    ? (firstAlbum.serverId ? `${firstAlbum.serverId}:${firstAlbum.id}` : firstAlbum.id)
+    : '';
 
   const recomputeArtworkBudget = () => {
     if (!windowArtworkByViewport) return;
@@ -86,25 +92,6 @@ export default function AlbumRow({
     setArtworkBudget(prev => (nextBudget > prev ? nextBudget : prev));
   };
 
-  const handleScroll = () => {
-    if (windowArtworkByViewport) recomputeArtworkBudget();
-
-    if (!scrollRef.current) return;
-    const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
-
-    if (!interactivityDisabled) {
-      setShowLeft(scrollLeft > 0);
-      setShowRight(scrollLeft < scrollWidth - clientWidth - 5);
-    }
-
-    onScrollLeftSnapshot?.(scrollLeft);
-
-    // Auto-load trigger (native horizontal scroll still works when rail buttons are perf-disabled)
-    if (onLoadMore && !loadingRef.current && scrollLeft > 0 && scrollLeft + clientWidth >= scrollWidth - 300) {
-      triggerLoadMore();
-    }
-  };
-
   const triggerLoadMore = async () => {
     if (!onLoadMore || loadingRef.current) return;
     loadingRef.current = true;
@@ -114,33 +101,29 @@ export default function AlbumRow({
     loadingRef.current = false;
   };
 
-  useEffect(() => {
-    handleScroll();
-    const raf = window.requestAnimationFrame(() => {
-      if (windowArtworkByViewport) recomputeArtworkBudget();
-    });
-    window.addEventListener('resize', handleScroll);
-    const ro = new ResizeObserver(() => {
-      if (windowArtworkByViewport) recomputeArtworkBudget();
-    });
-    if (scrollRef.current) ro.observe(scrollRef.current);
-    return () => {
-      window.cancelAnimationFrame(raf);
-      window.removeEventListener('resize', handleScroll);
-      ro.disconnect();
-    };
-    // handleScroll/recomputeArtworkBudget are recreated each render but read live
-    // refs/props; the listeners are intentionally (re)bound only when the row data
-    // or artwork config changes, not on every render.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [uniqueAlbums, interactivityDisabled, windowArtworkByViewport, initialArtworkBudget]);
+  const { showLeft, showRight, measure, scrollByPage } = useRailScroll({
+    scrollRef,
+    itemCount: uniqueAlbums.length,
+    resetKey: rowArtworkResetKey,
+    enabled: !interactivityDisabled,
+    onFillWidth: onLoadMore ? triggerLoadMore : undefined,
+    onLayoutChange: recomputeArtworkBudget,
+  });
 
-  // Reset when the row’s identity changes (new data / server), not when the list grows via
-  // “load more” — reusing albums.length would shrink the budget mid-scroll and flash placeholders.
-  const firstAlbum = uniqueAlbums[0];
-  const rowArtworkResetKey = firstAlbum
-    ? (firstAlbum.serverId ? `${firstAlbum.serverId}:${firstAlbum.id}` : firstAlbum.id)
-    : '';
+  const handleScroll = () => {
+    measure();
+
+    if (!scrollRef.current) return;
+    const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
+
+    onScrollLeftSnapshot?.(scrollLeft);
+
+    // Auto-load trigger (native horizontal scroll still works when rail buttons are perf-disabled)
+    if (onLoadMore && !loadingRef.current && scrollLeft > 0 && scrollLeft + clientWidth >= scrollWidth - 300) {
+      triggerLoadMore();
+    }
+  };
+
   useEffect(() => {
     // React Compiler set-state-in-effect rule: local state synced with store/prop inputs when the effect’s dependencies change.
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -219,12 +202,6 @@ export default function AlbumRow({
     onScrollRestoreComplete?.();
   }, [artworkBudget, restoreCompleteTick, onScrollRestoreComplete]);
 
-  const scroll = (dir: 'left' | 'right') => {
-    if (!scrollRef.current) return;
-    const amount = scrollRef.current.clientWidth * 0.75;
-    scrollRef.current.scrollBy({ left: dir === 'left' ? -amount : amount, behavior: 'smooth' });
-  };
-
   if (uniqueAlbums.length === 0) return null;
 
   return (
@@ -243,14 +220,14 @@ export default function AlbumRow({
             <>
               <button
                 className={`nav-btn ${!showLeft ? 'disabled' : ''}`}
-                onClick={() => scroll('left')}
+                onClick={() => scrollByPage('left')}
                 disabled={!showLeft}
               >
                 <ChevronLeft size={20} />
               </button>
               <button
                 className={`nav-btn ${!showRight ? 'disabled' : ''}`}
-                onClick={() => scroll('right')}
+                onClick={() => scrollByPage('right')}
                 disabled={!showRight}
               >
                 <ChevronRight size={20} />

--- a/src/features/artist/components/ArtistRow.tsx
+++ b/src/features/artist/components/ArtistRow.tsx
@@ -1,8 +1,9 @@
 import type { SubsonicArtist } from '@/lib/api/subsonicTypes';
-import React, { useRef, useState, useEffect, useLayoutEffect } from 'react';
+import React, { useRef, useEffect, useLayoutEffect } from 'react';
 import ArtistCardLocal from '@/features/artist/components/ArtistCardLocal';
 import { ChevronLeft, ChevronRight, ArrowRight } from 'lucide-react';
 import { useNavigate } from 'react-router';
+import { useRailScroll } from '@/lib/hooks/useRailScroll';
 
 interface Props {
   title: string;
@@ -25,18 +26,20 @@ export default function ArtistRow({
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
-  const [showLeft, setShowLeft] = useState(false);
-  const [showRight, setShowRight] = useState(true);
   const scrollRestoreTargetRef = useRef(restoreScrollLeft);
   const scrollRestoreDoneRef = useRef(false);
   const rowResetKey = artists[0]?.id ?? '';
 
+  const { showLeft, showRight, measure, scrollByPage } = useRailScroll({
+    scrollRef,
+    itemCount: artists.length,
+    resetKey: rowResetKey,
+  });
+
   const handleScroll = () => {
+    measure();
     if (!scrollRef.current) return;
-    const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
-    setShowLeft(scrollLeft > 0);
-    setShowRight(scrollLeft < scrollWidth - clientWidth - 5);
-    onScrollLeftSnapshot?.(scrollLeft);
+    onScrollLeftSnapshot?.(scrollRef.current.scrollLeft);
   };
 
   useEffect(() => {
@@ -88,21 +91,6 @@ export default function ArtistRow({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rowResetKey, artists.length]);
 
-  useEffect(() => {
-    handleScroll();
-    window.addEventListener('resize', handleScroll);
-    return () => window.removeEventListener('resize', handleScroll);
-    // handleScroll is recreated each render but reads live refs; the resize
-    // listener is intentionally rebound only when the row data changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [artists]);
-
-  const scroll = (dir: 'left' | 'right') => {
-    if (!scrollRef.current) return;
-    const amount = scrollRef.current.clientWidth * 0.75;
-    scrollRef.current.scrollBy({ left: dir === 'left' ? -amount : amount, behavior: 'smooth' });
-  };
-
   if (artists.length === 0) return null;
 
   return (
@@ -110,10 +98,10 @@ export default function ArtistRow({
       <div className="album-row-header">
         <h2 className="section-title" style={{ marginBottom: 0 }}>{title}</h2>
         <div className="album-row-nav">
-          <button className={`nav-btn ${!showLeft ? 'disabled' : ''}`} onClick={() => scroll('left')} disabled={!showLeft}>
+          <button className={`nav-btn ${!showLeft ? 'disabled' : ''}`} onClick={() => scrollByPage('left')} disabled={!showLeft}>
             <ChevronLeft size={20} />
           </button>
-          <button className={`nav-btn ${!showRight ? 'disabled' : ''}`} onClick={() => scroll('right')} disabled={!showRight}>
+          <button className={`nav-btn ${!showRight ? 'disabled' : ''}`} onClick={() => scrollByPage('right')} disabled={!showRight}>
             <ChevronRight size={20} />
           </button>
         </div>

--- a/src/features/favorites/components/RadioFavorites.tsx
+++ b/src/features/favorites/components/RadioFavorites.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useThemeStore } from '@/store/themeStore';
 import { useOverflowTooltip } from '@/lib/hooks/useOverflowTooltip';
@@ -10,6 +10,7 @@ import { COVER_DENSE_GRID_MIN_CELL_CSS_PX } from '@/cover/layoutSizes';
 import { radioStationKey, sameRadioStation } from '@/features/radio';
 import { useAuthStore } from '@/store/authStore';
 import { serverListDisplayLabel } from '@/lib/server/serverDisplayName';
+import { useRailScroll } from '@/lib/hooks/useRailScroll';
 
 interface RadioStationRowProps {
   title: string;
@@ -22,41 +23,32 @@ interface RadioStationRowProps {
 
 export function RadioStationRow({ title, stations, currentRadio, isPlaying, onPlay, onUnfavorite }: RadioStationRowProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [showLeft, setShowLeft] = useState(false);
-  const [showRight, setShowRight] = useState(true);
+  const { showLeft, showRight, measure, scrollByPage } = useRailScroll({
+    scrollRef,
+    itemCount: stations.length,
+    resetKey: stations[0] ? radioStationKey(stations[0]) : '',
+  });
   const servers = useAuthStore(s => s.servers);
   const serverLabelById = useMemo(() => new Map(
     servers.map(server => [server.id, serverListDisplayLabel(server, servers)]),
   ), [servers]);
   const showServerLabels = new Set(stations.map(station => station.serverId).filter(Boolean)).size > 1;
 
-  const handleScroll = () => {
-    if (!scrollRef.current) return;
-    const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
-    setShowLeft(scrollLeft > 0);
-    setShowRight(scrollLeft < scrollWidth - clientWidth - 5);
-  };
-
-  const scroll = (dir: 'left' | 'right') => {
-    if (!scrollRef.current) return;
-    scrollRef.current.scrollBy({ left: dir === 'left' ? -scrollRef.current.clientWidth * 0.75 : scrollRef.current.clientWidth * 0.75, behavior: 'smooth' });
-  };
-
   return (
     <section className="album-row-section">
       <div className="album-row-header">
         <h2 className="section-title" style={{ marginBottom: 0 }}>{title}</h2>
         <div className="album-row-nav">
-          <button className={`nav-btn${!showLeft ? ' disabled' : ''}`} onClick={() => scroll('left')} disabled={!showLeft}>
+          <button className={`nav-btn${!showLeft ? ' disabled' : ''}`} onClick={() => scrollByPage('left')} disabled={!showLeft}>
             <ChevronLeft size={20} />
           </button>
-          <button className={`nav-btn${!showRight ? ' disabled' : ''}`} onClick={() => scroll('right')} disabled={!showRight}>
+          <button className={`nav-btn${!showRight ? ' disabled' : ''}`} onClick={() => scrollByPage('right')} disabled={!showRight}>
             <ChevronRight size={20} />
           </button>
         </div>
       </div>
       <div className="album-grid-wrapper">
-        <div className="album-grid" ref={scrollRef} onScroll={handleScroll}>
+        <div className="album-grid" ref={scrollRef} onScroll={measure}>
           {stations.map(s => (
             <RadioFavCard
               key={radioStationKey(s)}

--- a/src/features/favorites/components/TopFavoriteArtists.tsx
+++ b/src/features/favorites/components/TopFavoriteArtists.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ChevronRight, Users } from 'lucide-react';
 import { ArtistCoverArtImage } from '@/cover/ArtistCoverArtImage';
@@ -6,6 +6,7 @@ import { COVER_DENSE_GRID_MIN_CELL_CSS_PX } from '@/cover/layoutSizes';
 import { coverServerScopeForServerId } from '@/cover/serverScope';
 import { useThemeStore } from '@/store/themeStore';
 import { useOverflowTooltip } from '@/lib/hooks/useOverflowTooltip';
+import { useRailScroll } from '@/lib/hooks/useRailScroll';
 
 export interface TopFavoriteArtist {
   id: string;
@@ -28,44 +29,28 @@ interface TopFavoriteArtistsRowProps {
 export function TopFavoriteArtistsRow({ title, artists, selectedKey, onToggle }: TopFavoriteArtistsRowProps) {
   const { t } = useTranslation();
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [showLeft, setShowLeft] = useState(false);
-  const [showRight, setShowRight] = useState(true);
-
-  const handleScroll = () => {
-    if (!scrollRef.current) return;
-    const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
-    setShowLeft(scrollLeft > 0);
-    setShowRight(scrollLeft < scrollWidth - clientWidth - 5);
-  };
-
-  useEffect(() => {
-    handleScroll();
-    window.addEventListener('resize', handleScroll);
-    return () => window.removeEventListener('resize', handleScroll);
-  }, [artists]);
-
-  const scroll = (dir: 'left' | 'right') => {
-    if (!scrollRef.current) return;
-    const amount = scrollRef.current.clientWidth * 0.75;
-    scrollRef.current.scrollBy({ left: dir === 'left' ? -amount : amount, behavior: 'smooth' });
-  };
+  const { showLeft, showRight, measure, scrollByPage } = useRailScroll({
+    scrollRef,
+    itemCount: artists.length,
+    resetKey: artists[0]?.id ?? '',
+  });
 
   return (
     <section className="album-row-section">
       <div className="album-row-header">
         <h2 className="section-title" style={{ marginBottom: 0 }}>{title}</h2>
         <div className="album-row-nav">
-          <button className={`nav-btn ${!showLeft ? 'disabled' : ''}`} onClick={() => scroll('left')} disabled={!showLeft}>
+          <button className={`nav-btn ${!showLeft ? 'disabled' : ''}`} onClick={() => scrollByPage('left')} disabled={!showLeft}>
             <ChevronLeft size={20} />
           </button>
-          <button className={`nav-btn ${!showRight ? 'disabled' : ''}`} onClick={() => scroll('right')} disabled={!showRight}>
+          <button className={`nav-btn ${!showRight ? 'disabled' : ''}`} onClick={() => scrollByPage('right')} disabled={!showRight}>
             <ChevronRight size={20} />
           </button>
         </div>
       </div>
 
       <div className="album-grid-wrapper">
-        <div className="album-grid" ref={scrollRef} onScroll={handleScroll}>
+        <div className="album-grid" ref={scrollRef} onScroll={measure}>
           {artists.map(a => (
             <TopFavoriteArtistCard
               key={a.id}

--- a/src/features/home/components/SongRail.tsx
+++ b/src/features/home/components/SongRail.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react';
 import SongCard from '@/features/home/components/SongCard';
 import { usePerfProbeFlags } from '@/lib/perf/perfFlags';
 import { dedupeById } from '@/lib/util/dedupeById';
+import { useRailScroll } from '@/lib/hooks/useRailScroll';
 
 interface Props {
   title: string;
@@ -38,9 +39,12 @@ export default function SongRail({
   const interactivityDisabled = perfFlags.disableMainstageRailInteractivity || disableInteractivity;
   const scrollRef = useRef<HTMLDivElement>(null);
   const uniqueSongs = useMemo(() => dedupeById(songs), [songs]);
-  const [showLeft, setShowLeft] = useState(false);
-  const [showRight, setShowRight] = useState(true);
   const [artworkBudget, setArtworkBudget] = useState(initialArtworkBudget);
+
+  const firstSong = uniqueSongs[0];
+  const rowArtworkResetKey = firstSong
+    ? (firstSong.serverId ? `${firstSong.serverId}:${firstSong.id}` : firstSong.id)
+    : '';
 
   const recomputeArtworkBudget = () => {
     if (!windowArtworkByViewport) return;
@@ -57,54 +61,19 @@ export default function SongRail({
     setArtworkBudget(prev => (nextBudget > prev ? nextBudget : prev));
   };
 
-  const handleScroll = () => {
-    if (windowArtworkByViewport) recomputeArtworkBudget();
+  const { showLeft, showRight, measure, scrollByPage } = useRailScroll({
+    scrollRef,
+    itemCount: uniqueSongs.length,
+    resetKey: rowArtworkResetKey,
+    enabled: !interactivityDisabled,
+    onLayoutChange: recomputeArtworkBudget,
+  });
 
-    if (!scrollRef.current) return;
-    const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
-
-    if (!interactivityDisabled) {
-      setShowLeft(scrollLeft > 0);
-      setShowRight(scrollLeft < scrollWidth - clientWidth - 5);
-    }
-  };
-
-  useEffect(() => {
-    handleScroll();
-    const raf = window.requestAnimationFrame(() => {
-      if (windowArtworkByViewport) recomputeArtworkBudget();
-    });
-    window.addEventListener('resize', handleScroll);
-    const ro = new ResizeObserver(() => {
-      if (windowArtworkByViewport) recomputeArtworkBudget();
-    });
-    if (scrollRef.current) ro.observe(scrollRef.current);
-    return () => {
-      window.cancelAnimationFrame(raf);
-      window.removeEventListener('resize', handleScroll);
-      ro.disconnect();
-    };
-    // handleScroll/recomputeArtworkBudget are recreated each render but read live
-    // refs/props; the listeners are intentionally (re)bound only when the row data
-    // or artwork config changes, not on every render.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [uniqueSongs, interactivityDisabled, windowArtworkByViewport, initialArtworkBudget]);
-
-  const firstSong = uniqueSongs[0];
-  const rowArtworkResetKey = firstSong
-    ? (firstSong.serverId ? `${firstSong.serverId}:${firstSong.id}` : firstSong.id)
-    : '';
   useEffect(() => {
     // React Compiler set-state-in-effect rule: state set from a DOM/layout measurement.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setArtworkBudget(initialArtworkBudget);
   }, [initialArtworkBudget, rowArtworkResetKey]);
-
-  const scroll = (dir: 'left' | 'right') => {
-    if (!scrollRef.current) return;
-    const amount = scrollRef.current.clientWidth * 0.75;
-    scrollRef.current.scrollBy({ left: dir === 'left' ? -amount : amount, behavior: 'smooth' });
-  };
 
   // Hide rail entirely if empty and no empty-state copy
   if (uniqueSongs.length === 0 && !loading && !emptyText) return null;
@@ -130,14 +99,14 @@ export default function SongRail({
             <>
               <button
                 className={`nav-btn ${!showLeft ? 'disabled' : ''}`}
-                onClick={() => scroll('left')}
+                onClick={() => scrollByPage('left')}
                 disabled={!showLeft}
               >
                 <ChevronLeft size={20} />
               </button>
               <button
                 className={`nav-btn ${!showRight ? 'disabled' : ''}`}
-                onClick={() => scroll('right')}
+                onClick={() => scrollByPage('right')}
                 disabled={!showRight}
               >
                 <ChevronRight size={20} />
@@ -151,7 +120,7 @@ export default function SongRail({
         {uniqueSongs.length === 0 && emptyText ? (
           <p className="song-row-empty">{emptyText}</p>
         ) : (
-          <div className="song-grid" ref={scrollRef} onScroll={handleScroll}>
+          <div className="song-grid" ref={scrollRef} onScroll={measure}>
             {uniqueSongs.map((s, idx) => (
               <SongCard
                 key={s.serverId ? `${s.serverId}:${s.id}` : s.id}

--- a/src/lib/hooks/useRailScroll.test.ts
+++ b/src/lib/hooks/useRailScroll.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useRailScroll } from './useRailScroll';
+import { latestResizeObserver } from '@/test/mocks/browser';
+
+/**
+ * jsdom does no layout, so the scroll box is described explicitly. The numbers
+ * mirror a real Mainstage row: twelve 180px cards with 16px gaps is 2336px of
+ * content, which fits inside a rail on a wide screen and overflows a narrow one.
+ */
+function railElement(scrollWidth: number, clientWidth: number, scrollLeft = 0) {
+  const el = document.createElement('div');
+  for (const [prop, value] of [
+    ['scrollWidth', scrollWidth],
+    ['clientWidth', clientWidth],
+    ['scrollLeft', scrollLeft],
+  ] as const) {
+    Object.defineProperty(el, prop, { value, configurable: true, writable: true });
+  }
+  return el;
+}
+
+/** The hook measures inside `requestAnimationFrame`; a microtask is too early. */
+async function settleFrame() {
+  await act(async () => { await new Promise(resolve => setTimeout(resolve, 32)); });
+}
+
+const FULL_ROW = 2336;
+const WIDE_RAIL = 3500;
+const NARROW_RAIL = 1200;
+
+describe('useRailScroll', () => {
+  it('pulls another page when the row does not fill its width', async () => {
+    const el = railElement(FULL_ROW, WIDE_RAIL);
+    const ref = { current: el };
+    const onFillWidth = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => useRailScroll({
+      scrollRef: ref,
+      itemCount: 12,
+      onFillWidth,
+    }));
+
+    await waitFor(() => expect(onFillWidth).toHaveBeenCalledTimes(1));
+  });
+
+  it('leaves an overflowing row alone', async () => {
+    const el = railElement(5000, NARROW_RAIL);
+    const ref = { current: el };
+    const onFillWidth = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => useRailScroll({
+      scrollRef: ref,
+      itemCount: 12,
+      onFillWidth,
+    }));
+
+    await settleFrame();
+    expect(onFillWidth).not.toHaveBeenCalled();
+  });
+
+  it('stops asking once a round brings nothing new', async () => {
+    const el = railElement(FULL_ROW, WIDE_RAIL);
+    const ref = { current: el };
+    const onFillWidth = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => useRailScroll({
+      scrollRef: ref,
+      itemCount: 12,
+      onFillWidth,
+    }));
+    await waitFor(() => expect(onFillWidth).toHaveBeenCalledTimes(1));
+
+    // The section had no more rows, so the count is unchanged. A resize must not
+    // restart the paging.
+    act(() => latestResizeObserver()?.emit());
+    await settleFrame();
+    expect(onFillWidth).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps paging while each round adds rows', async () => {
+    const el = railElement(FULL_ROW, WIDE_RAIL);
+    const ref = { current: el };
+    const onFillWidth = vi.fn().mockResolvedValue(undefined);
+
+    const { rerender } = renderHook(
+      ({ itemCount }) => useRailScroll({ scrollRef: ref, itemCount, onFillWidth }),
+      { initialProps: { itemCount: 12 } },
+    );
+    await waitFor(() => expect(onFillWidth).toHaveBeenCalledTimes(1));
+
+    rerender({ itemCount: 24 });
+    await waitFor(() => expect(onFillWidth).toHaveBeenCalledTimes(2));
+  });
+
+  it('gives up after the fill budget instead of paging forever', async () => {
+    const el = railElement(FULL_ROW, WIDE_RAIL);
+    const ref = { current: el };
+    const onFillWidth = vi.fn().mockResolvedValue(undefined);
+
+    const { rerender } = renderHook(
+      ({ itemCount }) => useRailScroll({ scrollRef: ref, itemCount, onFillWidth }),
+      { initialProps: { itemCount: 12 } },
+    );
+
+    for (const itemCount of [24, 36, 48, 60, 72]) {
+      await settleFrame();
+      rerender({ itemCount });
+    }
+    await settleFrame();
+
+    expect(onFillWidth.mock.calls.length).toBeLessThanOrEqual(4);
+  });
+
+  it('disables the next arrow when everything already fits', async () => {
+    const el = railElement(FULL_ROW, WIDE_RAIL);
+    const ref = { current: el };
+
+    const { result } = renderHook(() => useRailScroll({
+      scrollRef: ref,
+      itemCount: 12,
+    }));
+
+    await waitFor(() => expect(result.current.showRight).toBe(false));
+    expect(result.current.showLeft).toBe(false);
+  });
+
+  it('re-arms the arrow when the rail itself gets narrower', async () => {
+    const el = railElement(FULL_ROW, WIDE_RAIL);
+    const ref = { current: el };
+
+    const { result } = renderHook(() => useRailScroll({
+      scrollRef: ref,
+      itemCount: 12,
+    }));
+    await waitFor(() => expect(result.current.showRight).toBe(false));
+    // Let the mount frame settle first, so the assertion below can only be
+    // satisfied by the resize path.
+    await act(async () => { await new Promise(resolve => setTimeout(resolve, 32)); });
+
+    // The window did not change — the queue panel opened beside the row.
+    Object.defineProperty(el, 'clientWidth', { value: NARROW_RAIL, configurable: true, writable: true });
+    act(() => latestResizeObserver()?.emit());
+
+    await waitFor(() => expect(result.current.showRight).toBe(true));
+  });
+});

--- a/src/lib/hooks/useRailScroll.ts
+++ b/src/lib/hooks/useRailScroll.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Tolerance in px before a rail counts as scrollable. Sub-pixel layout rounding
+ * would otherwise arm the "next" arrow on a row that has nothing to reveal.
+ */
+const RAIL_OVERFLOW_SLACK_PX = 5;
+
+/**
+ * How often a row may pull another page to cover its own width before giving up.
+ * A wide window fits far more cards than one page holds; without a cap a very
+ * wide monitor would keep paging until the section is exhausted.
+ */
+const MAX_AUTO_FILL_ROUNDS = 4;
+
+export interface UseRailScrollOptions {
+  /** The scrolling `.album-grid` element. Owned by the row so its other
+      measurements (artwork windowing, scroll restore) can read it too. */
+  scrollRef: React.RefObject<HTMLDivElement | null>;
+  /** Items currently rendered in the row. Re-measures and re-arms auto-fill. */
+  itemCount: number;
+  /** Row data identity. Changing it restarts the auto-fill budget. */
+  resetKey?: string;
+  /** False while the nav buttons are suppressed. */
+  enabled?: boolean;
+  /**
+   * Loads the next page. Called only while the row does *not* overflow, so a
+   * window wider than one page still reaches the rest of the section: the only
+   * other trigger is horizontal scrolling, which a row without a scrollbar can
+   * never produce.
+   */
+  onFillWidth?: () => Promise<void>;
+  /** Extra work to run whenever the row is measured (viewport-dependent state). */
+  onLayoutChange?: () => void;
+}
+
+export interface RailScroll {
+  showLeft: boolean;
+  showRight: boolean;
+  /** Re-reads the scroll offsets. Call it from the row's own `onScroll`. */
+  measure: () => void;
+  scrollByPage: (dir: 'left' | 'right') => void;
+}
+
+/**
+ * Horizontal rail plumbing shared by every `.album-grid` row: arrow state, the
+ * observers that keep it honest, and paging by button.
+ */
+export function useRailScroll({
+  scrollRef,
+  itemCount,
+  resetKey = '',
+  enabled = true,
+  onFillWidth,
+  onLayoutChange,
+}: UseRailScrollOptions): RailScroll {
+  const [showLeft, setShowLeft] = useState(false);
+  const [showRight, setShowRight] = useState(true);
+
+  const fillRoundsRef = useRef(0);
+  const fillingRef = useRef(false);
+  const lastFilledCountRef = useRef(-1);
+  const itemCountRef = useRef(itemCount);
+  const fillWidthRef = useRef(onFillWidth);
+  const layoutChangeRef = useRef(onLayoutChange);
+  const enabledRef = useRef(enabled);
+
+  useEffect(() => {
+    itemCountRef.current = itemCount;
+    fillWidthRef.current = onFillWidth;
+    layoutChangeRef.current = onLayoutChange;
+    enabledRef.current = enabled;
+  });
+
+  const measure = useCallback(() => {
+    layoutChangeRef.current?.();
+    const el = scrollRef.current;
+    if (!el || !enabledRef.current) return;
+    const { scrollLeft, scrollWidth, clientWidth } = el;
+    setShowLeft(scrollLeft > 0);
+    setShowRight(scrollLeft < scrollWidth - clientWidth - RAIL_OVERFLOW_SLACK_PX);
+  }, [scrollRef]);
+
+  const overflows = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return false;
+    return el.scrollWidth > el.clientWidth + RAIL_OVERFLOW_SLACK_PX;
+  }, [scrollRef]);
+
+  const fillWidth = useCallback(async () => {
+    const fill = fillWidthRef.current;
+    if (!fill || fillingRef.current) return;
+    if (!scrollRef.current || overflows()) return;
+    if (fillRoundsRef.current >= MAX_AUTO_FILL_ROUNDS) return;
+    // The previous round returned nothing new — the section has no more rows.
+    if (lastFilledCountRef.current === itemCountRef.current) return;
+
+    fillRoundsRef.current += 1;
+    lastFilledCountRef.current = itemCountRef.current;
+    fillingRef.current = true;
+    try {
+      await fill();
+    } finally {
+      fillingRef.current = false;
+    }
+  }, [overflows, scrollRef]);
+
+  useEffect(() => {
+    fillRoundsRef.current = 0;
+    lastFilledCountRef.current = -1;
+  }, [resetKey]);
+
+  useEffect(() => {
+    measure();
+    // Cards need a frame to lay out before their width can decide anything.
+    const raf = window.requestAnimationFrame(() => {
+      measure();
+      void fillWidth();
+    });
+
+    const onViewportResize = () => {
+      measure();
+      void fillWidth();
+    };
+    window.addEventListener('resize', onViewportResize);
+
+    // The row can also change width without the window doing so — a collapsing
+    // sidebar or the queue panel opening beside it.
+    const observer = new ResizeObserver(onViewportResize);
+    const el = scrollRef.current;
+    if (el) observer.observe(el);
+
+    return () => {
+      window.cancelAnimationFrame(raf);
+      window.removeEventListener('resize', onViewportResize);
+      observer.disconnect();
+    };
+  }, [itemCount, resetKey, enabled, measure, fillWidth, scrollRef]);
+
+  const scrollByPage = useCallback((dir: 'left' | 'right') => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const amount = el.clientWidth * 0.75;
+    el.scrollBy({ left: dir === 'left' ? -amount : amount, behavior: 'smooth' });
+  }, [scrollRef]);
+
+  return { showLeft, showRight, measure, scrollByPage };
+}


### PR DESCRIPTION
Reported on Discord: on a 4K or dual-screen window the Mainstage rows stop after twelve albums, leave blank space to the right, and both arrows go grey.

- A rail card is capped at 180px, so twelve albums always occupy the same 2336px. A row wider than that has no overflow, so the arrows are inert — correctly, there is nothing to scroll. The defect is what that costs: the only trigger for loading the next page sits in the scroll handler behind a positive scroll offset, so a row without a scrollbar never reaches the rest of its section.
- The five horizontal rows now share `useRailScroll`, which pulls one more page while the row does not overflow. Capped at four rounds and stopped as soon as a round returns no new rows, so a very wide monitor cannot page through a whole section.
- Arrow state is now re-measured when only the row changes width — the queue panel opening beside it — which the previous per-row observer did not do.
- Rows with no paging path (Discover Songs, the artist and favourite rows) keep their fixed set; only their arrow state is corrected.

Known gap: on a very wide window a row without a paging path still leaves blank space. Whether those fixed sets should grow with the viewport is a separate decision, since it changes server load.

### Test plan

- `npm run lint`, `npm run dep:check`, `npx tsc --noEmit`, `npm run prebuild:release-notes` — pass
- `npx vitest run --coverage` — 652 files, 5039 tests pass; `scripts/check-frontend-hot-path-coverage.sh` — 15 files, 0 below threshold
- Seven new hook tests. Three mutation probes confirm they bite: removing the fill turns three red, removing the resize measurement one, removing the overflow guard one
- Verified in the dev build by the maintainer on a window spanning two 2560px screens: the rows fill and the next arrow arms again
- Unrelated to this branch: the node script tests for the Flatpak deploy script fail on Windows, on `origin/main` as well — the script rejects the local path form

Runtime benchmark: required - not captured yet, the Windows cold-start run needs the machine to itself. Note for whoever runs it: the harness drives a 2560px window, which sits close to the width where a full row stops overflowing, so the scenario has to be read carefully.
