### PR TITLE
Add favorite global shortcut and macOS Command support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The signed stable repository now keeps the current release and four previous releases, so a recent version can be selected again with Flatpak's commit rollback command instead of disappearing when the next update is published.
 
+### Global shortcuts can favourite the current track and use Command
+
+**By [@cucadmuh](https://github.com/cucadmuh), suggested by Rain on Discord, PR [#1540](https://github.com/Psysonic/psysonic/pull/1540)**
+
+* **Settings → Input → Global shortcuts** now offers an unbound action for adding the current track to favourites, even while Psysonic is out of focus.
+* On macOS, shortcut capture and labels now call the ⌘ modifier **Command** instead of Super. Existing shortcuts continue to work without being rebound.
+
 ## Fixed
 
 ### Shared Top Albums pictures show their covers again

--- a/src/config/shortcutActionRegistry.ts
+++ b/src/config/shortcutActionRegistry.ts
@@ -264,6 +264,7 @@ export const SHORTCUT_ACTION_REGISTRY = {
   'favorite-current-track': {
     getLabel: t => t('settings.shortcutFavoriteCurrentTrack', { defaultValue: 'Add current track to favorites' }),
     inApp: { defaultBinding: null },
+    global: { defaultBinding: null },
     runInMiniWindow: false,
     run: () => {
       const track = usePlayerStore.getState().currentTrack;

--- a/src/config/shortcutDispatch.test.ts
+++ b/src/config/shortcutDispatch.test.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
   hoisted.player.currentTrack = null;
   hoisted.player.setVolume.mockClear();
   hoisted.queueSongRating.mockClear();
+  hoisted.queueSongStar.mockClear();
   navigate.mockClear();
 });
 
@@ -101,5 +102,23 @@ describe('current track rating shortcut actions', () => {
     for (const [id] of CURRENT_TRACK_RATING_ACTIONS) {
       expect(DEFAULT_GLOBAL_SHORTCUTS).not.toHaveProperty(id);
     }
+  });
+});
+
+describe('current track favorite shortcut action', () => {
+  it('routes the favorite to the current track owner', () => {
+    hoisted.player.currentTrack = { id: 'shared', serverId: 'srv-b' };
+
+    executeRuntimeAction('favorite-current-track', { navigate, previewPolicy: 'ignore' });
+
+    expect(hoisted.queueSongStar).toHaveBeenCalledWith('shared', true, 'srv-b');
+  });
+
+  it('exposes the favorite action as an unbound global shortcut', () => {
+    expect(GLOBAL_SHORTCUT_ACTIONS).toContainEqual(expect.objectContaining({
+      id: 'favorite-current-track',
+      defaultBinding: null,
+    }));
+    expect(DEFAULT_GLOBAL_SHORTCUTS).not.toHaveProperty('favorite-current-track');
   });
 });

--- a/src/features/settings/components/InputTab.tsx
+++ b/src/features/settings/components/InputTab.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Keyboard, RotateCcw, X } from 'lucide-react';
 import { IN_APP_SHORTCUT_ACTIONS, GLOBAL_SHORTCUT_ACTIONS } from '@/config/shortcutActions';
+import { IS_MACOS } from '@/lib/util/platform';
 import { useGlobalShortcutsStore, type GlobalAction, buildGlobalShortcut, formatGlobalShortcut } from '@/store/globalShortcutsStore';
 import { useKeybindingsStore, type KeyAction, buildInAppBinding, formatBinding } from '@/store/keybindingsStore';
 import SettingsSubSection from '@/features/settings/components/SettingsSubSection';
