### PR TITLE
Fix Infinite Queue library scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * On a 4K or dual-screen window the album rows stopped after twelve entries, left the rest of the row empty, and both arrows stayed greyed out — with no way to reach the rest of the section.
 * Root cause: a row only loaded more entries while it was being scrolled, and a row wide enough to show a full page has nothing to scroll. Rows now keep pulling until they are actually full, and the arrows are re-checked when the row itself changes width, such as when the queue panel opens beside it.
 
+### Infinite Queue stays inside the selected libraries
+
+**By [@cucadmuh](https://github.com/cucadmuh), PR [#1539](https://github.com/Psysonic/psysonic/pull/1539)**
+
+* Infinite Queue could add tracks from unselected music folders, especially when Navidrome AudioMuse returned recommendations from the whole server. Similar songs, artist top tracks and the random fallback are now validated against the libraries selected in the sidebar.
+
 ## [1.52.0]
 
 ## Added

--- a/src/features/playback/utils/playback/buildInfiniteQueueCandidates.test.ts
+++ b/src/features/playback/utils/playback/buildInfiniteQueueCandidates.test.ts
@@ -39,6 +39,22 @@ import {
 } from '@/features/playback/utils/mixRatingFilter';
 import { makeSubsonicSong } from '@/test/helpers/factories';
 import { queueTrackIdentityKey } from '@/features/playback/utils/playback/queueIdentity';
+import type { LibraryBrowseScope } from '@/lib/library/libraryBrowseScope';
+
+const { getLibraryBrowseScopeMock } = vi.hoisted(() => ({
+  getLibraryBrowseScopeMock: vi.fn<() => LibraryBrowseScope>(() => ({
+    anchorServerId: null,
+    serverIds: [],
+    pairs: [],
+    fingerprint: '',
+    multiServer: false,
+  })),
+}));
+
+vi.mock('@/lib/library/libraryBrowseScope', async importOriginal => ({
+  ...await importOriginal<typeof import('@/lib/library/libraryBrowseScope')>(),
+  getLibraryBrowseScope: getLibraryBrowseScopeMock,
+}));
 
 const SERVER_ID = 'server-a';
 
@@ -74,6 +90,13 @@ beforeEach(() => {
   vi.mocked(getSimilarSongs2ForServer).mockResolvedValue([]);
   vi.mocked(getTopSongsForServer).mockResolvedValue([]);
   vi.mocked(getRandomSongsForServer).mockResolvedValue([]);
+  getLibraryBrowseScopeMock.mockReturnValue({
+    anchorServerId: null,
+    serverIds: [],
+    pairs: [],
+    fingerprint: '',
+    multiServer: false,
+  });
   // Default: filter disabled — the function then short-circuits the enrich path.
   vi.mocked(getMixMinRatingsConfigFromAuth).mockReturnValue({
     enabled: false,
@@ -98,6 +121,33 @@ describe('buildInfiniteQueueCandidates', () => {
 
     expect(getSimilarSongs2ForServer).toHaveBeenCalledWith(SERVER_ID, 'ar-A');
     expect(getTopSongsForServer).toHaveBeenCalledWith(SERVER_ID, 'Artist A');
+  });
+
+  it('uses the selected browse libraries for every infinite-queue source', async () => {
+    getLibraryBrowseScopeMock.mockReturnValue({
+      anchorServerId: SERVER_ID,
+      serverIds: [SERVER_ID],
+      pairs: [{ serverId: SERVER_ID, libraryId: 'music' }],
+      fingerprint: 'music',
+      multiServer: false,
+    });
+    vi.mocked(getSimilarSongs2ForServer).mockResolvedValue([]);
+    vi.mocked(getTopSongsForServer).mockResolvedValue([]);
+    vi.mocked(getRandomSongsForServer).mockResolvedValue([]);
+
+    await buildCandidates(seed());
+
+    expect(getSimilarSongs2ForServer).toHaveBeenCalledWith(SERVER_ID, 'ar-A', 50, ['music']);
+    expect(getTopSongsForServer).toHaveBeenCalledWith(SERVER_ID, 'Artist A', {
+      libraryIds: ['music'],
+    });
+    expect(getRandomSongsForServer).toHaveBeenCalledWith(
+      SERVER_ID,
+      expect.any(Number),
+      'Rock',
+      15000,
+      ['music'],
+    );
   });
 
   it('skips similar when artistId is missing', async () => {

--- a/src/features/playback/utils/playback/buildInfiniteQueueCandidates.ts
+++ b/src/features/playback/utils/playback/buildInfiniteQueueCandidates.ts
@@ -12,6 +12,10 @@ import {
 import { shuffleArray } from '@/lib/util/shuffleArray';
 import { songToTrack } from '@/lib/media/songToTrack';
 import { queueTrackIdentityKey } from '@/features/playback/utils/playback/queueIdentity';
+import {
+  browseScopeLibraryIdsForServer,
+  getLibraryBrowseScope,
+} from '@/lib/library/libraryBrowseScope';
 /**
  * Infinite queue source strategy (Instant Mix-like):
  * 1) Prefer artist-driven candidates (Top + Similar) around the current track.
@@ -28,10 +32,24 @@ export async function buildInfiniteQueueCandidates(
   const RANDOM_TOPUP_MAX_BATCHES = 8;
   const artistId = seedTrack?.artistId?.trim() || null;
   const artistName = seedTrack?.artist?.trim() || null;
+  const browseScope = getLibraryBrowseScope();
+  const libraryIds = browseScope.serverIds.includes(serverId)
+    ? browseScopeLibraryIdsForServer(browseScope.pairs, serverId)
+    : undefined;
 
   const [similar, top] = await Promise.all([
-    artistId ? getSimilarSongs2ForServer(serverId, artistId).catch(() => []) : Promise.resolve([]),
-    artistName ? getTopSongsForServer(serverId, artistName).catch(() => []) : Promise.resolve([]),
+    artistId
+      ? (libraryIds === undefined
+          ? getSimilarSongs2ForServer(serverId, artistId)
+          : getSimilarSongs2ForServer(serverId, artistId, 50, libraryIds))
+        .catch(() => [])
+      : Promise.resolve([]),
+    artistName
+      ? (libraryIds === undefined
+          ? getTopSongsForServer(serverId, artistName)
+          : getTopSongsForServer(serverId, artistName, { libraryIds }))
+        .catch(() => [])
+      : Promise.resolve([]),
   ]);
 
   const seedId = seedTrack?.id ?? null;
@@ -56,10 +74,9 @@ export async function buildInfiniteQueueCandidates(
     ...out.map(t => queueTrackIdentityKey(t.id, serverId)),
   ]);
   for (let b = 0; out.length < count && b < RANDOM_TOPUP_MAX_BATCHES; b++) {
-    const random = await getRandomSongsForServer(
-      serverId,
-      RANDOM_TOPUP_BATCH_SIZE,
-      seedTrack?.genre,
+    const random = await (libraryIds === undefined
+      ? getRandomSongsForServer(serverId, RANDOM_TOPUP_BATCH_SIZE, seedTrack?.genre)
+      : getRandomSongsForServer(serverId, RANDOM_TOPUP_BATCH_SIZE, seedTrack?.genre, 15000, libraryIds)
     ).catch(() => []);
     if (!random.length) break;
     const filteredRandomSongs = mixCfg.enabled

--- a/src/lib/api/subsonicArtists.server.test.ts
+++ b/src/lib/api/subsonicArtists.server.test.ts
@@ -5,12 +5,14 @@ const {
   librarySelectionMock,
   uploadArtistImageMock,
   findServerMock,
+  filterSongsToServerLibraryMock,
   similarSongsRequestCountMock,
 } = vi.hoisted(() => ({
   apiForServerMock: vi.fn(),
   librarySelectionMock: vi.fn<() => string[]>(() => []),
   uploadArtistImageMock: vi.fn(),
   findServerMock: vi.fn(),
+  filterSongsToServerLibraryMock: vi.fn(async (songs: unknown[]) => songs),
   similarSongsRequestCountMock: vi.fn((count: number) => count),
 }));
 
@@ -36,7 +38,7 @@ vi.mock('@/lib/api/subsonicClient', () => ({
 
 vi.mock('@/lib/api/subsonicLibrary', () => ({
   filterSongsToActiveLibrary: async (songs: unknown[]) => songs,
-  filterSongsToServerLibrary: async (songs: unknown[]) => songs,
+  filterSongsToServerLibrary: filterSongsToServerLibraryMock,
   similarSongsRequestCount: similarSongsRequestCountMock,
 }));
 
@@ -60,6 +62,7 @@ describe('explicit-server artist wrappers', () => {
     librarySelectionMock.mockReturnValue([]);
     uploadArtistImageMock.mockReset();
     findServerMock.mockReset();
+    filterSongsToServerLibraryMock.mockClear();
     similarSongsRequestCountMock.mockClear();
   });
 
@@ -192,6 +195,25 @@ describe('explicit-server artist wrappers', () => {
       expect.objectContaining({ id: 'seed', count: 12 }),
     );
     expect(similarSongsRequestCountMock).toHaveBeenCalledWith(12, 'srv-similar');
+  });
+
+  it('forwards an explicit browse scope through similar-song request and validation', async () => {
+    const similarSong = { id: 'similar-1', title: 'Similar' };
+    apiForServerMock.mockResolvedValue({ similarSongs2: { song: [similarSong] } });
+
+    await getSimilarSongs2ForServer('srv-similar', 'seed', 12, ['browse-folder']);
+
+    expect(similarSongsRequestCountMock).toHaveBeenCalledWith(12, 'srv-similar', ['browse-folder']);
+    expect(apiForServerMock).toHaveBeenCalledWith(
+      'srv-similar',
+      'getSimilarSongs2.view',
+      { id: 'seed', count: 12, musicFolderId: 'browse-folder' },
+    );
+    expect(filterSongsToServerLibraryMock).toHaveBeenCalledWith(
+      [similarSong],
+      'srv-similar',
+      ['browse-folder'],
+    );
   });
 
   it('routes legacy similar songs through the explicit owner scope', async () => {

--- a/src/lib/api/subsonicArtists.ts
+++ b/src/lib/api/subsonicArtists.ts
@@ -222,7 +222,7 @@ export async function getTopSongsForServer(
     const raw = data.topSongs?.song ?? [];
     const filtered = options.filterToLibrary === false
       ? raw
-      : await filterSongsToServerLibrary(raw, serverId);
+      : await filterSongsToServerLibrary(raw, serverId, options.libraryIds);
     return filtered.slice(0, limit).map(song => ({ ...song, serverId }));
   } catch {
     return [];
@@ -239,16 +239,24 @@ export async function getSimilarSongs2ForServer(
   serverId: string,
   id: string,
   count = 50,
+  explicitLibraryIds?: readonly string[],
 ): Promise<SubsonicSong[]> {
   try {
-    const requestCount = similarSongsRequestCount(count, serverId);
+    const requestCount = explicitLibraryIds === undefined
+      ? similarSongsRequestCount(count, serverId)
+      : similarSongsRequestCount(count, serverId, explicitLibraryIds);
+    const libraryParams = explicitLibraryIds === undefined
+      ? libraryFilterParamsForServer(serverId)
+      : explicitLibraryIds.length === 0
+        ? {}
+        : { musicFolderId: explicitLibraryIds.length === 1 ? explicitLibraryIds[0]! : [...explicitLibraryIds] };
     const data = await apiForServer<{ similarSongs2: { song: SubsonicSong[] } }>(
       serverId,
       'getSimilarSongs2.view',
-      { id, count: requestCount, ...libraryFilterParamsForServer(serverId) },
+      { id, count: requestCount, ...libraryParams },
     );
     const raw = data.similarSongs2?.song ?? [];
-    const filtered = await filterSongsToServerLibrary(raw, serverId);
+    const filtered = await filterSongsToServerLibrary(raw, serverId, explicitLibraryIds);
     return filtered.slice(0, count).map(song => ({ ...song, serverId }));
   } catch {
     return [];

--- a/src/lib/api/subsonicLibrary.server.test.ts
+++ b/src/lib/api/subsonicLibrary.server.test.ts
@@ -43,6 +43,7 @@ import {
   getAlbumListForServer,
   getRandomSongsForServer,
   getSongForServer,
+  filterSongsToServerLibrary,
   similarSongsRequestCount,
 } from '@/lib/api/subsonicLibrary';
 
@@ -138,6 +139,35 @@ describe('explicit-server library wrappers', () => {
       expect.objectContaining({ size: 8, musicFolderId: 'browse-b' }),
       2468,
     );
+  });
+
+  it('filters server-global recommendations to an explicit multi-library browse scope', async () => {
+    apiForServerMock.mockImplementation(async (_serverId: string, endpoint: string, params: Record<string, unknown>) => {
+      if (endpoint !== 'getAlbumList2.view') return {};
+      if (params.musicFolderId === 'browse-a') {
+        return { albumList2: { album: [album] } };
+      }
+      if (params.musicFolderId === 'browse-b') {
+        return { albumList2: { album: [{ ...album, id: 'album-3' }] } };
+      }
+      return { albumList2: { album: [] } };
+    });
+
+    await expect(filterSongsToServerLibrary([
+      song,
+      { ...song, id: 'song-2', albumId: 'album-2' },
+      { ...song, id: 'song-3', albumId: 'album-3' },
+    ], 'srv-random', ['browse-a', 'browse-b'])).resolves.toEqual([
+      song,
+      { ...song, id: 'song-3', albumId: 'album-3' },
+    ]);
+  });
+
+  it('does not fail open when an explicitly selected library has no albums', async () => {
+    apiForServerMock.mockResolvedValue({ albumList2: { album: [] } });
+
+    await expect(filterSongsToServerLibrary([song], 'srv-random', ['empty-library']))
+      .resolves.toEqual([]);
   });
 
   it('skips random-song network calls when the server guard fails', async () => {

--- a/src/lib/api/subsonicLibrary.ts
+++ b/src/lib/api/subsonicLibrary.ts
@@ -107,60 +107,83 @@ export async function getAlbumList(
 
 /**
  * Navidrome (and some servers) ignore `musicFolderId` on getSimilarSongs / getSimilarSongs2 / getTopSongs,
- * so similar tracks can leak from other libraries. When the user scoped to one folder, we keep a set of
- * album ids in that scope (paginated getAlbumList2) and drop songs whose albumId is not in the set.
+ * so similar tracks can leak from other libraries. For a scoped request, keep the album ids from each
+ * selected folder (paginated getAlbumList2) and drop songs whose albumId is not in that set.
  */
 let scopedLibraryAlbumIdCache: {
   serverId: string;
-  folderId: string;
+  scopeKey: string;
   filterVersion: number;
   ids: Set<string>;
 } | null = null;
 
-async function albumIdsInLibraryScope(serverId: string): Promise<Set<string> | null> {
-  const { musicLibraryFilterByServer, musicLibraryFilterVersion } = useAuthStore.getState();
+async function albumIdsInLibraryScope(
+  serverId: string,
+  explicitLibraryIds?: readonly string[],
+): Promise<Set<string> | null> {
+  const {
+    libraryBrowseScopeVersion,
+    musicLibraryFilterByServer,
+    musicLibraryFilterVersion,
+  } = useAuthStore.getState();
   if (!serverId) return null;
 
   const override = getLuckyMixLibraryScopeOverride();
-  let folder: string | null = null;
+  let libraryIds: string[] = [];
   if (override) {
-    folder = override;
+    libraryIds = [override];
+  } else if (explicitLibraryIds !== undefined) {
+    libraryIds = [...new Set(explicitLibraryIds)];
   } else {
     const selection = librarySelectionForServer(serverId);
     if (selection.length === 1) {
-      folder = selection[0];
+      libraryIds = selection;
     } else {
       const legacy = musicLibraryFilterByServer[serverId];
-      if (legacy !== undefined && legacy !== 'all') folder = legacy;
+      if (legacy !== undefined && legacy !== 'all') libraryIds = [legacy];
     }
   }
-  if (!folder) {
+  if (libraryIds.length === 0) {
     scopedLibraryAlbumIdCache = null;
     return null;
   }
+  const scopeKey = libraryIds.join('\u0000');
+  const filterVersion = explicitLibraryIds === undefined
+    ? musicLibraryFilterVersion
+    : libraryBrowseScopeVersion;
   const hit = scopedLibraryAlbumIdCache;
   if (
     hit &&
     hit.serverId === serverId &&
-    hit.folderId === folder &&
-    hit.filterVersion === musicLibraryFilterVersion
+    hit.scopeKey === scopeKey &&
+    hit.filterVersion === filterVersion
   ) {
     return hit.ids;
   }
   const ids = new Set<string>();
   const pageSize = 500;
-  let offset = 0;
-  for (;;) {
-    const albums = await getAlbumListForServer(serverId, 'alphabeticalByName', pageSize, offset);
-    for (const a of albums) ids.add(a.id);
-    if (albums.length < pageSize) break;
-    offset += pageSize;
-    if (offset > 500_000) break;
+  for (const libraryId of libraryIds) {
+    let offset = 0;
+    for (;;) {
+      const albums = await getAlbumListForServer(
+        serverId,
+        'alphabeticalByName',
+        pageSize,
+        offset,
+        {},
+        15000,
+        [libraryId],
+      );
+      for (const album of albums) ids.add(album.id);
+      if (albums.length < pageSize) break;
+      offset += pageSize;
+      if (offset > 500_000) break;
+    }
   }
   scopedLibraryAlbumIdCache = {
     serverId,
-    folderId: folder,
-    filterVersion: musicLibraryFilterVersion,
+    scopeKey,
+    filterVersion,
     ids,
   };
   return ids;
@@ -169,9 +192,10 @@ async function albumIdsInLibraryScope(serverId: string): Promise<Set<string> | n
 export async function filterSongsToServerLibrary(
   songs: SubsonicSong[],
   serverId: string,
+  explicitLibraryIds?: readonly string[],
 ): Promise<SubsonicSong[]> {
-  const allowed = await albumIdsInLibraryScope(serverId);
-  if (!allowed || allowed.size === 0) return songs;
+  const allowed = await albumIdsInLibraryScope(serverId, explicitLibraryIds);
+  if (!allowed || (allowed.size === 0 && explicitLibraryIds === undefined)) return songs;
   return songs.filter(s => s.albumId && allowed.has(s.albumId));
 }
 
@@ -204,15 +228,24 @@ export async function filterAlbumsToActiveLibrary(albums: SubsonicAlbum[]): Prom
   return filterAlbumsToServerLibrary(albums, activeServerId);
 }
 
-/** When scoped to one library, ask the server for more similar tracks — many will be filtered out client-side. */
-export function similarSongsRequestCount(desired: number, serverId?: string): number {
+/** When scoped to selected libraries, ask for more similar tracks because many may be filtered out client-side. */
+export function similarSongsRequestCount(
+  desired: number,
+  serverId?: string,
+  explicitLibraryIds?: readonly string[],
+): number {
   if (getLuckyMixLibraryScopeOverride()) {
     return Math.min(300, Math.max(desired, desired * 4));
   }
+  if (explicitLibraryIds !== undefined) {
+    return explicitLibraryIds.length === 0
+      ? desired
+      : Math.min(300, Math.max(desired, desired * 4));
+  }
   const { activeServerId, musicLibraryFilterByServer } = useAuthStore.getState();
   const ownerServerId = serverId ?? activeServerId;
-  const f = ownerServerId ? musicLibraryFilterByServer[ownerServerId] : undefined;
-  if (f === undefined || f === 'all') return desired;
+  const filter = ownerServerId ? musicLibraryFilterByServer[ownerServerId] : undefined;
+  if (filter === undefined || filter === 'all') return desired;
   return Math.min(300, Math.max(desired, desired * 4));
 }
 


### PR DESCRIPTION
## Summary
- make Infinite Queue use the selected sidebar library scope for Similar Songs, Top Songs, and random fallback candidates
- validate server-global recommendations against every explicitly selected music folder
- keep explicit empty-library results closed instead of leaking recommendations from the whole server

## Root cause
The sidebar picker writes `libraryBrowseSelectionByServer`, while Infinite Queue recommendation APIs defaulted to the separate legacy music-library selection. Navidrome and AudioMuse may return similar/top candidates server-wide, so the legacy post-filter saw an unscoped request and allowed tracks from libraries the user had not selected.

## Verification
- `npm run lint`
- `npm run dep:check`
- `npm test` (652 files, 5042 tests)
- `npm run prebuild:release-notes`
- `npx tsc --noEmit`
- `npx vitest run --coverage`
- `bash scripts/check-frontend-hot-path-coverage.sh`

## Runtime benchmark
- Applicability: not applicable - the benchmark harness has no Infinite Queue interaction, and this change does not alter route readiness, DOM structure, rendering, or shared mounted UI. The changed network-scope behavior is covered with deterministic request and filtering tests.

## Tauri boundary
No commands, events, or payload contracts changed.