### PR TITLE
Preserve Flatpak rollback history

### DIFF
--- a/.github/workflows/flatpak-release.yml
+++ b/.github/workflows/flatpak-release.yml
@@ -197,7 +197,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y appstream desktop-file-utils flatpak flatpak-builder gnupg jq python3-venv
+          sudo apt-get install -y appstream desktop-file-utils flatpak flatpak-builder gnupg jq ostree python3-venv
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
           flatpak install --user -y flathub \
             org.gnome.Platform//50 \
@@ -312,10 +312,33 @@ jobs:
 
           for CHANNEL in $DEPLOY_CHANNELS; do
             REPO_URL="$PUBLIC_BASE_URL/$CHANNEL/repo/"
+            REPO_SEED_URL=
+            case "$CHANNEL" in
+              stable) REPO_HISTORY_DEPTH=4 ;;
+              rc) REPO_HISTORY_DEPTH=2 ;;
+              test) REPO_HISTORY_DEPTH=0 ;;
+            esac
+
+            if [ "$CHANNEL" != test ]; then
+              SEED_STATUS="$(curl --silent --show-error --output /dev/null \
+                --write-out '%{http_code}' "${REPO_URL}summary")"
+              case "$SEED_STATUS" in
+                200) REPO_SEED_URL="$REPO_URL" ;;
+                404) ;;
+                *)
+                  echo "::error::Could not read existing $CHANNEL repository history: HTTP $SEED_STATUS"
+                  exit 1
+                  ;;
+              esac
+            fi
+
             make export-repository \
               FLATPAK_BRANCH="$CHANNEL" \
               GPG_SIGN="$GPG_KEY_ID" \
-              GPG_HOMEDIR="$GPG_HOME"
+              GPG_HOMEDIR="$GPG_HOME" \
+              GPG_KEYS="$GPG_PUBLIC_KEY" \
+              REPO_HISTORY_DEPTH="$REPO_HISTORY_DEPTH" \
+              REPO_SEED_URL="$REPO_SEED_URL"
 
             if [ "$CHANNEL" = "$PRIMARY_CHANNEL" ]; then
               make bundle-from-repository \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Without the system bar the mini player uses its own slim one: drag it by the track title, with pin, main window and close beside it.
 * Off by default, and it takes effect straight away — no restart. Windows only; Linux has always looked this way and macOS keeps its traffic lights.
 
+### Flatpak updates retain rollback history
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1537](https://github.com/Psysonic/psysonic/pull/1537)**
+
+* The signed stable repository now keeps the current release and four previous releases, so a recent version can be selected again with Flatpak's commit rollback command instead of disappearing when the next update is published.
+
 ## Fixed
 
 ### Shared Top Albums pictures show their covers again

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -113,6 +113,16 @@ not add it after the tag or rewrite the tag.
 3. Verify the bundle assets on the GitHub release and the signed channel under
    `https://flatpak.psysonic.de/<stable|rc>/` before announcing availability.
 
+Release repositories preserve bounded rollback history: the current commit plus
+four previous stable commits, and the current commit plus two previous RC
+commits. The test repository contains only its current commit. Inspect and select
+a retained stable commit with:
+
+```bash
+flatpak remote-info --log psysonic io.github.psysonic.psysonic
+flatpak update --user --commit=<commit> io.github.psysonic.psysonic
+```
+
 The supported installation path is per-user. Release instructions and the
 in-app updater use `flatpak install --user` and `flatpak update --user`.
 

--- a/scripts/deploy-flatpak-ssh.test.mjs
+++ b/scripts/deploy-flatpak-ssh.test.mjs
@@ -176,6 +176,18 @@ describe('Flatpak SSH deployment', () => {
     assert.doesNotMatch(publishWorkflow, /OSTREE_FTP|lftp/);
   });
 
+  it('retains bounded release history while keeping the test channel ephemeral', () => {
+    assert.match(publishWorkflow, /apt-get install -y[^\n]*\bostree\b/);
+    assert.match(publishWorkflow, /stable\) REPO_HISTORY_DEPTH=4/);
+    assert.match(publishWorkflow, /rc\) REPO_HISTORY_DEPTH=2/);
+    assert.match(publishWorkflow, /test\) REPO_HISTORY_DEPTH=0/);
+    assert.match(publishWorkflow, /if \[ "\$CHANNEL" != test \]/);
+    assert.match(publishWorkflow, /200\) REPO_SEED_URL="\$REPO_URL"/);
+    assert.match(publishWorkflow, /GPG_KEYS="\$GPG_PUBLIC_KEY"/);
+    assert.match(publishWorkflow, /REPO_HISTORY_DEPTH="\$REPO_HISTORY_DEPTH"/);
+    assert.match(publishWorkflow, /REPO_SEED_URL="\$REPO_SEED_URL"/);
+  });
+
   it('keeps the diagnostic workflow non-release and cleanup-oriented', () => {
     assert.match(diagnosticWorkflow, /workflow_dispatch/);
     assert.match(diagnosticWorkflow, /deploy-flatpak-ssh\.sh diagnose/);


### PR DESCRIPTION
## Summary
- seed stable and RC exports from the existing signed OSTree repository
- retain five stable commits, three RC commits, and one test commit
- add regression coverage and document manual rollback commands

## Dependency
- merge Psysonic/flatpak-psysonic#7 first so the checked-out packaging Makefile accepts the history variables

## Verification
- `nix develop -c bash -lc 'npm test'` (652 files, 5039 Vitest tests plus 57 Node tests)\n- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/flatpak-release.yml`\n- signed seven-generation OSTree integration test retained exactly five commits after pruning\n- `git diff --check`\n\n## Runtime benchmark\n- Not applicable: release automation, tests, and documentation only; application runtime paths are unchanged.\n\n## Tauri boundary\n- Not touched.