@@ -107,7 +108,7 @@ export function InputTab() {
       <SettingsSubSection
         title={t('settings.globalShortcutsTitle')}
         icon={<Keyboard size={16} />}
-        description={t('settings.globalShortcutsNote')}
+        description={t('settings.globalShortcutsNote', { metaModifier: IS_MACOS ? 'Command' : 'Super' })}
         action={
           <button
             type="button"

--- a/src/locales/bg/settings.ts
+++ b/src/locales/bg/settings.ts
@@ -671,7 +671,7 @@ export const settings = {
   shortcutListening: 'Натисни клавиш…',
   shortcutUnbound: '—',
   globalShortcutsTitle: 'Глобални клавишни комбинации',
-  globalShortcutsNote: 'Работят в цялата система, дори когато Psysonic е във фонов режим. Изискват Ctrl, Alt или Super като модификатор.',
+  globalShortcutsNote: 'Работят в цялата система, дори когато Psysonic е във фонов режим. Изискват Ctrl, Alt или {{metaModifier}} като модификатор.',
   shortcutClear: 'Изчисти',
   shortcutPlayPause: 'Възпроизвеждане / Пауза',
   shortcutNext: 'Следваща песен',

--- a/src/locales/de/settings.ts
+++ b/src/locales/de/settings.ts
@@ -573,7 +573,7 @@ export const settings = {
   shortcutUnbound: '—',
   shortcutClear: 'Löschen',
   globalShortcutsTitle: 'Globale Shortcuts',
-  globalShortcutsNote: 'Funktionieren systemweit, auch wenn Psysonic im Hintergrund läuft. Mindestens Ctrl, Alt oder Super als Modifier erforderlich.',
+  globalShortcutsNote: 'Funktionieren systemweit, auch wenn Psysonic im Hintergrund läuft. Mindestens Ctrl, Alt oder {{metaModifier}} als Modifier erforderlich.',
   shortcutPlayPause: 'Wiedergabe / Pause',
   shortcutNext: 'Nächster Titel',
   shortcutPrev: 'Vorheriger Titel',

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -671,7 +671,7 @@ export const settings = {
   shortcutListening: 'Press a key…',
   shortcutUnbound: '—',
   globalShortcutsTitle: 'Global Shortcuts',
-  globalShortcutsNote: 'Work system-wide even when Psysonic is in the background. Requires Ctrl, Alt, or Super as a modifier.',
+  globalShortcutsNote: 'Work system-wide even when Psysonic is in the background. Requires Ctrl, Alt, or {{metaModifier}} as a modifier.',
   shortcutClear: 'Clear',
   shortcutPlayPause: 'Play / Pause',
   shortcutNext: 'Next track',

--- a/src/locales/es/settings.ts
+++ b/src/locales/es/settings.ts
@@ -603,7 +603,7 @@ export const settings = {
   shortcutListening: 'Presiona una tecla…',
   shortcutUnbound: '—',
   globalShortcutsTitle: 'Atajos Globales',
-  globalShortcutsNote: 'Funcionan en todo el sistema incluso cuando Psysonic está en segundo plano. Requieren Ctrl, Alt o Super como modificador.',
+  globalShortcutsNote: 'Funcionan en todo el sistema incluso cuando Psysonic está en segundo plano. Requieren Ctrl, Alt o {{metaModifier}} como modificador.',
   shortcutClear: 'Limpiar',
   shortcutPlayPause: 'Reproducir / Pausa',
   shortcutNext: 'Siguiente pista',

--- a/src/locales/fr/settings.ts
+++ b/src/locales/fr/settings.ts
@@ -553,7 +553,7 @@ export const settings = {
   shortcutUnbound: '—',
   shortcutClear: 'Effacer',
   globalShortcutsTitle: 'Raccourcis globaux',
-  globalShortcutsNote: 'Fonctionnent à l\'échelle du système, même quand Psysonic est en arrière-plan. Nécessite Ctrl, Alt ou Super comme modificateur.',
+  globalShortcutsNote: 'Fonctionnent à l\'échelle du système, même quand Psysonic est en arrière-plan. Nécessite Ctrl, Alt ou {{metaModifier}} comme modificateur.',
   shortcutPlayPause: 'Lecture / Pause',
   shortcutNext: 'Piste suivante',
   shortcutPrev: 'Piste précédente',

--- a/src/locales/hu/settings.ts
+++ b/src/locales/hu/settings.ts
@@ -671,7 +671,7 @@ export const settings = {
   shortcutListening: 'Nyomj le egy billentyűt…',
   shortcutUnbound: '—',
   globalShortcutsTitle: 'Globális gyorsbillentyűk',
-  globalShortcutsNote: 'Rendszerszinten működnek, még akkor is, ha a Psysonic a háttérben van. Ctrl, Alt vagy Super módosítót igényel.',
+  globalShortcutsNote: 'Rendszerszinten működnek, még akkor is, ha a Psysonic a háttérben van. Ctrl, Alt vagy {{metaModifier}} módosítót igényel.',
   shortcutClear: 'Törlés',
   shortcutPlayPause: 'Lejátszás / Szünet',
   shortcutNext: 'Következő szám',

--- a/src/locales/it/settings.ts
+++ b/src/locales/it/settings.ts
@@ -671,7 +671,7 @@ export const settings = {
   shortcutListening: 'Premi un tasto…',
   shortcutUnbound: '—',
   globalShortcutsTitle: 'Scorciatoie globali',
-  globalShortcutsNote: 'Funzionano a livello di sistema anche quando Psysonic è in background. Richiedono Ctrl, Alt o Super come modificatore.',
+  globalShortcutsNote: 'Funzionano a livello di sistema anche quando Psysonic è in background. Richiedono Ctrl, Alt o {{metaModifier}} come modificatore.',
   shortcutClear: 'Cancella',
   shortcutPlayPause: 'Riproduci / Pausa',
   shortcutNext: 'Brano successivo',

--- a/src/locales/ja/settings.ts
+++ b/src/locales/ja/settings.ts
@@ -665,7 +665,7 @@ export const settings = {
   shortcutListening: 'キーを押してください…',
   shortcutUnbound: '—',
   globalShortcutsTitle: 'グローバルショートカット',
-  globalShortcutsNote: 'Psysonic がバックグラウンドや最小化中でもシステム全体で動作します。修飾キーとして Ctrl、Alt、Super のいずれかが必要です。',
+  globalShortcutsNote: 'Psysonic がバックグラウンドや最小化中でもシステム全体で動作します。修飾キーとして Ctrl、Alt、{{metaModifier}} のいずれかが必要です。',
   shortcutClear: 'クリア',
   shortcutPlayPause: '再生 / 一時停止',
   shortcutNext: '次のトラック',

--- a/src/locales/nb/settings.ts
+++ b/src/locales/nb/settings.ts
@@ -583,7 +583,7 @@ export const settings = {
   shortcutListening: 'Trykk på en tast…',
   shortcutUnbound: '-',
   globalShortcutsTitle: 'Globale snarveier',
-  globalShortcutsNote: 'Arbeid systemomfattende selv når Psysonic er i bakgrunnen. Krever Ctrl, Alt eller Super som modifikator.',
+  globalShortcutsNote: 'Arbeid systemomfattende selv når Psysonic er i bakgrunnen. Krever Ctrl, Alt eller {{metaModifier}} som modifikator.',
   shortcutClear: 'Fjern',
   shortcutPlayPause: 'Spill av / Pause',
   shortcutNext: 'Neste spor',

--- a/src/locales/nl/settings.ts
+++ b/src/locales/nl/settings.ts
@@ -553,7 +553,7 @@ export const settings = {
   shortcutUnbound: '—',
   shortcutClear: 'Wissen',
   globalShortcutsTitle: 'Globale sneltoetsen',
-  globalShortcutsNote: 'Werken systeembreed, ook als Psysonic op de achtergrond draait. Vereist Ctrl, Alt of Super als modifier.',
+  globalShortcutsNote: 'Werken systeembreed, ook als Psysonic op de achtergrond draait. Vereist Ctrl, Alt of {{metaModifier}} als modifier.',
   shortcutPlayPause: 'Afspelen / Pauzeren',
   shortcutNext: 'Volgend nummer',
   shortcutPrev: 'Vorig nummer',

--- a/src/locales/pl/settings.ts
+++ b/src/locales/pl/settings.ts
@@ -671,7 +671,7 @@ export const settings = {
   shortcutListening: 'Naciśnij klawisz…',
   shortcutUnbound: '—',
   globalShortcutsTitle: 'Globalne skróty',
-  globalShortcutsNote: 'Działaj w czałym systemie nawet jak PsySonic jest w tle. Wymaga Ctrl, Alt, lub Super jako klawisza modyfikującego.',
+  globalShortcutsNote: 'Działaj w czałym systemie nawet jak PsySonic jest w tle. Wymaga Ctrl, Alt, lub {{metaModifier}} jako klawisza modyfikującego.',
   shortcutClear: 'Wyczyść',
   shortcutPlayPause: 'Odtwórz / Pauza',
   shortcutNext: 'Następny utwór',

--- a/src/locales/ro/settings.ts
+++ b/src/locales/ro/settings.ts
@@ -606,7 +606,7 @@ export const settings = {
   shortcutListening: 'Apasă o tastă…',
   shortcutUnbound: '—',
   globalShortcutsTitle: 'Scurtături globale',
-  globalShortcutsNote: 'Funcționează la nivel de sistem și când Psysonic este în fundal. Necesită Ctrl, Alt, sau Super ca un modificator.',
+  globalShortcutsNote: 'Funcționează la nivel de sistem și când Psysonic este în fundal. Necesită Ctrl, Alt sau {{metaModifier}} ca modificator.',
   shortcutClear: 'Golește',
   shortcutPlayPause: 'Redă / Pauză',
   shortcutNext: 'Următoarea piesă',

--- a/src/locales/ru/settings.ts
+++ b/src/locales/ru/settings.ts
@@ -693,7 +693,7 @@ export const settings = {
   shortcutUnbound: '—',
   globalShortcutsTitle: 'Глобальные сочетания',
   globalShortcutsNote:
-    'Работают, когда окно не в фокусе. Нужен модификатор: Ctrl, Alt или Super.',
+    'Работают, когда окно не в фокусе. Нужен модификатор: Ctrl, Alt или {{metaModifier}}.',
   shortcutClear: 'Сбросить',
   shortcutPlayPause: 'Пауза / воспроизведение',
   shortcutNext: 'Следующий трек',

--- a/src/locales/uk/settings.ts
+++ b/src/locales/uk/settings.ts
@@ -674,7 +674,7 @@ export const settings = {
   shortcutListening: 'Натисніть клавішу…',
   shortcutUnbound: '—',
   globalShortcutsTitle: 'Глобальні гарячі клавіші',
-  globalShortcutsNote: 'Працюють у системі, навіть коли Psysonic у фоні. Потребують Ctrl, Alt або Super як модифікатор.',
+  globalShortcutsNote: 'Працюють у системі, навіть коли Psysonic у фоні. Потребують Ctrl, Alt або {{metaModifier}} як модифікатор.',
   shortcutClear: 'Очистити',
   shortcutPlayPause: 'Відтворити / Пауза',
   shortcutNext: 'Наступний трек',

--- a/src/locales/zh/settings.ts
+++ b/src/locales/zh/settings.ts
@@ -583,7 +583,7 @@ export const settings = {
   shortcutListening: '请按下按键…',
   shortcutUnbound: '—',
   globalShortcutsTitle: '全局快捷键',
-  globalShortcutsNote: '即使 Psysonic 在后台也能在系统范围内工作。需要 Ctrl、Alt 或 Super 作为修饰键。',
+  globalShortcutsNote: '即使 Psysonic 在后台也能在系统范围内工作。需要 Ctrl、Alt 或 {{metaModifier}} 作为修饰键。',
   shortcutClear: '清除',
   shortcutPlayPause: '播放 / 暂停',
   shortcutNext: '下一首',

--- a/src/store/globalShortcutsStore.test.ts
+++ b/src/store/globalShortcutsStore.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { buildGlobalShortcut, formatGlobalShortcut } from './globalShortcutsStore';
+
+describe('global shortcut meta modifier', () => {
+  it('stores and displays Command on macOS', () => {
+    const event = new KeyboardEvent('keydown', { code: 'KeyF', metaKey: true });
+
+    expect(buildGlobalShortcut(event, true)).toBe('command+KeyF');
+    expect(formatGlobalShortcut('command+KeyF', true)).toBe('Command+F');
+    expect(formatGlobalShortcut('super+KeyF', true)).toBe('Command+F');
+  });
+
+  it('keeps Super on non-macOS platforms', () => {
+    const event = new KeyboardEvent('keydown', { code: 'KeyF', metaKey: true });
+
+    expect(buildGlobalShortcut(event, false)).toBe('super+KeyF');
+    expect(formatGlobalShortcut('super+KeyF', false)).toBe('Super+F');
+  });
+});

--- a/src/store/globalShortcutsStore.ts
+++ b/src/store/globalShortcutsStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { commands } from '@/generated/bindings';
+import { IS_MACOS } from '@/lib/util/platform';
 import { MODIFIER_KEY_CODES, formatBinding } from './keybindingsStore';
 import { DEFAULT_GLOBAL_SHORTCUTS, isGlobalShortcutActionId, type GlobalAction } from '@/config/shortcutActions';
 
@@ -8,7 +9,7 @@ import { DEFAULT_GLOBAL_SHORTCUTS, isGlobalShortcutActionId, type GlobalAction }
 const GLOBAL_SHORTCUTS_OS_ENABLED = !import.meta.env.DEV;
 
 /** Build a Tauri-compatible shortcut string from a KeyboardEvent, or null if invalid. */
-export function buildGlobalShortcut(e: KeyboardEvent): string | null {
+export function buildGlobalShortcut(e: KeyboardEvent, isMacOS = IS_MACOS): string | null {
   if ((MODIFIER_KEY_CODES as readonly string[]).includes(e.code)) return null;
   // Require at least Ctrl, Alt, or Meta — Shift alone is too invasive
   if (!e.ctrlKey && !e.altKey && !e.metaKey) return null;
@@ -17,14 +18,14 @@ export function buildGlobalShortcut(e: KeyboardEvent): string | null {
   if (e.ctrlKey)  mods.push('ctrl');
   if (e.altKey)   mods.push('alt');
   if (e.shiftKey) mods.push('shift');
-  if (e.metaKey)  mods.push('super');
+  if (e.metaKey)  mods.push(isMacOS ? 'command' : 'super');
 
   return [...mods, e.code].join('+');
 }
 
 /** Human-readable label for a stored shortcut string, e.g. "ctrl+alt+ArrowRight" → "Ctrl+Alt+→". */
-export function formatGlobalShortcut(shortcut: string): string {
-  return formatBinding(shortcut);
+export function formatGlobalShortcut(shortcut: string, isMacOS = IS_MACOS): string {
+  return formatBinding(shortcut, isMacOS);
 }
 
 // Module-level guard — prevents double-registration from React StrictMode's

--- a/src/store/keybindingsStore.ts
+++ b/src/store/keybindingsStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { DEFAULT_IN_APP_BINDINGS, type KeyAction } from '@/config/shortcutActions';
+import { IS_MACOS } from '@/lib/util/platform';
 
 /** Physical keys only — ignore for binding capture */
 export const MODIFIER_KEY_CODES = [
@@ -113,13 +114,14 @@ export function formatKeyCode(code: string): string {
 }
 
 /** Label for settings UI: plain key or chord (same string shape as global shortcuts). */
-export function formatBinding(binding: string): string {
+export function formatBinding(binding: string, isMacOS = IS_MACOS): string {
   if (!binding.includes('+')) return formatKeyCode(binding);
   return binding.split('+').map(part => {
     if (part === 'ctrl') return 'Ctrl';
     if (part === 'alt') return 'Alt';
     if (part === 'shift') return 'Shift';
-    if (part === 'super' || part === 'meta') return 'Super';
+    if (part === 'command' || part === 'cmd') return 'Command';
+    if (part === 'super' || part === 'meta') return isMacOS ? 'Command' : 'Super';
     return formatKeyCode(part);
   }).join('+');
 }


### PR DESCRIPTION
## Summary
- Exposes **Add current track to favorites** as an optional, unbound global shortcut that works while Psysonic is unfocused.
- Stores and displays the macOS Meta key as **Command**, while Windows and Linux continue to use **Super**; existing macOS `super+...` bindings remain compatible and display as Command.
- Updates the global-shortcut modifier note in every shipped locale.
- Both feature requests were suggested by **Rain on Discord**.

## Verification
- `nix develop -c bash -lc 'npm run lint'`
- `nix develop -c bash -lc 'npm run dep:check'`
- `nix develop -c bash -lc 'npm test'` (653 files, 5047 tests)
- `nix develop -c bash -lc 'npm run prebuild:release-notes'`
- `nix develop -c bash -lc 'npx tsc --noEmit'`
- `nix develop -c bash -lc 'npx vitest run --coverage && bash scripts/check-frontend-hot-path-coverage.sh'`

## Tauri boundary
- No commands, events, or payload shapes changed. The feature reuses the existing global-shortcut registration command and `shortcut:global-action` event.

## Runtime benchmark
- Applicability: final smoke required because `/settings` behavior changed.
- Measured code: `16cbe5d9` / report `2026-09-11T21-35-44-877Z`
- Current head `daa6dab4` only adds the changelog attribution; runtime source is unchanged.
- Command: `psysonic benchmark run --scenario all-pages --runs 2 --profile realistic --json`
- `/settings`: cold 1630 ms, warm 900 ms, 0 long tasks, no errors or timeouts.
- Skips: `/label/:name` only, because the selected library had no reachable owned album with a record label.